### PR TITLE
Updates Node.js version to 24 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - run: npm ci


### PR DESCRIPTION
Upgrades the Node.js runtime from version 20 to 24 in the GitHub Actions publish workflow to resolve publishing issues and ensure compatibility with the latest Node.js features and security updates.