### PR TITLE
Adds image attachment support for vision-capable models

### DIFF
--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -1222,4 +1222,82 @@ describe('Agent', () => {
       expect(agent.getStepLimitHit()).toBeNull();
     });
   });
+
+  describe('image attachments', () => {
+    const mockImageAttachment = {
+      path: '/tmp/test.png',
+      mimeType: 'image/png',
+      data: Buffer.from('fake-png-data'),
+    };
+
+    it('processInput with images builds multipart UserContent', async () => {
+      mockGenerateText.mockResolvedValue({
+        response: { messages: [{ role: 'assistant', content: 'I see an image.' }] },
+        usage: { promptTokens: 200, completionTokens: 50, totalTokens: 250 },
+      });
+      const agent = new Agent(makeConfig(), toolOptions, store);
+      await agent.processInput('Describe this', [mockImageAttachment]);
+
+      const call = mockGenerateText.mock.calls[0][0];
+      const userMsg = call.messages.find((m: any) => m.role === 'user');
+      // Content should be an array with text + image parts
+      expect(Array.isArray(userMsg.content)).toBe(true);
+      expect(userMsg.content).toHaveLength(2);
+      expect(userMsg.content[0].type).toBe('text');
+      expect(userMsg.content[1].type).toBe('image');
+      expect(userMsg.content[1].mimeType).toBe('image/png');
+    });
+
+    it('processInput with images timestamps the text part', async () => {
+      mockGenerateText.mockResolvedValue({
+        response: { messages: [{ role: 'assistant', content: 'Done' }] },
+        usage: { promptTokens: 200, completionTokens: 50, totalTokens: 250 },
+      });
+      const agent = new Agent(makeConfig(), toolOptions, store);
+      await agent.processInput('What is this?', [mockImageAttachment]);
+
+      const call = mockGenerateText.mock.calls[0][0];
+      const userMsg = call.messages.find((m: any) => m.role === 'user');
+      // The text part should have a timestamp prefix
+      expect(userMsg.content[0].text).toMatch(
+        /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\] What is this\?$/,
+      );
+    });
+
+    it('processInput without images still sends a string', async () => {
+      mockGenerateText.mockResolvedValue({
+        response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
+        usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+      });
+      const agent = new Agent(makeConfig(), toolOptions, store);
+      await agent.processInput('Hello');
+
+      const call = mockGenerateText.mock.calls[0][0];
+      const userMsg = call.messages.find((m: any) => m.role === 'user');
+      expect(typeof userMsg.content).toBe('string');
+    });
+
+    it('processInput with multiple images attaches all of them', async () => {
+      mockGenerateText.mockResolvedValue({
+        response: { messages: [{ role: 'assistant', content: 'I see two images.' }] },
+        usage: { promptTokens: 300, completionTokens: 50, totalTokens: 350 },
+      });
+      const secondImage = {
+        path: '/tmp/photo.jpg',
+        mimeType: 'image/jpeg',
+        data: Buffer.from('fake-jpg-data'),
+      };
+      const agent = new Agent(makeConfig(), toolOptions, store);
+      await agent.processInput('Compare these', [mockImageAttachment, secondImage]);
+
+      const call = mockGenerateText.mock.calls[0][0];
+      const userMsg = call.messages.find((m: any) => m.role === 'user');
+      expect(Array.isArray(userMsg.content)).toBe(true);
+      expect(userMsg.content).toHaveLength(3); // 1 text + 2 images
+      expect(userMsg.content[0].type).toBe('text');
+      expect(userMsg.content[1].type).toBe('image');
+      expect(userMsg.content[2].type).toBe('image');
+      expect(userMsg.content[2].mimeType).toBe('image/jpeg');
+    });
+  });
 });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import { generateText, type CoreMessage } from 'ai';
+import { generateText, type CoreMessage, type UserContent } from 'ai';
 import { getModel } from './providers/index.js';
 import { createTools, type ToolOptions } from './tools/index.js';
 import { createSubAgentTool } from './tools/subagent.js';
@@ -42,9 +42,10 @@ import {
   buildRAGQuery,
   applyStickiness,
 } from './rag-query.js';
-import { formatCurrentDateTime, timestampUserMessage } from './tools/datetime.js';
+import { formatCurrentDateTime, timestampUserMessage, timestampUserContent } from './tools/datetime.js';
 import { ToolProfileStore, buildToolProfilesPrompt } from './tool-profiles.js';
 import { augmentTools } from './tools/augment.js';
+import { type ImageAttachment, IMAGE_TOKEN_ESTIMATE } from './image.js';
 
 const BASE_SYSTEM_PROMPT = `# Identity
 
@@ -390,11 +391,22 @@ export class Agent {
    * @param userInput - The raw text from the user's REPL input
    * @throws Error wrapping the underlying API error if generation fails for non-abort, non-overflow reasons
    */
-  async processInput(userInput: string): Promise<void> {
+  async processInput(userInput: string, images?: ImageAttachment[]): Promise<void> {
     this.lastStepLimitHit = false;
 
-    const timestamped = timestampUserMessage(userInput);
-    this.history.push({ role: 'user', content: timestamped });
+    if (images && images.length > 0) {
+      const contentParts: UserContent = [
+        { type: 'text', text: userInput },
+        ...images.map((img) => ({
+          type: 'image' as const,
+          image: img.data,
+          mimeType: img.mimeType,
+        })),
+      ];
+      this.history.push({ role: 'user', content: timestampUserContent(contentParts) });
+    } else {
+      this.history.push({ role: 'user', content: timestampUserMessage(userInput) });
+    }
 
     this.abortController = new AbortController();
     this.lastStepPromptTokens = 0;
@@ -402,7 +414,8 @@ export class Agent {
 
     try {
       // Check if context compression is needed
-      const newMessageEstimate = Math.ceil(timestamped.length / 4);
+      const imageTokens = images ? images.length * IMAGE_TOKEN_ESTIMATE : 0;
+      const newMessageEstimate = Math.ceil(userInput.length / 4) + imageTokens;
       if (
         shouldCompress(
           this.lastPromptTokens,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -418,8 +418,10 @@ export class Agent {
 
     try {
       // Check if context compression is needed
+      const timestampOverhead = 30; // [YYYY-MM-DDTHH:MM:SS+HH:MM] prefix
       const imageTokens = images ? images.length * IMAGE_TOKEN_ESTIMATE : 0;
-      const newMessageEstimate = Math.ceil(userInput.length / 4) + imageTokens;
+      const newMessageEstimate =
+        Math.ceil((userInput.length + timestampOverhead) / 4) + imageTokens;
       if (
         shouldCompress(
           this.lastPromptTokens,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -42,7 +42,11 @@ import {
   buildRAGQuery,
   applyStickiness,
 } from './rag-query.js';
-import { formatCurrentDateTime, timestampUserMessage, timestampUserContent } from './tools/datetime.js';
+import {
+  formatCurrentDateTime,
+  timestampUserMessage,
+  timestampUserContent,
+} from './tools/datetime.js';
 import { ToolProfileStore, buildToolProfilesPrompt } from './tool-profiles.js';
 import { augmentTools } from './tools/augment.js';
 import { type ImageAttachment, IMAGE_TOKEN_ESTIMATE } from './image.js';

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -629,6 +629,22 @@ describe('estimateHistoryTokens', () => {
     const largeTokens = estimateHistoryTokens(large);
     expect(largeTokens).toBeGreaterThan(smallTokens * 100);
   });
+
+  it('uses flat estimate for image parts instead of serializing buffer', () => {
+    const imageMsg: CoreMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this' },
+          { type: 'image', image: Buffer.alloc(5_000_000), mimeType: 'image/png' },
+        ],
+      },
+    ];
+    const tokens = estimateHistoryTokens(imageMsg);
+    // Should be ~1000 (image) + ~4 (text), NOT millions from base64 serialization
+    expect(tokens).toBeGreaterThan(900);
+    expect(tokens).toBeLessThan(1200);
+  });
 });
 
 describe('emergencyTruncate', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
 import type { RAGStore } from './rag.js';
 import { DOMAIN_REGISTRY, getDomainIds } from './domains.js';
+import { estimateContentPartTokens } from './image.js';
 
 /** Model name → context window size in tokens */
 export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
@@ -352,17 +353,32 @@ export function truncateToolResults(
   });
 }
 
+/** Estimates token count for a single message's content. */
+function estimateMessageTokens(msg: CoreMessage): number {
+  if (typeof msg.content === 'string') {
+    return Math.ceil(msg.content.length / 3.6);
+  }
+  if (Array.isArray(msg.content)) {
+    let tokens = 0;
+    for (const part of msg.content) {
+      tokens += estimateContentPartTokens(part);
+    }
+    return tokens;
+  }
+  return Math.ceil(JSON.stringify(msg.content).length / 3.6);
+}
+
 /**
  * Rough-but-safe token estimator for pre-flight checks.
  * Uses 3.6 chars/token (instead of 4) for a ~10% safety margin,
  * since tool-result tokens can be denser than natural language.
  */
 export function estimateHistoryTokens(history: CoreMessage[]): number {
-  let chars = 0;
+  let tokens = 0;
   for (const msg of history) {
-    chars += JSON.stringify(msg.content).length;
+    tokens += estimateMessageTokens(msg);
   }
-  return Math.ceil(chars / 3.6);
+  return tokens;
 }
 
 /**
@@ -400,7 +416,7 @@ export function emergencyTruncate(
   let accumulated = 0;
   let cutoff = history.length;
   for (let i = history.length - 1; i >= 0; i--) {
-    const msgTokens = Math.ceil(JSON.stringify(history[i].content).length / 3.6);
+    const msgTokens = estimateMessageTokens(history[i]);
     if (accumulated + msgTokens > historyBudget) {
       cutoff = i + 1;
       break;

--- a/src/history.test.ts
+++ b/src/history.test.ts
@@ -80,6 +80,25 @@ describe('HistoryStore', () => {
         expect.stringContaining('conversation-history.json'),
       );
     });
+
+    it('strips image parts before writing to disk', () => {
+      const messages = [
+        {
+          role: 'user' as const,
+          content: [
+            { type: 'text', text: 'Describe this' },
+            { type: 'image', image: Buffer.from('binary-data'), mimeType: 'image/png' },
+          ],
+        },
+      ];
+      store.save(messages as any);
+
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      const parsed = JSON.parse(written);
+      expect(parsed[0].content[1]).toEqual({ type: 'text', text: '[Image attached]' });
+      expect(parsed[0].content[0]).toEqual({ type: 'text', text: 'Describe this' });
+      expect(written).not.toContain('binary-data');
+    });
   });
 
   describe('clear', () => {

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import type { CoreMessage } from 'ai';
 import { STATE_DIR, HISTORY_FILE } from './paths.js';
+import { stripImagesFromHistory } from './image.js';
 
 /**
  * Manages persistence of conversation history.
@@ -25,8 +26,9 @@ export class HistoryStore {
   /** Atomically writes the conversation history to disk. */
   save(messages: CoreMessage[]): void {
     fs.mkdirSync(STATE_DIR, { recursive: true });
+    const stripped = stripImagesFromHistory(messages);
     const tmp = HISTORY_FILE + '.tmp';
-    fs.writeFileSync(tmp, JSON.stringify(messages, null, 2), 'utf-8');
+    fs.writeFileSync(tmp, JSON.stringify(stripped, null, 2), 'utf-8');
     fs.renameSync(tmp, HISTORY_FILE);
   }
 

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { CoreMessage } from 'ai';
+import {
+  detectMimeType,
+  loadImage,
+  tryLoadImage,
+  extractImagePaths,
+  isVisionCapableModel,
+  stripImagesFromHistory,
+  estimateContentPartTokens,
+  IMAGE_TOKEN_ESTIMATE,
+} from './image.js';
+
+/* ---------- detectMimeType ---------- */
+describe('detectMimeType', () => {
+  it.each([
+    ['/path/to/file.png', 'image/png'],
+    ['/path/to/file.PNG', 'image/png'],
+    ['/path/to/file.jpg', 'image/jpeg'],
+    ['/path/to/file.jpeg', 'image/jpeg'],
+    ['/path/to/file.gif', 'image/gif'],
+    ['/path/to/file.webp', 'image/webp'],
+  ])('returns correct MIME for %s', (filePath, expected) => {
+    expect(detectMimeType(filePath)).toBe(expected);
+  });
+
+  it.each(['/path/to/file.bmp', '/path/to/file.pdf', '/path/to/file.ts', '/path/to/file.txt'])(
+    'returns null for unsupported %s',
+    (filePath) => {
+      expect(detectMimeType(filePath)).toBeNull();
+    },
+  );
+});
+
+/* ---------- loadImage ---------- */
+describe('loadImage', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-image-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads a valid PNG file', () => {
+    const imgPath = path.join(tmpDir, 'test.png');
+    const content = Buffer.from('fake-png-content');
+    fs.writeFileSync(imgPath, content);
+
+    const result = loadImage(imgPath);
+    expect(result.path).toBe(imgPath);
+    expect(result.mimeType).toBe('image/png');
+    expect(result.data).toEqual(content);
+  });
+
+  it('loads a valid JPEG file', () => {
+    const imgPath = path.join(tmpDir, 'photo.jpg');
+    const content = Buffer.from('fake-jpeg-content');
+    fs.writeFileSync(imgPath, content);
+
+    const result = loadImage(imgPath);
+    expect(result.mimeType).toBe('image/jpeg');
+  });
+
+  it('throws for non-existent file', () => {
+    expect(() => loadImage('/tmp/definitely-not-a-real-file.png')).toThrow('Image file not found');
+  });
+
+  it('throws for a directory', () => {
+    expect(() => loadImage(tmpDir)).toThrow('Path is a directory');
+  });
+
+  it('throws for unsupported extension', () => {
+    const txtPath = path.join(tmpDir, 'file.txt');
+    fs.writeFileSync(txtPath, 'hello');
+
+    expect(() => loadImage(txtPath)).toThrow('Unsupported image format');
+  });
+
+  it('throws for oversized file', () => {
+    const imgPath = path.join(tmpDir, 'big.png');
+    // Create a file just over 10MB by writing a sparse-ish buffer
+    const bigBuffer = Buffer.alloc(10 * 1024 * 1024 + 1);
+    fs.writeFileSync(imgPath, bigBuffer);
+
+    expect(() => loadImage(imgPath)).toThrow('too large');
+  });
+
+  it('expands ~ in paths', () => {
+    // We can't easily test ~ expansion with a real file, but we can verify
+    // the error message shows the expanded path (not ~)
+    expect(() => loadImage('~/definitely-not-real.png')).toThrow(os.homedir());
+  });
+});
+
+/* ---------- tryLoadImage ---------- */
+describe('tryLoadImage', () => {
+  it('returns null for non-existent file', () => {
+    expect(tryLoadImage('/tmp/definitely-not-a-real-file.png')).toBeNull();
+  });
+
+  it('returns null for unsupported extension', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-try-'));
+    const txtPath = path.join(tmpDir, 'file.txt');
+    fs.writeFileSync(txtPath, 'hello');
+
+    expect(tryLoadImage(txtPath)).toBeNull();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns ImageAttachment for valid file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-try-'));
+    const imgPath = path.join(tmpDir, 'ok.png');
+    fs.writeFileSync(imgPath, Buffer.from('data'));
+
+    const result = tryLoadImage(imgPath);
+    expect(result).not.toBeNull();
+    expect(result!.mimeType).toBe('image/png');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+/* ---------- extractImagePaths ---------- */
+describe('extractImagePaths', () => {
+  it('finds absolute paths', () => {
+    const result = extractImagePaths('look at /tmp/screenshot.png please');
+    expect(result).toEqual(['/tmp/screenshot.png']);
+  });
+
+  it('finds home-dir paths and expands ~', () => {
+    const result = extractImagePaths('describe ~/photos/cat.jpg');
+    expect(result).toEqual([path.join(os.homedir(), '/photos/cat.jpg')]);
+  });
+
+  it('finds relative paths', () => {
+    const result = extractImagePaths('check ./images/logo.webp');
+    expect(result).toEqual(['./images/logo.webp']);
+  });
+
+  it('finds multiple images', () => {
+    const result = extractImagePaths('compare /tmp/a.png and /tmp/b.jpeg');
+    expect(result).toEqual(['/tmp/a.png', '/tmp/b.jpeg']);
+  });
+
+  it('handles quoted paths', () => {
+    const result = extractImagePaths('look at "/tmp/my file.png" please');
+    expect(result).toEqual(['/tmp/my file.png']);
+  });
+
+  it('returns empty array when no images found', () => {
+    expect(extractImagePaths('just a normal message')).toEqual([]);
+  });
+
+  it('ignores non-image extensions', () => {
+    expect(extractImagePaths('edit /tmp/code.ts and /tmp/data.json')).toEqual([]);
+  });
+
+  it('handles case-insensitive extensions', () => {
+    const result = extractImagePaths('look at /tmp/photo.PNG');
+    expect(result).toEqual(['/tmp/photo.PNG']);
+  });
+});
+
+/* ---------- isVisionCapableModel ---------- */
+describe('isVisionCapableModel', () => {
+  it('returns true for all Anthropic models', () => {
+    expect(isVisionCapableModel('anthropic', 'claude-sonnet-4-5-20250929')).toBe(true);
+    expect(isVisionCapableModel('anthropic', 'claude-haiku-4-5-20251001')).toBe(true);
+  });
+
+  it('returns true for OpenAI vision models', () => {
+    expect(isVisionCapableModel('openai', 'gpt-4o')).toBe(true);
+    expect(isVisionCapableModel('openai', 'gpt-4o-mini')).toBe(true);
+    expect(isVisionCapableModel('openai', 'gpt-4.1')).toBe(true);
+    expect(isVisionCapableModel('openai', 'gpt-4.1-mini')).toBe(true);
+    expect(isVisionCapableModel('openai', 'gpt-5.2')).toBe(true);
+    expect(isVisionCapableModel('openai', 'o3')).toBe(true);
+    expect(isVisionCapableModel('openai', 'o4-mini')).toBe(true);
+  });
+
+  it('returns false for OpenAI text-only models', () => {
+    expect(isVisionCapableModel('openai', 'gpt-3.5-turbo')).toBe(false);
+  });
+
+  it('returns true for xAI vision models', () => {
+    expect(isVisionCapableModel('xai', 'grok-2-vision-1212')).toBe(true);
+    expect(isVisionCapableModel('xai', 'grok-2-vision-latest')).toBe(true);
+    expect(isVisionCapableModel('xai', 'grok-4-fast-non-reasoning')).toBe(true);
+  });
+
+  it('returns false for xAI text-only models', () => {
+    expect(isVisionCapableModel('xai', 'grok-3')).toBe(false);
+    expect(isVisionCapableModel('xai', 'grok-3-mini')).toBe(false);
+  });
+
+  it('returns true for unknown providers (optimistic)', () => {
+    expect(isVisionCapableModel('custom', 'some-model')).toBe(true);
+  });
+});
+
+/* ---------- estimateContentPartTokens ---------- */
+describe('estimateContentPartTokens', () => {
+  it('returns IMAGE_TOKEN_ESTIMATE for image parts', () => {
+    const part = { type: 'image', image: Buffer.from('data'), mimeType: 'image/png' };
+    expect(estimateContentPartTokens(part)).toBe(IMAGE_TOKEN_ESTIMATE);
+  });
+
+  it('returns text-based estimate for text parts', () => {
+    const part = { type: 'text', text: 'hello world' };
+    const tokens = estimateContentPartTokens(part);
+    expect(tokens).toBeGreaterThan(0);
+    expect(tokens).toBe(Math.ceil('hello world'.length / 3.6));
+  });
+
+  it('returns same estimate regardless of image size', () => {
+    const small = { type: 'image', image: Buffer.alloc(100), mimeType: 'image/png' };
+    const large = { type: 'image', image: Buffer.alloc(5_000_000), mimeType: 'image/png' };
+    expect(estimateContentPartTokens(small)).toBe(estimateContentPartTokens(large));
+  });
+});
+
+/* ---------- stripImagesFromHistory ---------- */
+describe('stripImagesFromHistory', () => {
+  it('replaces ImagePart entries with text placeholders', () => {
+    const history: CoreMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this' },
+          { type: 'image', image: Buffer.from('png-data'), mimeType: 'image/png' },
+        ],
+      },
+    ];
+
+    const stripped = stripImagesFromHistory(history);
+    expect(stripped[0].content).toEqual([
+      { type: 'text', text: 'Describe this' },
+      { type: 'text', text: '[Image attached]' },
+    ]);
+  });
+
+  it('leaves string content unchanged', () => {
+    const history: CoreMessage[] = [{ role: 'user', content: 'hello' }];
+    const stripped = stripImagesFromHistory(history);
+    expect(stripped[0].content).toBe('hello');
+  });
+
+  it('leaves non-user messages unchanged', () => {
+    const history: CoreMessage[] = [{ role: 'assistant', content: 'response' }];
+    const stripped = stripImagesFromHistory(history);
+    expect(stripped[0]).toBe(history[0]);
+  });
+
+  it('does not mutate the original array', () => {
+    const original: CoreMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'test' },
+          { type: 'image', image: Buffer.from('data'), mimeType: 'image/png' },
+        ],
+      },
+    ];
+
+    const originalContent = original[0].content;
+    stripImagesFromHistory(original);
+    expect(original[0].content).toBe(originalContent);
+  });
+
+  it('preserves messages with no image parts', () => {
+    const history: CoreMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'just text' },
+          { type: 'text', text: 'more text' },
+        ],
+      },
+    ];
+
+    const stripped = stripImagesFromHistory(history);
+    expect(stripped[0]).toBe(history[0]); // same reference — no change needed
+  });
+});

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -228,6 +228,11 @@ describe('estimateContentPartTokens', () => {
     const large = { type: 'image', image: Buffer.alloc(5_000_000), mimeType: 'image/png' };
     expect(estimateContentPartTokens(small)).toBe(estimateContentPartTokens(large));
   });
+
+  it('returns flat estimate for file parts', () => {
+    const part = { type: 'file', data: Buffer.alloc(2_000_000), mimeType: 'application/pdf' };
+    expect(estimateContentPartTokens(part)).toBe(IMAGE_TOKEN_ESTIMATE);
+  });
 });
 
 /* ---------- stripImagesFromHistory ---------- */

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -148,9 +148,14 @@ describe('extractImagePaths', () => {
     expect(result).toEqual(['/tmp/a.png', '/tmp/b.jpeg']);
   });
 
-  it('handles quoted paths', () => {
+  it('handles double-quoted paths', () => {
     const result = extractImagePaths('look at "/tmp/my file.png" please');
     expect(result).toEqual(['/tmp/my file.png']);
+  });
+
+  it('handles single-quoted paths', () => {
+    const result = extractImagePaths("check '/tmp/my file.jpg' now");
+    expect(result).toEqual(['/tmp/my file.jpg']);
   });
 
   it('returns empty array when no images found', () => {

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -135,7 +135,8 @@ describe('extractImagePaths', () => {
 
   it('finds home-dir paths and expands ~', () => {
     const result = extractImagePaths('describe ~/photos/cat.jpg');
-    expect(result).toEqual([path.join(os.homedir(), '/photos/cat.jpg')]);
+    expect(result).toEqual([path.join(os.homedir(), 'photos', 'cat.jpg')]);
+    expect(result[0]).not.toBe('/photos/cat.jpg');
   });
 
   it('finds relative paths', () => {

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,0 +1,210 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { CoreMessage } from 'ai';
+
+/** Describes a loaded image ready to be attached to a user message. */
+export interface ImageAttachment {
+  /** Resolved absolute path (for display/logging). */
+  path: string;
+  /** MIME type, e.g. `'image/png'`. */
+  mimeType: string;
+  /** Raw image bytes — the AI SDK accepts `Buffer` as `DataContent`. */
+  data: Buffer;
+}
+
+/** Map of lowercase file extensions to MIME types supported by vision models. */
+export const SUPPORTED_EXTENSIONS = new Map<string, string>([
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.gif', 'image/gif'],
+  ['.webp', 'image/webp'],
+]);
+
+/** Maximum file size for image uploads (10 MB). */
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+
+/**
+ * Flat token estimate per image for pre-flight compression/truncation checks.
+ * Actual token costs vary by model and resolution, but 1000 is a safe overestimate.
+ */
+export const IMAGE_TOKEN_ESTIMATE = 1000;
+
+/**
+ * Regex matching tokens that look like file paths ending in a supported image extension.
+ * Handles absolute paths, relative paths, `~` home-dir expansion, and quoted paths.
+ */
+const IMAGE_PATH_RE = /(?:"([^"]+\.(?:png|jpe?g|gif|webp))"|'([^']+\.(?:png|jpe?g|gif|webp))'|((?:[~.]?\/|\.\.\/)?[\w.\-\/]+\.(?:png|jpe?g|gif|webp)))/gi;
+
+/** Returns the MIME type for a file path based on its extension, or `null` if unsupported. */
+export function detectMimeType(filePath: string): string | null {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_EXTENSIONS.get(ext) ?? null;
+}
+
+/**
+ * Expands `~` at the start of a path to the user's home directory.
+ */
+function expandHome(filePath: string): string {
+  if (filePath.startsWith('~/') || filePath === '~') {
+    return path.join(os.homedir(), filePath.slice(1));
+  }
+  return filePath;
+}
+
+/**
+ * Loads and validates an image file from disk.
+ * @throws {Error} If the file does not exist, is a directory, exceeds 10 MB, or has an unsupported extension.
+ */
+export function loadImage(filePath: string): ImageAttachment {
+  const resolved = path.resolve(expandHome(filePath));
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    throw new Error(`Image file not found: ${resolved}`);
+  }
+
+  if (stat.isDirectory()) {
+    throw new Error(`Path is a directory, not an image file: ${resolved}`);
+  }
+
+  if (stat.size > MAX_IMAGE_SIZE) {
+    const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
+    throw new Error(`Image file too large (${sizeMB} MB, max 10 MB): ${resolved}`);
+  }
+
+  const mimeType = detectMimeType(resolved);
+  if (!mimeType) {
+    const ext = path.extname(resolved);
+    throw new Error(
+      `Unsupported image format "${ext}". Supported: ${[...SUPPORTED_EXTENSIONS.keys()].join(', ')}`,
+    );
+  }
+
+  const data = fs.readFileSync(resolved);
+
+  return { path: resolved, mimeType, data };
+}
+
+/**
+ * Like `loadImage`, but returns `null` instead of throwing.
+ * Used for inline detection where a non-existent or invalid file should be silently skipped.
+ */
+export function tryLoadImage(filePath: string): ImageAttachment | null {
+  try {
+    return loadImage(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scans user text for tokens that look like file paths ending in supported image extensions.
+ * Returns the extracted path strings (with `~` expansion applied).
+ */
+export function extractImagePaths(text: string): string[] {
+  const paths: string[] = [];
+  let match: RegExpExecArray | null;
+  IMAGE_PATH_RE.lastIndex = 0;
+  while ((match = IMAGE_PATH_RE.exec(text)) !== null) {
+    // Groups: 1 = double-quoted, 2 = single-quoted, 3 = unquoted
+    const raw = match[1] ?? match[2] ?? match[3];
+    if (raw) {
+      paths.push(expandHome(raw));
+    }
+  }
+  return paths;
+}
+
+/**
+ * Checks whether the given provider/model combination supports image input.
+ *
+ * - Anthropic: all models in the list are Claude 3+ and support vision.
+ * - OpenAI: gpt-4o, gpt-4.1, gpt-4-turbo, gpt-5 families support vision. o3/o3-mini do not.
+ * - xAI: only `grok-*-vision-*` models support vision; none of the current defaults do.
+ */
+export function isVisionCapableModel(provider: string, model: string): boolean {
+  switch (provider) {
+    case 'anthropic':
+      // All Claude 3+ models support vision
+      return true;
+
+    case 'openai': {
+      const m = model.toLowerCase();
+      // GPT-4o, GPT-4.1, GPT-4-turbo, GPT-5 families support vision
+      if (m.startsWith('gpt-4o') || m.startsWith('gpt-4.1') || m.startsWith('gpt-4-turbo')) return true;
+      if (m.startsWith('gpt-5')) return true;
+      // o3, o3-mini, o4-mini support vision
+      if (m.startsWith('o3') || m.startsWith('o4')) return true;
+      return false;
+    }
+
+    case 'xai': {
+      const m = model.toLowerCase();
+      // Only grok-vision models support image input
+      if (m.includes('vision')) return true;
+      // Grok-4 models support vision
+      if (m.startsWith('grok-4')) return true;
+      return false;
+    }
+
+    default:
+      // Unknown provider — optimistically allow (the API will reject if unsupported)
+      return true;
+  }
+}
+
+/**
+ * Estimates the token count contribution of a single content part.
+ * For image parts, returns the flat IMAGE_TOKEN_ESTIMATE instead of serializing the binary data.
+ */
+export function estimateContentPartTokens(part: unknown): number {
+  if (typeof part !== 'object' || part === null || !('type' in part)) {
+    return Math.ceil(JSON.stringify(part).length / 3.6);
+  }
+  const typed = part as { type: string; text?: string };
+  if (typed.type === 'image') {
+    return IMAGE_TOKEN_ESTIMATE;
+  }
+  if (typed.type === 'text' && typeof typed.text === 'string') {
+    return Math.ceil(typed.text.length / 3.6);
+  }
+  return Math.ceil(JSON.stringify(part).length / 3.6);
+}
+
+/**
+ * Returns a new history array where `ImagePart` entries in user messages are replaced
+ * with a `[Image attached]` text placeholder. Does not mutate the original.
+ * Used before persisting history to disk to avoid writing base64 data.
+ */
+export function stripImagesFromHistory(history: CoreMessage[]): CoreMessage[] {
+  const hasImages = history.some(
+    (msg) =>
+      msg.role === 'user' &&
+      Array.isArray(msg.content) &&
+      msg.content.some(
+        (p) => typeof p === 'object' && p !== null && 'type' in p && p.type === 'image',
+      ),
+  );
+  if (!hasImages) return history;
+
+  return history.map((msg) => {
+    if (msg.role !== 'user' || typeof msg.content === 'string' || !Array.isArray(msg.content)) {
+      return msg;
+    }
+
+    let changed = false;
+    const newContent = msg.content.map((part) => {
+      if (typeof part === 'object' && part !== null && 'type' in part && part.type === 'image') {
+        changed = true;
+        return { type: 'text' as const, text: '[Image attached]' };
+      }
+      return part;
+    });
+
+    return changed ? { ...msg, content: newContent } : msg;
+  });
+}

--- a/src/image.ts
+++ b/src/image.ts
@@ -48,8 +48,11 @@ export function detectMimeType(filePath: string): string | null {
  * Expands `~` at the start of a path to the user's home directory.
  */
 function expandHome(filePath: string): string {
-  if (filePath.startsWith('~/') || filePath === '~') {
-    return path.join(os.homedir(), filePath.slice(1));
+  if (filePath === '~') {
+    return os.homedir();
+  }
+  if (filePath.startsWith('~/')) {
+    return path.join(os.homedir(), filePath.slice(2));
   }
   return filePath;
 }
@@ -121,34 +124,30 @@ export function extractImagePaths(text: string): string[] {
 }
 
 /**
- * Checks whether the given provider/model combination supports image input.
+ * Heuristic check for whether the given provider/model combination supports image input.
  *
- * - Anthropic: all models in the list are Claude 3+ and support vision.
- * - OpenAI: gpt-4o, gpt-4.1, gpt-4-turbo, gpt-5 families support vision. o3/o3-mini do not.
- * - xAI: only `grok-*-vision-*` models support vision; none of the current defaults do.
+ * - Anthropic: all models are treated as vision-capable (all current models are Claude 3+).
+ * - OpenAI: gpt-4o, gpt-4.1, gpt-4-turbo, gpt-5, o3, and o4 families are treated as vision-capable.
+ * - xAI: models containing `vision` in the name, plus grok-4 family, are treated as vision-capable.
+ * - Unknown providers: optimistically allowed (the API will reject if unsupported).
  */
 export function isVisionCapableModel(provider: string, model: string): boolean {
   switch (provider) {
     case 'anthropic':
-      // All Claude 3+ models support vision
       return true;
 
     case 'openai': {
       const m = model.toLowerCase();
-      // GPT-4o, GPT-4.1, GPT-4-turbo, GPT-5 families support vision
       if (m.startsWith('gpt-4o') || m.startsWith('gpt-4.1') || m.startsWith('gpt-4-turbo'))
         return true;
       if (m.startsWith('gpt-5')) return true;
-      // o3, o4 families support vision
       if (m.startsWith('o3') || m.startsWith('o4')) return true;
       return false;
     }
 
     case 'xai': {
       const m = model.toLowerCase();
-      // Only grok-vision models support image input
       if (m.includes('vision')) return true;
-      // Grok-4 models support vision
       if (m.startsWith('grok-4')) return true;
       return false;
     }

--- a/src/image.ts
+++ b/src/image.ts
@@ -35,7 +35,8 @@ export const IMAGE_TOKEN_ESTIMATE = 1000;
  * Regex matching tokens that look like file paths ending in a supported image extension.
  * Handles absolute paths, relative paths, `~` home-dir expansion, and quoted paths.
  */
-const IMAGE_PATH_RE = /(?:"([^"]+\.(?:png|jpe?g|gif|webp))"|'([^']+\.(?:png|jpe?g|gif|webp))'|((?:[~.]?\/|\.\.\/)?[\w.\-\/]+\.(?:png|jpe?g|gif|webp)))/gi;
+const IMAGE_PATH_RE =
+  /(?:"([^"]+\.(?:png|jpe?g|gif|webp))"|'([^']+\.(?:png|jpe?g|gif|webp))'|((?:[~.]?\/|\.\.\/)?[\w.\-\/]+\.(?:png|jpe?g|gif|webp)))/gi;
 
 /** Returns the MIME type for a file path based on its extension, or `null` if unsupported. */
 export function detectMimeType(filePath: string): string | null {
@@ -135,9 +136,10 @@ export function isVisionCapableModel(provider: string, model: string): boolean {
     case 'openai': {
       const m = model.toLowerCase();
       // GPT-4o, GPT-4.1, GPT-4-turbo, GPT-5 families support vision
-      if (m.startsWith('gpt-4o') || m.startsWith('gpt-4.1') || m.startsWith('gpt-4-turbo')) return true;
+      if (m.startsWith('gpt-4o') || m.startsWith('gpt-4.1') || m.startsWith('gpt-4-turbo'))
+        return true;
       if (m.startsWith('gpt-5')) return true;
-      // o3, o3-mini, o4-mini support vision
+      // o3, o4 families support vision
       if (m.startsWith('o3') || m.startsWith('o4')) return true;
       return false;
     }
@@ -166,7 +168,7 @@ export function estimateContentPartTokens(part: unknown): number {
     return Math.ceil(JSON.stringify(part).length / 3.6);
   }
   const typed = part as { type: string; text?: string };
-  if (typed.type === 'image') {
+  if (typed.type === 'image' || typed.type === 'file') {
     return IMAGE_TOKEN_ESTIMATE;
   }
   if (typed.type === 'text' && typeof typed.text === 'string') {

--- a/src/output.ts
+++ b/src/output.ts
@@ -369,9 +369,7 @@ export function printHelp(): void {
   console.log(
     t.text('  /task') + t.muted('    — Run an isolated task (no history, structured output)'),
   );
-  console.log(
-    t.text('  /image') + t.muted('   — Attach an image: /image <path> [prompt]'),
-  );
+  console.log(t.text('  /image') + t.muted('   — Attach an image: /image <path> [prompt]'));
   console.log(t.text('  /memory') + t.muted('  — List persistent memories'));
   console.log(t.text('  /scratch') + t.muted(' — List session scratch notes'));
   console.log(t.text('  /mcp') + t.muted('      — List MCP servers and tools'));

--- a/src/output.ts
+++ b/src/output.ts
@@ -369,6 +369,9 @@ export function printHelp(): void {
   console.log(
     t.text('  /task') + t.muted('    — Run an isolated task (no history, structured output)'),
   );
+  console.log(
+    t.text('  /image') + t.muted('   — Attach an image: /image <path> [prompt]'),
+  );
   console.log(t.text('  /memory') + t.muted('  — List persistent memories'));
   console.log(t.text('  /scratch') + t.muted(' — List session scratch notes'));
   console.log(t.text('  /mcp') + t.muted('      — List MCP servers and tools'));

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -1076,7 +1076,9 @@ describe('REPL /image command', () => {
     typeLine('/image /tmp/test.png');
 
     await vi.waitFor(() => {
-      expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('does not support image'));
+      expect(mockPrintError).toHaveBeenCalledWith(
+        expect.stringContaining('does not support image'),
+      );
     });
     expect(mockLoadImage).not.toHaveBeenCalled();
 
@@ -1086,7 +1088,9 @@ describe('REPL /image command', () => {
 
   it('/image with bad file path shows error', async () => {
     mockIsVisionCapableModel.mockReturnValue(true);
-    mockLoadImage.mockImplementation(() => { throw new Error('Image file not found: /tmp/nope.png'); });
+    mockLoadImage.mockImplementation(() => {
+      throw new Error('Image file not found: /tmp/nope.png');
+    });
     const { startRepl } = await import('./repl.js');
     const replPromise = startRepl(makeConfig());
 
@@ -1102,7 +1106,11 @@ describe('REPL /image command', () => {
   });
 
   it('/image with valid file calls processInput with attachment', async () => {
-    const mockAttachment = { path: '/tmp/test.png', mimeType: 'image/png', data: Buffer.from('data') };
+    const mockAttachment = {
+      path: '/tmp/test.png',
+      mimeType: 'image/png',
+      data: Buffer.from('data'),
+    };
     mockIsVisionCapableModel.mockReturnValue(true);
     mockLoadImage.mockReturnValue(mockAttachment);
     mockProcessInput.mockResolvedValue(undefined);
@@ -1123,7 +1131,11 @@ describe('REPL /image command', () => {
   });
 
   it('/image without prompt text defaults to "Describe this image."', async () => {
-    const mockAttachment = { path: '/tmp/test.png', mimeType: 'image/png', data: Buffer.from('data') };
+    const mockAttachment = {
+      path: '/tmp/test.png',
+      mimeType: 'image/png',
+      data: Buffer.from('data'),
+    };
     mockIsVisionCapableModel.mockReturnValue(true);
     mockLoadImage.mockReturnValue(mockAttachment);
     mockProcessInput.mockResolvedValue(undefined);
@@ -1135,6 +1147,56 @@ describe('REPL /image command', () => {
     typeLine('/image /tmp/test.png');
 
     await vi.waitFor(() => {
+      expect(mockProcessInput).toHaveBeenCalledWith('Describe this image.', [mockAttachment]);
+    });
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('/image with double-quoted path containing spaces', async () => {
+    const mockAttachment = {
+      path: '/tmp/my screenshot.png',
+      mimeType: 'image/png',
+      data: Buffer.from('data'),
+    };
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockLoadImage.mockReturnValue(mockAttachment);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('/image "/tmp/my screenshot.png" What is this?');
+
+    await vi.waitFor(() => {
+      expect(mockLoadImage).toHaveBeenCalledWith('/tmp/my screenshot.png');
+      expect(mockProcessInput).toHaveBeenCalledWith('What is this?', [mockAttachment]);
+    });
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('/image with single-quoted path containing spaces', async () => {
+    const mockAttachment = {
+      path: '/tmp/my photo.jpg',
+      mimeType: 'image/jpeg',
+      data: Buffer.from('data'),
+    };
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockLoadImage.mockReturnValue(mockAttachment);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine("/image '/tmp/my photo.jpg'");
+
+    await vi.waitFor(() => {
+      expect(mockLoadImage).toHaveBeenCalledWith('/tmp/my photo.jpg');
       expect(mockProcessInput).toHaveBeenCalledWith('Describe this image.', [mockAttachment]);
     });
 
@@ -1160,7 +1222,11 @@ describe('REPL inline image detection', () => {
   });
 
   it('attaches image when path found in text and model supports vision', async () => {
-    const mockAttachment = { path: '/tmp/test.png', mimeType: 'image/png', data: Buffer.from('data') };
+    const mockAttachment = {
+      path: '/tmp/test.png',
+      mimeType: 'image/png',
+      data: Buffer.from('data'),
+    };
     mockExtractImagePaths.mockReturnValue(['/tmp/test.png']);
     mockIsVisionCapableModel.mockReturnValue(true);
     mockTryLoadImage.mockReturnValue(mockAttachment);
@@ -1192,7 +1258,9 @@ describe('REPL inline image detection', () => {
     typeLine('describe /tmp/test.png');
 
     await vi.waitFor(() => {
-      expect(mockPrintWarning).toHaveBeenCalledWith(expect.stringContaining('does not support vision'));
+      expect(mockPrintWarning).toHaveBeenCalledWith(
+        expect.stringContaining('does not support vision'),
+      );
     });
     // Should still call processInput but without images
     await vi.waitFor(() => {

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -107,6 +107,7 @@ const mockPrintInfo = vi.fn();
 const mockPrintWelcome = vi.fn();
 const mockPrintHelp = vi.fn();
 const mockPrintError = vi.fn();
+const mockPrintWarning = vi.fn();
 const mockPrintConversationReplay = vi.fn();
 const mockStartSpinner = vi.fn();
 const mockStopSpinner = vi.fn();
@@ -116,6 +117,7 @@ vi.mock('./output.js', () => ({
   printHelp: (...args: any[]) => mockPrintHelp(...args),
   printInfo: (...args: any[]) => mockPrintInfo(...args),
   printError: (...args: any[]) => mockPrintError(...args),
+  printWarning: (...args: any[]) => mockPrintWarning(...args),
   printWelcome: (...args: any[]) => mockPrintWelcome(...args),
   printConversationReplay: (...args: any[]) => mockPrintConversationReplay(...args),
   startSpinner: (...args: any[]) => mockStartSpinner(...args),
@@ -211,6 +213,17 @@ vi.mock('./specialist-candidates.js', () => ({
 
 vi.mock('./specialist-detector.js', () => ({
   detectSpecialistCandidate: vi.fn().mockResolvedValue(null),
+}));
+
+const mockLoadImage = vi.fn();
+const mockTryLoadImage = vi.fn();
+const mockExtractImagePaths = vi.fn(() => []);
+const mockIsVisionCapableModel = vi.fn(() => true);
+vi.mock('./image.js', () => ({
+  loadImage: (...args: any[]) => mockLoadImage(...args),
+  tryLoadImage: (...args: any[]) => mockTryLoadImage(...args),
+  extractImagePaths: (...args: any[]) => mockExtractImagePaths(...args),
+  isVisionCapableModel: (...args: any[]) => mockIsVisionCapableModel(...args),
 }));
 
 // ── Helpers ────────────────────────────────────────────
@@ -1015,6 +1028,198 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     });
 
     expect(mockCandidateUpdateStatus).toHaveBeenCalledWith('cand-3', 'accepted');
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+});
+
+describe('REPL /image command', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rlEmitter = makeRl();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'clear').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    // Default: inline detection finds no images
+    mockExtractImagePaths.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('/image with no args shows usage error', async () => {
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('/image');
+
+    await vi.waitFor(() => {
+      expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('Usage'));
+    });
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('/image with non-vision model shows error', async () => {
+    mockIsVisionCapableModel.mockReturnValue(false);
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('/image /tmp/test.png');
+
+    await vi.waitFor(() => {
+      expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('does not support image'));
+    });
+    expect(mockLoadImage).not.toHaveBeenCalled();
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('/image with bad file path shows error', async () => {
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockLoadImage.mockImplementation(() => { throw new Error('Image file not found: /tmp/nope.png'); });
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('/image /tmp/nope.png');
+
+    await vi.waitFor(() => {
+      expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('not found'));
+    });
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('/image with valid file calls processInput with attachment', async () => {
+    const mockAttachment = { path: '/tmp/test.png', mimeType: 'image/png', data: Buffer.from('data') };
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockLoadImage.mockReturnValue(mockAttachment);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('/image /tmp/test.png What is this?');
+
+    await vi.waitFor(() => {
+      expect(mockProcessInput).toHaveBeenCalledWith('What is this?', [mockAttachment]);
+    });
+    expect(mockHistorySave).toHaveBeenCalled();
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('/image without prompt text defaults to "Describe this image."', async () => {
+    const mockAttachment = { path: '/tmp/test.png', mimeType: 'image/png', data: Buffer.from('data') };
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockLoadImage.mockReturnValue(mockAttachment);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('/image /tmp/test.png');
+
+    await vi.waitFor(() => {
+      expect(mockProcessInput).toHaveBeenCalledWith('Describe this image.', [mockAttachment]);
+    });
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+});
+
+describe('REPL inline image detection', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rlEmitter = makeRl();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'clear').mockImplementation(() => {});
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('attaches image when path found in text and model supports vision', async () => {
+    const mockAttachment = { path: '/tmp/test.png', mimeType: 'image/png', data: Buffer.from('data') };
+    mockExtractImagePaths.mockReturnValue(['/tmp/test.png']);
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockTryLoadImage.mockReturnValue(mockAttachment);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('describe /tmp/test.png');
+
+    await vi.waitFor(() => {
+      expect(mockProcessInput).toHaveBeenCalledWith('describe /tmp/test.png', [mockAttachment]);
+    });
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('warns and sends as text when model does not support vision', async () => {
+    mockExtractImagePaths.mockReturnValue(['/tmp/test.png']);
+    mockIsVisionCapableModel.mockReturnValue(false);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('describe /tmp/test.png');
+
+    await vi.waitFor(() => {
+      expect(mockPrintWarning).toHaveBeenCalledWith(expect.stringContaining('does not support vision'));
+    });
+    // Should still call processInput but without images
+    await vi.waitFor(() => {
+      expect(mockProcessInput).toHaveBeenCalledWith('describe /tmp/test.png', undefined);
+    });
+    expect(mockTryLoadImage).not.toHaveBeenCalled();
+
+    rlEmitter.emit('close');
+    await replPromise.catch(() => {});
+  });
+
+  it('silently skips when image path found but file does not exist', async () => {
+    mockExtractImagePaths.mockReturnValue(['/tmp/nope.png']);
+    mockIsVisionCapableModel.mockReturnValue(true);
+    mockTryLoadImage.mockReturnValue(null);
+    mockProcessInput.mockResolvedValue(undefined);
+
+    const { startRepl } = await import('./repl.js');
+    const replPromise = startRepl(makeConfig());
+
+    await vi.waitFor(() => expect(rlEmitter.prompt).toHaveBeenCalled());
+    typeLine('look at /tmp/nope.png');
+
+    await vi.waitFor(() => {
+      // processInput called without images (undefined)
+      expect(mockProcessInput).toHaveBeenCalledWith('look at /tmp/nope.png', undefined);
+    });
 
     rlEmitter.emit('close');
     await replPromise.catch(() => {});

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -523,20 +523,24 @@ export async function startRepl(
     await mcpManager.close();
   };
 
+  function initSpinner(): void {
+    const spinnerStats: SpinnerStats = {
+      startTime: Date.now(),
+      totalPromptTokens: 0,
+      totalCompletionTokens: 0,
+      latestPromptTokens: 0,
+      model: config.model,
+      contextWindowOverride: config.tokenWindow || undefined,
+    };
+    agent.setSpinnerStats(spinnerStats);
+    startSpinner(() => buildSpinnerMessage(spinnerStats));
+  }
+
   async function runGuidedCreation(message: string): Promise<void> {
     processing = true;
     interrupted = false;
     try {
-      const spinnerStats: SpinnerStats = {
-        startTime: Date.now(),
-        totalPromptTokens: 0,
-        totalCompletionTokens: 0,
-        latestPromptTokens: 0,
-        model: config.model,
-        contextWindowOverride: config.tokenWindow || undefined,
-      };
-      agent.setSpinnerStats(spinnerStats);
-      startSpinner(() => buildSpinnerMessage(spinnerStats));
+      initSpinner();
       await agent.processInput(message);
       historyStore.save(agent.getHistory());
     } catch (err: unknown) {
@@ -1508,14 +1512,27 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         if (!args) {
           printError('Usage: /image <path> [prompt]');
           printInfo('  Example: /image ~/screenshot.png What is on the screen?');
-          printInfo('  Tip: you can also paste image paths inline, e.g. "describe ~/screenshot.png"');
+          printInfo(
+            '  Tip: you can also paste image paths inline, e.g. "describe ~/screenshot.png"',
+          );
           void prompt();
           return;
         }
 
-        const spaceIdx = args.indexOf(' ');
-        const imagePath = spaceIdx === -1 ? args : args.slice(0, spaceIdx);
-        const userText = spaceIdx === -1 ? 'Describe this image.' : args.slice(spaceIdx + 1).trim() || 'Describe this image.';
+        let imagePath: string;
+        let userText: string;
+        const quoteMatch = args.match(/^(["'])(.+?)\1(?:\s+(.*))?$/);
+        if (quoteMatch) {
+          imagePath = quoteMatch[2];
+          userText = quoteMatch[3]?.trim() || 'Describe this image.';
+        } else {
+          const spaceIdx = args.indexOf(' ');
+          imagePath = spaceIdx === -1 ? args : args.slice(0, spaceIdx);
+          userText =
+            spaceIdx === -1
+              ? 'Describe this image.'
+              : args.slice(spaceIdx + 1).trim() || 'Describe this image.';
+        }
 
         if (!isVisionCapableModel(config.provider, config.model)) {
           printError(
@@ -1540,16 +1557,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         processing = true;
         interrupted = false;
         try {
-          const spinnerStats: SpinnerStats = {
-            startTime: Date.now(),
-            totalPromptTokens: 0,
-            totalCompletionTokens: 0,
-            latestPromptTokens: 0,
-            model: config.model,
-            contextWindowOverride: config.tokenWindow || undefined,
-          };
-          agent.setSpinnerStats(spinnerStats);
-          startSpinner(() => buildSpinnerMessage(spinnerStats));
+          initSpinner();
           await agent.processInput(userText, [attachment]);
           historyStore.save(agent.getHistory());
         } catch (err: unknown) {
@@ -1598,16 +1606,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
           processing = true;
           interrupted = false;
           try {
-            const spinnerStats: SpinnerStats = {
-              startTime: Date.now(),
-              totalPromptTokens: 0,
-              totalCompletionTokens: 0,
-              latestPromptTokens: 0,
-              model: config.model,
-              contextWindowOverride: config.tokenWindow || undefined,
-            };
-            agent.setSpinnerStats(spinnerStats);
-            startSpinner(() => buildSpinnerMessage(spinnerStats));
+            initSpinner();
             await agent.processInput(message);
             historyStore.save(agent.getHistory());
           } catch (err: unknown) {
@@ -1657,16 +1656,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
     processing = true;
     interrupted = false;
     try {
-      const spinnerStats: SpinnerStats = {
-        startTime: Date.now(),
-        totalPromptTokens: 0,
-        totalCompletionTokens: 0,
-        latestPromptTokens: 0,
-        model: config.model,
-        contextWindowOverride: config.tokenWindow || undefined,
-      };
-      agent.setSpinnerStats(spinnerStats);
-      startSpinner(() => buildSpinnerMessage(spinnerStats));
+      initSpinner();
       await agent.processInput(trimmed, inlineImages);
       historyStore.save(agent.getHistory());
     } catch (err: unknown) {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -78,6 +78,13 @@ import {
 } from './output.js';
 import { buildMemoryContext } from './memory-context.js';
 import { debugLog } from './logger.js';
+import {
+  loadImage,
+  tryLoadImage,
+  extractImagePaths,
+  isVisionCapableModel,
+  type ImageAttachment,
+} from './image.js';
 
 /** Promote a pending candidate to a full specialist, updating status and logging. */
 function promoteCandidate(
@@ -170,6 +177,7 @@ export async function startRepl(
     { command: '/candidates', description: 'Review specialist suggestions' },
     { command: '/critic', description: 'Toggle critic mode for response verification' },
     { command: '/agent-options', description: 'Configure auto-creation for specialist agents' },
+    { command: '/image', description: 'Attach an image: /image <path> [prompt]' },
     { command: '/debug', description: 'Print diagnostic report for troubleshooting' },
     { command: '/exit', description: 'Quit Bernard' },
   ];
@@ -1495,6 +1503,74 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         return;
       }
 
+      if (trimmed === '/image' || trimmed.startsWith('/image ')) {
+        const args = trimmed.slice('/image'.length).trim();
+        if (!args) {
+          printError('Usage: /image <path> [prompt]');
+          printInfo('  Example: /image ~/screenshot.png What is on the screen?');
+          printInfo('  Tip: you can also paste image paths inline, e.g. "describe ~/screenshot.png"');
+          void prompt();
+          return;
+        }
+
+        const spaceIdx = args.indexOf(' ');
+        const imagePath = spaceIdx === -1 ? args : args.slice(0, spaceIdx);
+        const userText = spaceIdx === -1 ? 'Describe this image.' : args.slice(spaceIdx + 1).trim() || 'Describe this image.';
+
+        if (!isVisionCapableModel(config.provider, config.model)) {
+          printError(
+            `Model "${config.model}" does not support image input. Switch to a vision-capable model with /model.`,
+          );
+          void prompt();
+          return;
+        }
+
+        let attachment: ImageAttachment;
+        try {
+          attachment = loadImage(imagePath);
+        } catch (err: unknown) {
+          printError(err instanceof Error ? err.message : String(err));
+          void prompt();
+          return;
+        }
+
+        printInfo(`  Attaching image: ${attachment.path}`);
+        printInfo(`  Image will be sent to ${config.provider}/${config.model}`);
+
+        processing = true;
+        interrupted = false;
+        try {
+          const spinnerStats: SpinnerStats = {
+            startTime: Date.now(),
+            totalPromptTokens: 0,
+            totalCompletionTokens: 0,
+            latestPromptTokens: 0,
+            model: config.model,
+            contextWindowOverride: config.tokenWindow || undefined,
+          };
+          agent.setSpinnerStats(spinnerStats);
+          startSpinner(() => buildSpinnerMessage(spinnerStats));
+          await agent.processInput(userText, [attachment]);
+          historyStore.save(agent.getHistory());
+        } catch (err: unknown) {
+          if (!interrupted) {
+            printError(err instanceof Error ? err.message : String(err));
+          }
+        } finally {
+          processing = false;
+          stopSpinner();
+        }
+
+        if (interrupted) {
+          printInfo('Interrupted.');
+          interrupted = false;
+        }
+
+        console.log();
+        void prompt();
+        return;
+      }
+
       // Dynamic routine invocation: /{routine-id} [args...]
       {
         const parts = trimmed.slice(1).split(/\s+/);
@@ -1556,6 +1632,28 @@ Remember: the systemPrompt should read like a persona definition — who this sp
       }
     } // end slash command handling
 
+    let inlineImages: ImageAttachment[] | undefined;
+    const candidatePaths = extractImagePaths(trimmed);
+    if (candidatePaths.length > 0) {
+      if (isVisionCapableModel(config.provider, config.model)) {
+        const loaded: ImageAttachment[] = [];
+        for (const p of candidatePaths) {
+          const img = tryLoadImage(p);
+          if (img) loaded.push(img);
+        }
+        if (loaded.length > 0) {
+          for (const img of loaded) {
+            printInfo(`  Attaching image: ${img.path}`);
+          }
+          inlineImages = loaded;
+        }
+      } else {
+        printWarning(
+          `Image(s) detected but model "${config.model}" does not support vision. Sending as text only.`,
+        );
+      }
+    }
+
     processing = true;
     interrupted = false;
     try {
@@ -1569,7 +1667,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
       };
       agent.setSpinnerStats(spinnerStats);
       startSpinner(() => buildSpinnerMessage(spinnerStats));
-      await agent.processInput(trimmed);
+      await agent.processInput(trimmed, inlineImages);
       historyStore.save(agent.getHistory());
     } catch (err: unknown) {
       if (!interrupted) {

--- a/src/tools/datetime.test.ts
+++ b/src/tools/datetime.test.ts
@@ -105,9 +105,7 @@ describe('timestampUserContent', () => {
   it('inserts text part when array has no text parts', () => {
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_DATE);
-    const input = [
-      { type: 'image' as const, image: Buffer.from('data'), mimeType: 'image/png' },
-    ];
+    const input = [{ type: 'image' as const, image: Buffer.from('data'), mimeType: 'image/png' }];
     const result = timestampUserContent(input);
     const parts = result as Array<{ type: string; text?: string }>;
     expect(parts).toHaveLength(2);

--- a/src/tools/datetime.test.ts
+++ b/src/tools/datetime.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { formatCurrentDateTime, timestampUserMessage, stripTimestamp } from './datetime.js';
+import {
+  formatCurrentDateTime,
+  timestampUserMessage,
+  timestampUserContent,
+  stripTimestamp,
+} from './datetime.js';
 
 const FIXED_DATE = new Date('2025-06-15T14:30:00-04:00');
 
@@ -65,6 +70,63 @@ describe('timestampUserMessage', () => {
     expect(result).toMatch(
       /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\] \[test\] message$/,
     );
+  });
+});
+
+describe('timestampUserContent', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('delegates to timestampUserMessage for string input', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+    const result = timestampUserContent('Hello');
+    expect(typeof result).toBe('string');
+    expect(result).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\] Hello$/);
+  });
+
+  it('prepends timestamp to first text part in array', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+    const input = [
+      { type: 'text' as const, text: 'Describe this' },
+      { type: 'image' as const, image: Buffer.from('data'), mimeType: 'image/png' },
+    ];
+    const result = timestampUserContent(input);
+    expect(Array.isArray(result)).toBe(true);
+    const parts = result as Array<{ type: string; text?: string }>;
+    expect(parts).toHaveLength(2);
+    expect(parts[0].type).toBe('text');
+    expect(parts[0].text).toMatch(
+      /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\] Describe this$/,
+    );
+    expect(parts[1].type).toBe('image');
+  });
+
+  it('inserts text part when array has no text parts', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+    const input = [
+      { type: 'image' as const, image: Buffer.from('data'), mimeType: 'image/png' },
+    ];
+    const result = timestampUserContent(input);
+    const parts = result as Array<{ type: string; text?: string }>;
+    expect(parts).toHaveLength(2);
+    expect(parts[0].type).toBe('text');
+    expect(parts[0].text).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\]$/);
+    expect(parts[1].type).toBe('image');
+  });
+
+  it('does not mutate the original array', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+    const original = [
+      { type: 'text' as const, text: 'original text' },
+      { type: 'image' as const, image: Buffer.from('data'), mimeType: 'image/png' },
+    ];
+    const originalText = original[0].text;
+    timestampUserContent(original);
+    expect(original[0].text).toBe(originalText);
+    expect(original).toHaveLength(2);
   });
 });
 

--- a/src/tools/datetime.ts
+++ b/src/tools/datetime.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, type UserContent } from 'ai';
 import { z } from 'zod';
 
 /** Regex matching the [ISO-8601] prefix produced by timestampUserMessage. */
@@ -43,8 +43,8 @@ export function formatCurrentDateTime(): string {
   return `${date} at ${time}`;
 }
 
-/** Wraps user input with a local ISO 8601 timestamp prefix. */
-export function timestampUserMessage(userInput: string): string {
+/** Generates a `[ISO-8601]` prefix string for the current moment. */
+function makeTimestampPrefix(): string {
   const now = new Date();
   const tzOffset = -now.getTimezoneOffset();
   const sign = tzOffset >= 0 ? '+' : '-';
@@ -54,7 +54,36 @@ export function timestampUserMessage(userInput: string): string {
     `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}` +
     `T${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}` +
     `${sign}${hh}:${mm}`;
-  return `[${localISO}] ${userInput}`;
+  return `[${localISO}] `;
+}
+
+/** Wraps user input with a local ISO 8601 timestamp prefix. */
+export function timestampUserMessage(userInput: string): string {
+  return makeTimestampPrefix() + userInput;
+}
+
+/**
+ * Timestamps a `UserContent` value (string or content-part array).
+ * For strings, delegates to `timestampUserMessage`.
+ * For arrays, prepends the timestamp to the first text part, or inserts a new one.
+ */
+export function timestampUserContent(content: UserContent): UserContent {
+  if (typeof content === 'string') {
+    return timestampUserMessage(content);
+  }
+
+  const prefix = makeTimestampPrefix();
+  const parts = [...content];
+  const firstTextIdx = parts.findIndex(
+    (p) => typeof p === 'object' && p !== null && 'type' in p && p.type === 'text',
+  );
+  if (firstTextIdx >= 0) {
+    const tp = parts[firstTextIdx] as { type: 'text'; text: string };
+    parts[firstTextIdx] = { type: 'text', text: prefix + tp.text };
+  } else {
+    parts.unshift({ type: 'text', text: prefix.trim() });
+  }
+  return parts;
 }
 
 /** Strips a leading [ISO-timestamp] prefix from a message string. */


### PR DESCRIPTION
Enables users to attach images to conversations when using vision-capable models like GPT-4o, Claude, and Grok-vision:

- Adds `/image  [prompt]` command for explicit image attachment
- Implements automatic inline detection of image paths in messages
- Provides comprehensive image validation with size limits and format checking
- Updates token estimation to account for image content in context management
- Strips images from persisted history to prevent disk bloat
- Extends timestamp handling to support multipart content with text and images
- Includes comprehensive test coverage for all image handling functionality

closes #110