### PR TITLE
Consistent Menu Selection Interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ bernard -p openai -m gpt-4o  # Use specific provider/model
 - **src/agent.ts** — Agent loop using AI SDK `generateText` + `maxSteps` + auto-continue on truncation + optional critic verification
 - **src/config.ts** — .env loading, defaults, validation
 - **src/output.ts** — Chalk-based terminal formatting
+- **src/menu.ts** — Reusable numbered-list selection UI (`printMenuList`, `selectFromMenu`, `promptValue`) with Escape/Enter-to-cancel support
 - **src/theme.ts** — Color theme definitions (bernard, ocean, forest, synthwave, high-contrast, colorblind)
 - **src/domains.ts** — Memory domain registry (tool-usage, user-preferences, general) with specialized extraction prompts
 - **src/routines.ts** — RoutineStore class: per-file JSON storage for named multi-step workflows

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ Features:
 | `/create-task`    | Create a task routine (`task-` prefixed) with guided AI assistance                   |
 | `/specialists`    | List saved specialists                                                               |
 | `/candidates`     | Review auto-detected specialist suggestions _(v0.6.0+)_                              |
-| `/critic`         | Toggle critic mode for response verification (on/off)                                |
-| `/agent-options`  | Configure auto-creation for specialist agents                                        |
+| `/critic`         | Toggle critic mode                                                                   |
+| `/agent-options`  | Configure specialist auto-creation settings                                          |
 | `/options`        | View and modify runtime options (max-tokens, max-steps, shell-timeout, token-window) |
 | `/debug`          | Print a diagnostic report for troubleshooting (no secrets leaked)                    |
 | `/exit`           | Quit Bernard (also: `exit`, `quit`)                                                  |
@@ -492,10 +492,7 @@ Use `/candidates` to see pending suggestions with their name, description, confi
 **Auto-creation** — You can enable automatic specialist creation for high-confidence candidates:
 
 ```bash
-/agent-options auto-create on       # Enable auto-creation
-/agent-options auto-create off      # Disable auto-creation
-/agent-options threshold 0.85       # Set confidence threshold (0-1)
-/agent-options                      # Show current settings
+/agent-options    # Interactive menu to configure auto-create on/off and threshold
 ```
 
 Or via environment variables: `BERNARD_AUTO_CREATE_SPECIALISTS=true` and `BERNARD_AUTO_CREATE_THRESHOLD=0.85`.
@@ -509,9 +506,7 @@ Storage: one JSON file per candidate in `~/.local/share/bernard/specialist-candi
 Critic mode adds planning, proactive scratch/memory usage, and post-response verification. Toggle it during a session:
 
 ```bash
-/critic on    # Enable critic mode
-/critic off   # Disable critic mode
-/critic       # Show current status
+/critic    # Interactive menu to toggle on/off
 ```
 
 When enabled:
@@ -858,6 +853,7 @@ src/
 ├── config.ts             # Config loading and validation
 ├── critic.ts             # Critic agent for response verification
 ├── output.ts             # Terminal formatting (Chalk)
+├── menu.ts               # Reusable numbered-list selection UI
 ├── theme.ts              # Color theme definitions and switching
 ├── memory.ts             # MemoryStore (persistent + scratch)
 ├── context.ts            # Context compression + domain fact extraction

--- a/src/menu.test.ts
+++ b/src/menu.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  countMenuItems,
+  getMenuItem,
+  printMenuList,
+  selectFromMenu,
+  promptValue,
+  type MenuEntry,
+} from './menu.js';
+
+// ── Mock output + theme ──────────────────────────────────
+
+const mockPrintInfo = vi.fn();
+vi.mock('./output.js', () => ({
+  printInfo: (...args: any[]) => mockPrintInfo(...args),
+}));
+
+vi.mock('./theme.js', () => ({
+  getTheme: () => ({
+    ansi: { prompt: '', reset: '' },
+  }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeRl() {
+  const emitter = new EventEmitter() as any;
+  emitter.question = vi.fn();
+  return emitter;
+}
+
+// ── Test data ────────────────────────────────────────────
+
+const simpleEntries: MenuEntry[] = [
+  { label: 'Alpha' },
+  { label: 'Beta' },
+  { label: 'Gamma' },
+];
+
+const groupedEntries: MenuEntry[] = [
+  { label: 'Red', active: true, value: 'r' },
+  { label: 'Green', value: 'g' },
+  { type: 'section', title: 'Cool colors:' },
+  { label: 'Blue', value: 'b' },
+  { label: 'Purple', annotation: '(new)', value: 'p' },
+];
+
+const entriesWithDescription: MenuEntry[] = [
+  { label: 'max-tokens', annotation: '= 4096 (default)', description: 'Max response tokens' },
+  { label: 'shell-timeout', annotation: '= 30000 (custom)', description: 'Shell command timeout' },
+];
+
+// ── Tests ────────────────────────────────────────────────
+
+describe('countMenuItems', () => {
+  it('counts items, skipping sections', () => {
+    expect(countMenuItems(groupedEntries)).toBe(4);
+  });
+
+  it('returns 0 for empty entries', () => {
+    expect(countMenuItems([])).toBe(0);
+  });
+
+  it('counts items-only entries', () => {
+    expect(countMenuItems(simpleEntries)).toBe(3);
+  });
+});
+
+describe('getMenuItem', () => {
+  it('returns the correct item by index, skipping sections', () => {
+    const item = getMenuItem(groupedEntries, 2);
+    expect(item).toBeDefined();
+    expect(item!.label).toBe('Blue');
+  });
+
+  it('returns first item at index 0', () => {
+    expect(getMenuItem(simpleEntries, 0)!.label).toBe('Alpha');
+  });
+
+  it('returns undefined for out-of-bounds index', () => {
+    expect(getMenuItem(simpleEntries, 10)).toBeUndefined();
+  });
+
+  it('returns undefined for empty entries', () => {
+    expect(getMenuItem([], 0)).toBeUndefined();
+  });
+});
+
+describe('printMenuList', () => {
+  beforeEach(() => {
+    mockPrintInfo.mockClear();
+  });
+
+  it('prints numbered items', () => {
+    printMenuList(simpleEntries);
+    expect(mockPrintInfo).toHaveBeenCalledWith('    1. Alpha');
+    expect(mockPrintInfo).toHaveBeenCalledWith('    2. Beta');
+    expect(mockPrintInfo).toHaveBeenCalledWith('    3. Gamma');
+  });
+
+  it('prints section headers without consuming a number', () => {
+    printMenuList(groupedEntries);
+    const calls = mockPrintInfo.mock.calls.map((c) => c[0]);
+    expect(calls).toContain('\n  Cool colors:');
+    expect(calls).toContain('    1. Red (active)');
+    expect(calls).toContain('    2. Green');
+    expect(calls).toContain('    3. Blue');
+    expect(calls).toContain('    4. Purple (new)');
+  });
+
+  it('prints descriptions on a second line', () => {
+    printMenuList(entriesWithDescription);
+    expect(mockPrintInfo).toHaveBeenCalledWith('       Max response tokens');
+    expect(mockPrintInfo).toHaveBeenCalledWith('       Shell command timeout');
+  });
+
+  it('handles empty entries without error', () => {
+    printMenuList([]);
+    expect(mockPrintInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe('selectFromMenu', () => {
+  let rl: any;
+
+  beforeEach(() => {
+    rl = makeRl();
+    mockPrintInfo.mockClear();
+  });
+
+  it('returns the selected item on valid input', async () => {
+    rl.question.mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      cb('2');
+    });
+
+    const result = await selectFromMenu(rl, simpleEntries);
+    expect(result).toEqual({
+      cancelled: false,
+      index: 1,
+      item: { label: 'Beta' },
+    });
+  });
+
+  it('returns cancelled on empty input', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1](''));
+
+    const result = await selectFromMenu(rl, simpleEntries);
+    expect(result).toEqual({ cancelled: true });
+    expect(mockPrintInfo).toHaveBeenCalledWith('  Cancelled.');
+  });
+
+  it('returns cancelled on non-numeric input', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('abc'));
+
+    const result = await selectFromMenu(rl, simpleEntries);
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('returns cancelled on out-of-range input (too high)', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('99'));
+
+    const result = await selectFromMenu(rl, simpleEntries);
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('returns cancelled on out-of-range input (zero)', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('0'));
+
+    const result = await selectFromMenu(rl, simpleEntries);
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('skips section entries when resolving index', async () => {
+    // groupedEntries has: Red(0), Green(1), [section], Blue(2), Purple(3)
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('3'));
+
+    const result = await selectFromMenu(rl, groupedEntries);
+    expect(result).toEqual({
+      cancelled: false,
+      index: 2,
+      item: expect.objectContaining({ label: 'Blue', value: 'b' }),
+    });
+  });
+
+  it('uses custom promptLabel', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('1'));
+
+    await selectFromMenu(rl, simpleEntries, { promptLabel: 'Pick one' });
+    const promptStr = rl.question.mock.calls[0][0] as string;
+    expect(promptStr).toContain('Pick one');
+  });
+
+  it('returns cancelled on pre-aborted signal', async () => {
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await selectFromMenu(rl, simpleEntries, {}, ac.signal);
+    expect(result).toEqual({ cancelled: true });
+    expect(rl.question).not.toHaveBeenCalled();
+  });
+
+  it('returns cancelled when signal is aborted during prompt', async () => {
+    const ac = new AbortController();
+
+    // Don't call callback immediately — simulate waiting for user input
+    rl.question.mockImplementation(() => {});
+
+    const resultPromise = selectFromMenu(rl, simpleEntries, {}, ac.signal);
+
+    // Abort while "waiting"
+    ac.abort();
+
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: true });
+  });
+});
+
+describe('promptValue', () => {
+  let rl: any;
+
+  beforeEach(() => {
+    rl = makeRl();
+    mockPrintInfo.mockClear();
+  });
+
+  it('returns the raw value on non-empty input', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('  42  '));
+
+    const result = await promptValue(rl, { label: 'Enter value' });
+    expect(result).toEqual({ cancelled: false, raw: '42' });
+  });
+
+  it('returns cancelled on empty input', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1](''));
+
+    const result = await promptValue(rl, { label: 'Enter value' });
+    expect(result).toEqual({ cancelled: true });
+    expect(mockPrintInfo).toHaveBeenCalledWith('  Cancelled.');
+  });
+
+  it('returns cancelled on pre-aborted signal', async () => {
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await promptValue(rl, { label: 'Enter value' }, ac.signal);
+    expect(result).toEqual({ cancelled: true });
+    expect(rl.question).not.toHaveBeenCalled();
+  });
+
+  it('returns cancelled when signal is aborted during prompt', async () => {
+    const ac = new AbortController();
+    rl.question.mockImplementation(() => {});
+
+    const resultPromise = promptValue(rl, { label: 'Enter value' }, ac.signal);
+    ac.abort();
+
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('includes label in prompt string', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('x'));
+
+    await promptValue(rl, { label: 'New threshold' });
+    const promptStr = rl.question.mock.calls[0][0] as string;
+    expect(promptStr).toContain('New threshold');
+  });
+});

--- a/src/menu.test.ts
+++ b/src/menu.test.ts
@@ -32,11 +32,7 @@ function makeRl() {
 
 // ── Test data ────────────────────────────────────────────
 
-const simpleEntries: MenuEntry[] = [
-  { label: 'Alpha' },
-  { label: 'Beta' },
-  { label: 'Gamma' },
-];
+const simpleEntries: MenuEntry[] = [{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }];
 
 const groupedEntries: MenuEntry[] = [
   { label: 'Red', active: true, value: 'r' },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,0 +1,177 @@
+import type * as readline from 'node:readline';
+import { printInfo } from './output.js';
+import { getTheme } from './theme.js';
+
+/** A single selectable item in a menu. */
+export interface MenuItem {
+  /** Text shown next to the number. */
+  label: string;
+  /** If true, appends " (active)" marker. */
+  active?: boolean;
+  /** Optional annotation shown after the label (e.g. "= 4096 (default)"). */
+  annotation?: string;
+  /** Optional second line shown below the item, indented further. */
+  description?: string;
+  /** Opaque payload returned to the caller on selection. */
+  value?: unknown;
+}
+
+/** A section divider inserted between items in the numbered list. */
+export interface MenuSection {
+  type: 'section';
+  /** Header text printed before the next batch of items. */
+  title: string;
+}
+
+/** Union of what can appear in the entries array. */
+export type MenuEntry = MenuItem | MenuSection;
+
+/** Options for selectFromMenu(). */
+export interface MenuOptions {
+  /** Prompt string override, e.g. "Select option". Default: "Select". */
+  promptLabel?: string;
+}
+
+/** Options for promptValue(). */
+export interface ValuePromptOptions {
+  /** Prompt label, e.g. "New value for max-tokens". */
+  label: string;
+}
+
+/** Result from selectFromMenu(). */
+export type SelectResult = { cancelled: true } | { cancelled: false; index: number; item: MenuItem };
+
+/** Result from promptValue(). */
+export type ValueResult = { cancelled: true } | { cancelled: false; raw: string };
+
+/** Type guard for MenuSection entries. */
+function isSection(entry: MenuEntry): entry is MenuSection {
+  return 'type' in entry && entry.type === 'section';
+}
+
+/** Count the selectable (non-section) items in an entries array. */
+export function countMenuItems(entries: MenuEntry[]): number {
+  let count = 0;
+  for (const e of entries) {
+    if (!isSection(e)) count++;
+  }
+  return count;
+}
+
+/** Get the Nth (0-based) selectable item, skipping sections. */
+export function getMenuItem(entries: MenuEntry[], index: number): MenuItem | undefined {
+  let n = 0;
+  for (const e of entries) {
+    if (!isSection(e)) {
+      if (n === index) return e;
+      n++;
+    }
+  }
+  return undefined;
+}
+
+/** Print a numbered list with optional section headers. */
+export function printMenuList(entries: MenuEntry[]): void {
+  let n = 1;
+  for (const entry of entries) {
+    if (isSection(entry)) {
+      printInfo(`\n  ${entry.title}`);
+    } else {
+      const activeMarker = entry.active ? ' (active)' : '';
+      const annotation = entry.annotation ? ` ${entry.annotation}` : '';
+      printInfo(`    ${n}. ${entry.label}${activeMarker}${annotation}`);
+      if (entry.description) {
+        printInfo(`       ${entry.description}`);
+      }
+      n++;
+    }
+  }
+}
+
+/**
+ * Wrap rl.question in a Promise with optional AbortSignal support.
+ * Returns null on abort or if the signal was already aborted.
+ */
+function questionWithSignal(
+  rl: readline.Interface,
+  prompt: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve(null);
+      return;
+    }
+
+    let settled = false;
+    const settle = (val: string | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(val);
+    };
+
+    const onAbort = () => settle(null);
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    if (signal) {
+      rl.question(prompt, { signal }, (answer) => {
+        signal.removeEventListener('abort', onAbort);
+        settle(answer);
+      });
+    } else {
+      rl.question(prompt, (answer) => settle(answer));
+    }
+  });
+}
+
+/**
+ * Prompt the user to select from a numbered list.
+ * Returns cancelled if input is empty, non-numeric, out of range, or signal aborted.
+ */
+export async function selectFromMenu(
+  rl: readline.Interface,
+  entries: MenuEntry[],
+  options?: MenuOptions,
+  signal?: AbortSignal,
+): Promise<SelectResult> {
+  const count = countMenuItems(entries);
+  const label = options?.promptLabel ?? 'Select';
+  const { ansi } = getTheme();
+  const promptStr = `  ${ansi.prompt}${label} [1-${count}]${ansi.reset} (Enter to cancel): `;
+
+  const answer = await questionWithSignal(rl, promptStr, signal);
+  if (answer === null || answer.trim() === '') {
+    printInfo('  Cancelled.');
+    return { cancelled: true };
+  }
+
+  const num = parseInt(answer.trim(), 10);
+  if (num >= 1 && num <= count) {
+    const item = getMenuItem(entries, num - 1)!;
+    return { cancelled: false, index: num - 1, item };
+  }
+
+  printInfo('  Cancelled.');
+  return { cancelled: true };
+}
+
+/**
+ * Prompt the user to enter a free-form string value.
+ * Returns cancelled if input is empty or signal aborted.
+ */
+export async function promptValue(
+  rl: readline.Interface,
+  options: ValuePromptOptions,
+  signal?: AbortSignal,
+): Promise<ValueResult> {
+  const { ansi } = getTheme();
+  const promptStr = `  ${ansi.prompt}${options.label}${ansi.reset} (Enter to cancel): `;
+
+  const answer = await questionWithSignal(rl, promptStr, signal);
+  if (answer === null || answer.trim() === '') {
+    printInfo('  Cancelled.');
+    return { cancelled: true };
+  }
+
+  return { cancelled: false, raw: answer.trim() };
+}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -137,7 +137,7 @@ export async function selectFromMenu(
   const items = entries.filter((e) => !isSection(e)) as MenuItem[];
   const label = options?.promptLabel ?? 'Select';
   const { ansi } = getTheme();
-  const promptStr = `  ${ansi.prompt}${label} [1-${items.length}]${ansi.reset} (Enter to cancel): `;
+  const promptStr = `  ${ansi.prompt}${label} [1-${items.length}]${ansi.reset} (Enter or Esc to cancel): `;
 
   const answer = await questionWithSignal(rl, promptStr, signal);
   if (answer === null || answer.trim() === '') {
@@ -164,7 +164,7 @@ export async function promptValue(
   signal?: AbortSignal,
 ): Promise<ValueResult> {
   const { ansi } = getTheme();
-  const promptStr = `  ${ansi.prompt}${options.label}${ansi.reset} (Enter to cancel): `;
+  const promptStr = `  ${ansi.prompt}${options.label}${ansi.reset} (Enter or Esc to cancel): `;
 
   const answer = await questionWithSignal(rl, promptStr, signal);
   if (answer === null || answer.trim() === '') {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -134,10 +134,10 @@ export async function selectFromMenu(
   options?: MenuOptions,
   signal?: AbortSignal,
 ): Promise<SelectResult> {
-  const count = countMenuItems(entries);
+  const items = entries.filter((e) => !isSection(e)) as MenuItem[];
   const label = options?.promptLabel ?? 'Select';
   const { ansi } = getTheme();
-  const promptStr = `  ${ansi.prompt}${label} [1-${count}]${ansi.reset} (Enter to cancel): `;
+  const promptStr = `  ${ansi.prompt}${label} [1-${items.length}]${ansi.reset} (Enter to cancel): `;
 
   const answer = await questionWithSignal(rl, promptStr, signal);
   if (answer === null || answer.trim() === '') {
@@ -146,9 +146,8 @@ export async function selectFromMenu(
   }
 
   const num = parseInt(answer.trim(), 10);
-  if (num >= 1 && num <= count) {
-    const item = getMenuItem(entries, num - 1)!;
-    return { cancelled: false, index: num - 1, item };
+  if (num >= 1 && num <= items.length) {
+    return { cancelled: false, index: num - 1, item: items[num - 1] };
   }
 
   printInfo('  Cancelled.');

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -39,7 +39,9 @@ export interface ValuePromptOptions {
 }
 
 /** Result from selectFromMenu(). */
-export type SelectResult = { cancelled: true } | { cancelled: false; index: number; item: MenuItem };
+export type SelectResult =
+  | { cancelled: true }
+  | { cancelled: false; index: number; item: MenuItem };
 
 /** Result from promptValue(). */
 export type ValueResult = { cancelled: true } | { cancelled: false; raw: string };

--- a/src/output.ts
+++ b/src/output.ts
@@ -390,9 +390,7 @@ export function printHelp(): void {
     t.text('  /create-specialist') + t.muted(' — Create a specialist with guided AI assistance'),
   );
   console.log(t.text('  /candidates') + t.muted(' — Review specialist suggestions'));
-  console.log(
-    t.text('  /critic') + t.muted('   — Toggle critic mode'),
-  );
+  console.log(t.text('  /critic') + t.muted('   — Toggle critic mode'));
   console.log(
     t.text('  /options') +
       t.muted('  — View and set options (max-tokens, max-steps, shell-timeout, token-window)'),

--- a/src/output.ts
+++ b/src/output.ts
@@ -391,14 +391,14 @@ export function printHelp(): void {
   );
   console.log(t.text('  /candidates') + t.muted(' — Review specialist suggestions'));
   console.log(
-    t.text('  /critic') + t.muted('   — Toggle critic mode (on/off) for response verification'),
+    t.text('  /critic') + t.muted('   — Toggle critic mode'),
   );
   console.log(
     t.text('  /options') +
       t.muted('  — View and set options (max-tokens, max-steps, shell-timeout, token-window)'),
   );
   console.log(
-    t.text('  /agent-options') + t.muted(' — Configure auto-creation for specialist agents'),
+    t.text('  /agent-options') + t.muted(' — Configure specialist auto-creation settings'),
   );
   console.log(t.text('  /update') + t.muted('   — Check for and install updates'));
   console.log(t.text('  /debug') + t.muted('    — Print diagnostic report for troubleshooting'));

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -259,6 +259,14 @@ function typeLine(text: string): void {
   process.nextTick(() => rlEmitter.emit('line', text));
 }
 
+/**
+ * Extract the callback from the most recent rl.question() call.
+ * With AbortSignal the signature is rl.question(prompt, {signal}, cb) — callback at index 2.
+ */
+function getQuestionCallback(): (answer: string) => void {
+  return rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+}
+
 // ── Tests ──────────────────────────────────────────────
 
 describe('REPL /clear command', () => {
@@ -843,7 +851,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const topCb = getQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -851,7 +859,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const valCb = getQuestionCallback();
     valCb('80');
 
     await vi.waitFor(() => {
@@ -879,7 +887,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const topCb = getQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -887,7 +895,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const valCb = getQuestionCallback();
     valCb('0.75');
 
     await vi.waitFor(() => {
@@ -915,7 +923,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const topCb = getQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -923,7 +931,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const valCb = getQuestionCallback();
     valCb('150');
 
     await vi.waitFor(() => {
@@ -981,7 +989,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const topCb = getQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('1');
 
@@ -989,7 +997,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const subCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const subCb = getQuestionCallback();
     subCb('1');
 
     await vi.waitFor(() => {
@@ -1042,7 +1050,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const topCb = getQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('1');
 
@@ -1050,7 +1058,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const subCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const subCb = getQuestionCallback();
     subCb('1');
 
     await vi.waitFor(() => {
@@ -1098,7 +1106,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const topCb = getQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -1106,7 +1114,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    const valCb = getQuestionCallback();
     valCb('0.8');
 
     await vi.waitFor(() => {

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -260,12 +260,15 @@ function typeLine(text: string): void {
 }
 
 /**
- * Extract the callback from the most recent rl.question() call that was
- * made with an AbortSignal: rl.question(prompt, {signal}, cb) — callback at index 2.
- * Menu functions always pass a signal, so this is the correct index for menu prompts.
+ * Extract the callback from the most recent rl.question() call.
+ * Supports both rl.question(prompt, cb) and rl.question(prompt, {signal}, cb).
  */
 function getMenuQuestionCallback(): (answer: string) => void {
-  return rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+  const call = rlEmitter.question.mock.calls.at(-1);
+  if (!call) throw new Error('Expected rl.question() to have been called');
+  const callback = call[call.length - 1];
+  if (typeof callback !== 'function') throw new Error('Expected the last rl.question() argument to be a callback');
+  return callback as (answer: string) => void;
 }
 
 // ── Tests ──────────────────────────────────────────────

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -260,10 +260,11 @@ function typeLine(text: string): void {
 }
 
 /**
- * Extract the callback from the most recent rl.question() call.
- * With AbortSignal the signature is rl.question(prompt, {signal}, cb) — callback at index 2.
+ * Extract the callback from the most recent rl.question() call that was
+ * made with an AbortSignal: rl.question(prompt, {signal}, cb) — callback at index 2.
+ * Menu functions always pass a signal, so this is the correct index for menu prompts.
  */
-function getQuestionCallback(): (answer: string) => void {
+function getMenuQuestionCallback(): (answer: string) => void {
   return rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
 }
 
@@ -851,7 +852,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = getQuestionCallback();
+    const topCb = getMenuQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -859,7 +860,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = getQuestionCallback();
+    const valCb = getMenuQuestionCallback();
     valCb('80');
 
     await vi.waitFor(() => {
@@ -887,7 +888,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = getQuestionCallback();
+    const topCb = getMenuQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -895,7 +896,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = getQuestionCallback();
+    const valCb = getMenuQuestionCallback();
     valCb('0.75');
 
     await vi.waitFor(() => {
@@ -923,7 +924,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = getQuestionCallback();
+    const topCb = getMenuQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -931,7 +932,7 @@ describe('REPL /agent-options threshold normalization', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = getQuestionCallback();
+    const valCb = getMenuQuestionCallback();
     valCb('150');
 
     await vi.waitFor(() => {
@@ -989,7 +990,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = getQuestionCallback();
+    const topCb = getMenuQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('1');
 
@@ -997,7 +998,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const subCb = getQuestionCallback();
+    const subCb = getMenuQuestionCallback();
     subCb('1');
 
     await vi.waitFor(() => {
@@ -1050,7 +1051,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = getQuestionCallback();
+    const topCb = getMenuQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('1');
 
@@ -1058,7 +1059,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const subCb = getQuestionCallback();
+    const subCb = getMenuQuestionCallback();
     subCb('1');
 
     await vi.waitFor(() => {
@@ -1106,7 +1107,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const topCb = getQuestionCallback();
+    const topCb = getMenuQuestionCallback();
     rlEmitter.question.mockClear();
     topCb('2');
 
@@ -1114,7 +1115,7 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
     await vi.waitFor(() => {
       expect(rlEmitter.question).toHaveBeenCalled();
     });
-    const valCb = getQuestionCallback();
+    const valCb = getMenuQuestionCallback();
     valCb('0.8');
 
     await vi.waitFor(() => {

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -837,7 +837,22 @@ describe('REPL /agent-options threshold normalization', () => {
       expect(rlEmitter.prompt).toHaveBeenCalled();
     });
 
-    typeLine('/agent-options threshold 80');
+    typeLine('/agent-options');
+
+    // First question: top-level menu — select "2" for threshold
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    rlEmitter.question.mockClear();
+    topCb('2');
+
+    // Second question: value prompt — enter "80"
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    valCb('80');
 
     await vi.waitFor(() => {
       expect(mockPrintInfo).toHaveBeenCalledWith(expect.stringContaining('0.8'));
@@ -858,7 +873,22 @@ describe('REPL /agent-options threshold normalization', () => {
       expect(rlEmitter.prompt).toHaveBeenCalled();
     });
 
-    typeLine('/agent-options threshold 0.75');
+    typeLine('/agent-options');
+
+    // First question: top-level menu — select "2" for threshold
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    rlEmitter.question.mockClear();
+    topCb('2');
+
+    // Second question: value prompt — enter "0.75"
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    valCb('0.75');
 
     await vi.waitFor(() => {
       expect(mockPrintInfo).toHaveBeenCalledWith(expect.stringContaining('0.75'));
@@ -879,7 +909,22 @@ describe('REPL /agent-options threshold normalization', () => {
       expect(rlEmitter.prompt).toHaveBeenCalled();
     });
 
-    typeLine('/agent-options threshold 150');
+    typeLine('/agent-options');
+
+    // First question: top-level menu — select "2" for threshold
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    rlEmitter.question.mockClear();
+    topCb('2');
+
+    // Second question: value prompt — enter "150"
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    valCb('150');
 
     await vi.waitFor(() => {
       expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('between 0 and 100'));
@@ -930,7 +975,22 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
       expect(rlEmitter.prompt).toHaveBeenCalled();
     });
 
-    typeLine('/agent-options auto-create on');
+    typeLine('/agent-options');
+
+    // First question: top-level menu — select "1" for auto-create
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    rlEmitter.question.mockClear();
+    topCb('1');
+
+    // Second question: sub-menu — select "1" for On
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const subCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    subCb('1');
 
     await vi.waitFor(() => {
       expect(mockSpecialistCreate).toHaveBeenCalledWith(
@@ -976,10 +1036,27 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
       expect(rlEmitter.prompt).toHaveBeenCalled();
     });
 
-    typeLine('/agent-options auto-create on');
+    typeLine('/agent-options');
+
+    // First question: top-level menu — select "1" for auto-create
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    rlEmitter.question.mockClear();
+    topCb('1');
+
+    // Second question: sub-menu — select "1" for On
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const subCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    subCb('1');
 
     await vi.waitFor(() => {
-      expect(mockPrintInfo).toHaveBeenCalledWith('Auto-create specialists: on');
+      expect(mockPrintInfo).toHaveBeenCalledWith(
+        expect.stringContaining('Auto-create specialists: on'),
+      );
     });
 
     expect(mockSpecialistCreate).not.toHaveBeenCalled();
@@ -1014,8 +1091,23 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
       expect(rlEmitter.prompt).toHaveBeenCalled();
     });
 
-    // Lower threshold from 0.9 to 0.8 — candidate at 0.85 should now qualify
-    typeLine('/agent-options threshold 0.8');
+    // Lower threshold from 0.9 to 0.8
+    typeLine('/agent-options');
+
+    // First question: top-level menu — select "2" for threshold
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const topCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    rlEmitter.question.mockClear();
+    topCb('2');
+
+    // Second question: value prompt — enter "0.8"
+    await vi.waitFor(() => {
+      expect(rlEmitter.question).toHaveBeenCalled();
+    });
+    const valCb = rlEmitter.question.mock.calls[0][2] as (answer: string) => void;
+    valCb('0.8');
 
     await vi.waitFor(() => {
       expect(mockSpecialistCreate).toHaveBeenCalledWith(

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -267,7 +267,8 @@ function getMenuQuestionCallback(): (answer: string) => void {
   const call = rlEmitter.question.mock.calls.at(-1);
   if (!call) throw new Error('Expected rl.question() to have been called');
   const callback = call[call.length - 1];
-  if (typeof callback !== 'function') throw new Error('Expected the last rl.question() argument to be a callback');
+  if (typeof callback !== 'function')
+    throw new Error('Expected the last rl.question() argument to be a callback');
   return callback as (answer: string) => void;
 }
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -90,6 +90,8 @@ import {
   selectFromMenu,
   promptValue,
   type MenuEntry,
+  type SelectResult,
+  type ValueResult,
 } from './menu.js';
 
 /** Promote a pending candidate to a full specialist, updating status and logging. */
@@ -276,24 +278,21 @@ export async function startRepl(
   let processing = false;
   let interrupted = false;
   let taskAbortController: AbortController | null = null;
-  let menuActive = false;
   let menuAbortController: AbortController | null = null;
 
   function createMenuSignal(): AbortSignal {
     menuAbortController = new AbortController();
-    menuActive = true;
     return menuAbortController.signal;
   }
 
   function clearMenuSignal(): void {
     menuAbortController = null;
-    menuActive = false;
   }
 
   process.stdin.on('keypress', (_str: string, key: any) => {
     if (!key) return;
 
-    if (key.name === 'escape' && menuActive && menuAbortController) {
+    if (key.name === 'escape' && menuAbortController) {
       menuAbortController.abort();
       return;
     }
@@ -1110,7 +1109,6 @@ export async function startRepl(
         const currentKey = getActiveThemeKey();
         const regularKeys = allKeys.filter((k) => k !== 'high-contrast' && k !== 'colorblind');
         const a11yKeys = allKeys.filter((k) => k === 'high-contrast' || k === 'colorblind');
-        const ordered = [...regularKeys, ...a11yKeys];
 
         const entries: MenuEntry[] = [
           ...regularKeys.map((k) => ({
@@ -1135,7 +1133,7 @@ export async function startRepl(
         try {
           const result = await selectFromMenu(rl, entries, {}, signal);
           if (!result.cancelled) {
-            const chosen = ordered[result.index];
+            const chosen = result.item.value as string;
             setTheme(chosen);
             config.theme = chosen;
             savePreferences({
@@ -1172,7 +1170,7 @@ export async function startRepl(
         console.log();
 
         const signal1 = createMenuSignal();
-        let optResult: Awaited<ReturnType<typeof selectFromMenu>>;
+        let optResult: SelectResult;
         try {
           optResult = await selectFromMenu(rl, menuEntries, { promptLabel: 'Select option' }, signal1);
         } finally {
@@ -1182,7 +1180,7 @@ export async function startRepl(
         if (!optResult.cancelled) {
           const [name, opt] = optEntries[optResult.index];
           const signal2 = createMenuSignal();
-          let valResult: Awaited<ReturnType<typeof promptValue>>;
+          let valResult: ValueResult;
           try {
             valResult = await promptValue(rl, { label: `New value for ${name}` }, signal2);
           } finally {
@@ -1415,7 +1413,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         console.log();
 
         const signal1 = createMenuSignal();
-        let topResult: Awaited<ReturnType<typeof selectFromMenu>>;
+        let topResult: SelectResult;
         try {
           topResult = await selectFromMenu(rl, topEntries, {}, signal1);
         } finally {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1172,7 +1172,12 @@ export async function startRepl(
         const signal1 = createMenuSignal();
         let optResult: SelectResult;
         try {
-          optResult = await selectFromMenu(rl, menuEntries, { promptLabel: 'Select option' }, signal1);
+          optResult = await selectFromMenu(
+            rl,
+            menuEntries,
+            { promptLabel: 'Select option' },
+            signal1,
+          );
         } finally {
           clearMenuSignal();
         }
@@ -1459,11 +1464,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
             // Sub-menu: threshold numeric input
             const signal2 = createMenuSignal();
             try {
-              const val = await promptValue(
-                rl,
-                { label: 'New threshold (0-100)' },
-                signal2,
-              );
+              const val = await promptValue(rl, { label: 'New threshold (0-100)' }, signal2);
               if (!val.cancelled) {
                 const parsed = parseFloat(val.raw);
                 if (isNaN(parsed) || parsed < 0 || parsed > 100) {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -85,6 +85,12 @@ import {
   isVisionCapableModel,
   type ImageAttachment,
 } from './image.js';
+import {
+  printMenuList,
+  selectFromMenu,
+  promptValue,
+  type MenuEntry,
+} from './menu.js';
 
 /** Promote a pending candidate to a full specialist, updating status and logging. */
 function promoteCandidate(
@@ -175,8 +181,8 @@ export async function startRepl(
     { command: '/specialists', description: 'List specialist agents' },
     { command: '/create-specialist', description: 'Create a specialist with guided AI assistance' },
     { command: '/candidates', description: 'Review specialist suggestions' },
-    { command: '/critic', description: 'Toggle critic mode for response verification' },
-    { command: '/agent-options', description: 'Configure auto-creation for specialist agents' },
+    { command: '/critic', description: 'Toggle critic mode' },
+    { command: '/agent-options', description: 'Configure specialist auto-creation settings' },
     { command: '/image', description: 'Attach an image: /image <path> [prompt]' },
     { command: '/debug', description: 'Print diagnostic report for troubleshooting' },
     { command: '/exit', description: 'Quit Bernard' },
@@ -270,9 +276,27 @@ export async function startRepl(
   let processing = false;
   let interrupted = false;
   let taskAbortController: AbortController | null = null;
+  let menuActive = false;
+  let menuAbortController: AbortController | null = null;
+
+  function createMenuSignal(): AbortSignal {
+    menuAbortController = new AbortController();
+    menuActive = true;
+    return menuAbortController.signal;
+  }
+
+  function clearMenuSignal(): void {
+    menuAbortController = null;
+    menuActive = false;
+  }
 
   process.stdin.on('keypress', (_str: string, key: any) => {
     if (!key) return;
+
+    if (key.name === 'escape' && menuActive && menuAbortController) {
+      menuAbortController.abort();
+      return;
+    }
 
     if (key.name === 'escape' && processing) {
       if (taskAbortController) {
@@ -1017,16 +1041,16 @@ export async function startRepl(
           void prompt();
           return;
         }
+        const entries: MenuEntry[] = available.map((p) => ({ label: p }));
         printInfo(`\n  Current: ${config.provider} (${config.model})\n`);
         printInfo('  Available providers:');
-        for (let i = 0; i < available.length; i++) {
-          printInfo(`    ${i + 1}. ${available[i]}`);
-        }
+        printMenuList(entries);
         console.log();
-        rl.question(`  Select [1-${available.length}]: `, (answer) => {
-          const num = parseInt(answer.trim(), 10);
-          if (num >= 1 && num <= available.length) {
-            config.provider = available[num - 1];
+        const signal = createMenuSignal();
+        try {
+          const result = await selectFromMenu(rl, entries, {}, signal);
+          if (!result.cancelled) {
+            config.provider = available[result.index];
             config.model = getDefaultModel(config.provider);
             savePreferences({
               provider: config.provider,
@@ -1037,12 +1061,12 @@ export async function startRepl(
               theme: config.theme,
             });
             printInfo(`  Switched to ${config.provider} (${config.model})`);
-          } else {
-            printInfo('  Cancelled.');
           }
-          console.log();
-          void prompt();
-        });
+        } finally {
+          clearMenuSignal();
+        }
+        console.log();
+        void prompt();
         return;
       }
 
@@ -1053,16 +1077,16 @@ export async function startRepl(
           void prompt();
           return;
         }
+        const entries: MenuEntry[] = models.map((m) => ({ label: m }));
         printInfo(`\n  Current: ${config.provider} / ${config.model}\n`);
         printInfo('  Available models:');
-        for (let i = 0; i < models.length; i++) {
-          printInfo(`    ${i + 1}. ${models[i]}`);
-        }
+        printMenuList(entries);
         console.log();
-        rl.question(`  Select [1-${models.length}]: `, (answer) => {
-          const num = parseInt(answer.trim(), 10);
-          if (num >= 1 && num <= models.length) {
-            config.model = models[num - 1];
+        const signal = createMenuSignal();
+        try {
+          const result = await selectFromMenu(rl, entries, {}, signal);
+          if (!result.cancelled) {
+            config.model = models[result.index];
             savePreferences({
               provider: config.provider,
               model: config.model,
@@ -1072,12 +1096,12 @@ export async function startRepl(
               theme: config.theme,
             });
             printInfo(`  Switched to ${config.model}`);
-          } else {
-            printInfo('  Cancelled.');
           }
-          console.log();
-          void prompt();
-        });
+        } finally {
+          clearMenuSignal();
+        }
+        console.log();
+        void prompt();
         return;
       }
 
@@ -1086,28 +1110,32 @@ export async function startRepl(
         const currentKey = getActiveThemeKey();
         const regularKeys = allKeys.filter((k) => k !== 'high-contrast' && k !== 'colorblind');
         const a11yKeys = allKeys.filter((k) => k === 'high-contrast' || k === 'colorblind');
+        const ordered = [...regularKeys, ...a11yKeys];
+
+        const entries: MenuEntry[] = [
+          ...regularKeys.map((k) => ({
+            label: THEMES[k].name,
+            active: k === currentKey,
+            value: k,
+          })),
+          { type: 'section' as const, title: 'Accessibility:' },
+          ...a11yKeys.map((k) => ({
+            label: THEMES[k].name,
+            active: k === currentKey,
+            value: k,
+          })),
+        ];
 
         printInfo(`\n  Current theme: ${THEMES[currentKey].name}\n`);
         printInfo('  Themes:');
-        let idx = 1;
-        for (const k of regularKeys) {
-          const marker = k === currentKey ? ' (active)' : '';
-          printInfo(`    ${idx}. ${THEMES[k].name}${marker}`);
-          idx++;
-        }
-        printInfo('\n  Accessibility:');
-        for (const k of a11yKeys) {
-          const marker = k === currentKey ? ' (active)' : '';
-          printInfo(`    ${idx}. ${THEMES[k].name}${marker}`);
-          idx++;
-        }
+        printMenuList(entries);
         console.log();
 
-        const ordered = [...regularKeys, ...a11yKeys];
-        rl.question(`  Select [1-${ordered.length}]: `, (answer) => {
-          const num = parseInt(answer.trim(), 10);
-          if (num >= 1 && num <= ordered.length) {
-            const chosen = ordered[num - 1];
+        const signal = createMenuSignal();
+        try {
+          const result = await selectFromMenu(rl, entries, {}, signal);
+          if (!result.cancelled) {
+            const chosen = ordered[result.index];
             setTheme(chosen);
             config.theme = chosen;
             savePreferences({
@@ -1119,62 +1147,72 @@ export async function startRepl(
               theme: chosen,
             });
             printInfo(`  Switched to ${THEMES[chosen].name} theme.`);
-          } else {
-            printInfo('  Cancelled.');
           }
-          console.log();
-          void prompt();
-        });
+        } finally {
+          clearMenuSignal();
+        }
+        console.log();
+        void prompt();
         return;
       }
 
       if (trimmed === '/options') {
-        const entries = Object.entries(OPTIONS_REGISTRY);
-        printInfo('\n  Options:');
-        for (let i = 0; i < entries.length; i++) {
-          const [name, opt] = entries[i];
+        const optEntries = Object.entries(OPTIONS_REGISTRY);
+        const menuEntries: MenuEntry[] = optEntries.map(([name, opt]) => {
           const current = config[opt.configKey];
-          const isDefault = current === opt.default;
-          const label = isDefault ? '(default)' : '(custom)';
-          printInfo(`    ${i + 1}. ${name} = ${current} ${label}`);
-          printInfo(`       ${opt.description}`);
+          const tag = current === opt.default ? '(default)' : '(custom)';
+          return {
+            label: name,
+            annotation: `= ${current} ${tag}`,
+            description: opt.description,
+          };
+        });
+        printInfo('\n  Options:');
+        printMenuList(menuEntries);
+        console.log();
+
+        const signal1 = createMenuSignal();
+        let optResult: Awaited<ReturnType<typeof selectFromMenu>>;
+        try {
+          optResult = await selectFromMenu(rl, menuEntries, { promptLabel: 'Select option' }, signal1);
+        } finally {
+          clearMenuSignal();
+        }
+
+        if (!optResult.cancelled) {
+          const [name, opt] = optEntries[optResult.index];
+          const signal2 = createMenuSignal();
+          let valResult: Awaited<ReturnType<typeof promptValue>>;
+          try {
+            valResult = await promptValue(rl, { label: `New value for ${name}` }, signal2);
+          } finally {
+            clearMenuSignal();
+          }
+
+          if (!valResult.cancelled) {
+            const val = parseInt(valResult.raw, 10);
+            const minVal = opt.default === 0 ? 0 : 1;
+            if (!isNaN(val) && val >= minVal) {
+              saveOption(name, val);
+              config[opt.configKey] = val;
+              printInfo(`  ${name} set to ${val}`);
+              if (name === 'token-window') {
+                const modelWindow = getContextWindow(config.model);
+                if (val > modelWindow) {
+                  printInfo(
+                    `  Warning: ${val} exceeds ${config.model}'s context window (${modelWindow})`,
+                  );
+                }
+              }
+            } else {
+              printError(
+                `  Invalid value. Must be ${minVal === 0 ? 'a non-negative integer' : 'a positive integer'}.`,
+              );
+            }
+          }
         }
         console.log();
-        rl.question(`  Select option [1-${entries.length}] (Enter to cancel): `, (answer) => {
-          const num = parseInt(answer.trim(), 10);
-          if (num >= 1 && num <= entries.length) {
-            const [name, opt] = entries[num - 1];
-            rl.question(`  New value for ${name} (Enter to cancel): `, (valAnswer) => {
-              const val = parseInt(valAnswer.trim(), 10);
-              const minVal = opt.default === 0 ? 0 : 1;
-              if (!isNaN(val) && val >= minVal) {
-                saveOption(name, val);
-                config[opt.configKey] = val;
-                printInfo(`  ${name} set to ${val}`);
-                if (name === 'token-window') {
-                  const modelWindow = getContextWindow(config.model);
-                  if (val > modelWindow) {
-                    printInfo(
-                      `  Warning: ${val} exceeds ${config.model}'s context window (${modelWindow})`,
-                    );
-                  }
-                }
-              } else if (valAnswer.trim() === '') {
-                printInfo('  Cancelled.');
-              } else {
-                printError(
-                  `  Invalid value. Must be ${minVal === 0 ? 'a non-negative integer' : 'a positive integer'}.`,
-                );
-              }
-              console.log();
-              void prompt();
-            });
-          } else {
-            printInfo('  Cancelled.');
-            console.log();
-            void prompt();
-          }
-        });
+        void prompt();
         return;
       }
 
@@ -1325,89 +1363,140 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         return;
       }
 
-      if (trimmed === '/critic' || trimmed.startsWith('/critic ')) {
-        const arg = trimmed.slice('/critic'.length).trim().toLowerCase();
-        if (arg === 'on') {
-          config.criticMode = true;
-          savePreferences({
-            provider: config.provider,
-            model: config.model,
-            maxTokens: config.maxTokens,
-            shellTimeout: config.shellTimeout,
-            tokenWindow: config.tokenWindow,
-            theme: config.theme,
-            criticMode: true,
-          });
-          printInfo('[CRITIC:ON] Responses will be planned and verified.');
-        } else if (arg === 'off') {
-          config.criticMode = false;
-          savePreferences({
-            provider: config.provider,
-            model: config.model,
-            maxTokens: config.maxTokens,
-            shellTimeout: config.shellTimeout,
-            tokenWindow: config.tokenWindow,
-            theme: config.theme,
-            criticMode: false,
-          });
-          printInfo('[CRITIC:OFF] Critic mode disabled.');
-        } else {
-          printInfo(`Critic mode: ${config.criticMode ? 'ON' : 'OFF'}. Usage: /critic on|off`);
+      if (trimmed === '/critic') {
+        const entries: MenuEntry[] = [
+          { label: 'On', active: config.criticMode === true },
+          { label: 'Off', active: config.criticMode === false },
+        ];
+        printInfo(`\n  Critic mode: ${config.criticMode ? 'ON' : 'OFF'}\n`);
+        printMenuList(entries);
+        console.log();
+        const signal = createMenuSignal();
+        try {
+          const result = await selectFromMenu(rl, entries, {}, signal);
+          if (!result.cancelled) {
+            config.criticMode = result.index === 0;
+            savePreferences({
+              provider: config.provider,
+              model: config.model,
+              maxTokens: config.maxTokens,
+              shellTimeout: config.shellTimeout,
+              tokenWindow: config.tokenWindow,
+              theme: config.theme,
+              criticMode: config.criticMode,
+            });
+            printInfo(
+              config.criticMode
+                ? '  [CRITIC:ON] Responses will be planned and verified.'
+                : '  [CRITIC:OFF] Critic mode disabled.',
+            );
+          }
+        } finally {
+          clearMenuSignal();
         }
+        console.log();
         void prompt();
         return;
       }
 
-      if (trimmed === '/agent-options' || trimmed.startsWith('/agent-options ')) {
-        const args = trimmed.slice('/agent-options'.length).trim();
-        if (!args) {
-          // Display current settings
-          printInfo(`Auto-create specialists: ${config.autoCreateSpecialists ? 'on' : 'off'}`);
-          printInfo(
-            `Auto-create threshold: ${config.autoCreateThreshold} (${Math.round(config.autoCreateThreshold * 100)}%)`,
-          );
-        } else if (args === 'auto-create on') {
-          config.autoCreateSpecialists = true;
-          savePreferences({
-            ...loadPreferences(),
-            autoCreateSpecialists: true,
-            provider: config.provider,
-            model: config.model,
-          });
-          printInfo('Auto-create specialists: on');
-          promotePendingCandidates(candidateStore, specialistStore, config.autoCreateThreshold);
-        } else if (args === 'auto-create off') {
-          config.autoCreateSpecialists = false;
-          savePreferences({
-            ...loadPreferences(),
-            autoCreateSpecialists: false,
-            provider: config.provider,
-            model: config.model,
-          });
-          printInfo('Auto-create specialists: off');
-        } else if (args.startsWith('threshold ')) {
-          const val = parseFloat(args.slice('threshold '.length));
-          if (isNaN(val) || val < 0 || val > 100) {
-            printError('Threshold must be a number between 0 and 100 (e.g. 0.8 or 80)');
+      if (trimmed === '/agent-options') {
+        const topEntries: MenuEntry[] = [
+          {
+            label: 'Auto-create specialists',
+            annotation: `= ${config.autoCreateSpecialists ? 'on' : 'off'}`,
+          },
+          {
+            label: 'Auto-create threshold',
+            annotation: `= ${config.autoCreateThreshold} (${Math.round(config.autoCreateThreshold * 100)}%)`,
+          },
+        ];
+        printInfo('\n  Agent Options:\n');
+        printMenuList(topEntries);
+        console.log();
+
+        const signal1 = createMenuSignal();
+        let topResult: Awaited<ReturnType<typeof selectFromMenu>>;
+        try {
+          topResult = await selectFromMenu(rl, topEntries, {}, signal1);
+        } finally {
+          clearMenuSignal();
+        }
+
+        if (!topResult.cancelled) {
+          if (topResult.index === 0) {
+            // Sub-menu: on/off for auto-create
+            const subEntries: MenuEntry[] = [
+              { label: 'On', active: config.autoCreateSpecialists },
+              { label: 'Off', active: !config.autoCreateSpecialists },
+            ];
+            printInfo('\n  Auto-create specialists:\n');
+            printMenuList(subEntries);
+            console.log();
+            const signal2 = createMenuSignal();
+            try {
+              const sub = await selectFromMenu(rl, subEntries, {}, signal2);
+              if (!sub.cancelled) {
+                config.autoCreateSpecialists = sub.index === 0;
+                savePreferences({
+                  ...loadPreferences(),
+                  autoCreateSpecialists: config.autoCreateSpecialists,
+                  provider: config.provider,
+                  model: config.model,
+                });
+                printInfo(
+                  `  Auto-create specialists: ${config.autoCreateSpecialists ? 'on' : 'off'}`,
+                );
+                if (config.autoCreateSpecialists) {
+                  promotePendingCandidates(
+                    candidateStore,
+                    specialistStore,
+                    config.autoCreateThreshold,
+                  );
+                }
+              }
+            } finally {
+              clearMenuSignal();
+            }
           } else {
-            const normalized = normalizeThreshold(val);
-            config.autoCreateThreshold = normalized;
-            savePreferences({
-              ...loadPreferences(),
-              autoCreateThreshold: normalized,
-              provider: config.provider,
-              model: config.model,
-            });
-            printInfo(`Auto-create threshold: ${normalized} (${Math.round(normalized * 100)}%)`);
-            if (config.autoCreateSpecialists) {
-              promotePendingCandidates(candidateStore, specialistStore, config.autoCreateThreshold);
+            // Sub-menu: threshold numeric input
+            const signal2 = createMenuSignal();
+            try {
+              const val = await promptValue(
+                rl,
+                { label: 'New threshold (0-100)' },
+                signal2,
+              );
+              if (!val.cancelled) {
+                const parsed = parseFloat(val.raw);
+                if (isNaN(parsed) || parsed < 0 || parsed > 100) {
+                  printError('Threshold must be a number between 0 and 100 (e.g. 0.8 or 80)');
+                } else {
+                  const normalized = normalizeThreshold(parsed);
+                  config.autoCreateThreshold = normalized;
+                  savePreferences({
+                    ...loadPreferences(),
+                    autoCreateThreshold: normalized,
+                    provider: config.provider,
+                    model: config.model,
+                  });
+                  printInfo(
+                    `  Auto-create threshold: ${normalized} (${Math.round(normalized * 100)}%)`,
+                  );
+                  if (config.autoCreateSpecialists) {
+                    promotePendingCandidates(
+                      candidateStore,
+                      specialistStore,
+                      config.autoCreateThreshold,
+                    );
+                  }
+                }
+              }
+            } finally {
+              clearMenuSignal();
             }
           }
-        } else {
-          printError(
-            'Usage: /agent-options auto-create on|off  OR  /agent-options threshold <0-100>',
-          );
         }
+        console.log();
         void prompt();
         return;
       }


### PR DESCRIPTION
This pull request introduces a reusable menu UI system for the terminal, refactors several command-line interactions to use this menu, and updates documentation and tests accordingly. The main goal is to provide a more interactive, user-friendly experience for commands that previously required manual text input, such as toggling critic mode or configuring agent options. Additionally, command descriptions and help output are updated for clarity and consistency.

**Major improvements include:**

### New Menu UI System

- Added `src/menu.ts`, which provides a reusable, accessible numbered-list selection UI for the terminal, including support for Escape/Enter-to-cancel and value prompts. This module exposes functions like `printMenuList`, `selectFromMenu`, and `promptValue`, and defines types for menu entries and results.

### Refactored Interactive Commands

- Refactored `/agent-options`, `/critic`, provider/model selection, and similar commands to use the new menu UI instead of manual argument parsing or raw input. This includes support for interactive configuration of specialist auto-creation and threshold, as well as toggling critic mode. [[1]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128R1043-R1052) [[2]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128L1040-L1045) [[3]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128R1079-R1088) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L495-R495) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L512-R509)
- Updated REPL tests to simulate and validate the new interactive menu flows, ensuring correct behavior for menu navigation and value entry. [[1]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L840-R863) [[2]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L861-R899) [[3]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L882-R935) [[4]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L933-R1001) [[5]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L979-R1067) [[6]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L1017-R1118) [[7]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3R262-R269)

### Documentation and Help Updates

- Updated documentation (`README.md`, `CLAUDE.md`) to describe the new menu-driven workflows for `/critic` and `/agent-options`, replacing older argument-based examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L251-R252) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L495-R495) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L512-R509) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R856) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R20)
- Updated command descriptions and help output for clarity and to match the new interaction style. [[1]](diffhunk://#diff-d16f040f75d9c87c24621868e0fbf670d915c53bd8fb1da21e4c08e66d670fc3L394-R401) [[2]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128L178-R187)

---

**References:**
- Menu UI system:
- Refactored interactive commands: [[1]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128R1043-R1052) [[2]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128L1040-L1045) [[3]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128R1079-R1088) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L495-R495) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L512-R509)
- REPL test updates: [[1]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L840-R863) [[2]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L861-R899) [[3]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L882-R935) [[4]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L933-R1001) [[5]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L979-R1067) [[6]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3L1017-R1118) [[7]](diffhunk://#diff-68f913cea40c3d147b72b1113acff803c0cbcc5c509a6e3245288b04962af0e3R262-R269)
- Documentation/help updates: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L251-R252) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L495-R495) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L512-R509) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R856) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R20) [[6]](diffhunk://#diff-d16f040f75d9c87c24621868e0fbf670d915c53bd8fb1da21e4c08e66d670fc3L394-R401) [[7]](diffhunk://#diff-15ae128780ca5d79a5f47ddc159435eb8fcfebc015949fdeba41fc66ecaf5128L178-R187)

closes #102