### PR TITLE
Adds tool details toggle to hide function call outputs

### DIFF
--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -32,8 +32,11 @@ vi.mock('./output.js', () => ({
   printToolResult: vi.fn(),
   printInfo: vi.fn(),
   printWarning: vi.fn(),
+  printCriticRetry: vi.fn(),
   startSpinner: vi.fn(),
   stopSpinner: vi.fn(),
+  buildSpinnerMessage: vi.fn(() => ''),
+  clearPinnedRegion: vi.fn(),
 }));
 
 vi.mock('./context.js', () => ({

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,6 +12,7 @@ import {
   printCriticRetry,
   startSpinner,
   buildSpinnerMessage,
+  clearPinnedRegion,
   type SpinnerStats,
 } from './output.js';
 import { debugLog } from './logger.js';
@@ -497,6 +498,7 @@ export class Agent {
   async processInput(userInput: string, images?: ImageAttachment[]): Promise<void> {
     this.lastStepLimitHit = false;
     this.planStore.clear();
+    clearPinnedRegion('plan');
 
     if (images && images.length > 0) {
       const contentParts: UserContent = [

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -687,11 +687,9 @@ export class Agent {
               }
             }
             for (const tc of toolCalls) {
-              debugLog(`onStepFinish:toolCall:${tc.toolName}`, tc.args);
               printToolCall(tc.toolName, tc.args as Record<string, unknown>);
             }
             for (const tr of toolResults) {
-              debugLog(`onStepFinish:toolResult:${tr.toolName}`, tr.result);
               printToolResult(tr.toolName, tr.result);
             }
             if (text) {
@@ -907,6 +905,7 @@ export class Agent {
     } finally {
       this.abortController = null;
       this.spinnerStats = null;
+      clearPinnedRegion('plan');
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export interface BernardConfig {
   criticMode: boolean;
   /** Whether coordinator (ReAct) mode is active for iterative reasoning with subagent delegation. */
   reactMode: boolean;
-  /** Whether full tool result output is shown in the terminal. Tool call lines are always shown. */
+  /** Whether tool-call arguments and full tool result output are shown in the terminal. Tool names and call lines are always shown. */
   toolDetails: boolean;
   /** Whether to auto-create specialists above the confidence threshold. */
   autoCreateSpecialists: boolean;
@@ -138,6 +138,7 @@ export function savePreferences(prefs: {
   if (prefs.tokenWindow !== undefined) data.tokenWindow = prefs.tokenWindow;
   if (prefs.maxSteps !== undefined) data.maxSteps = prefs.maxSteps;
   if (prefs.theme !== undefined) data.theme = prefs.theme;
+  if (prefs.autoUpdate !== undefined) data.autoUpdate = prefs.autoUpdate;
   if (prefs.criticMode !== undefined) data.criticMode = prefs.criticMode;
   if (prefs.reactMode !== undefined) data.reactMode = prefs.reactMode;
   if (prefs.toolDetails !== undefined) data.toolDetails = prefs.toolDetails;
@@ -153,19 +154,11 @@ export function savePreferences(prefs: {
     /* ignore */
   }
 
-  if (prefs.autoUpdate !== undefined) {
-    data.autoUpdate = prefs.autoUpdate;
-  } else if (existing && typeof existing.autoUpdate === 'boolean') {
-    data.autoUpdate = existing.autoUpdate;
-  }
-  if (prefs.criticMode === undefined && existing && typeof existing.criticMode === 'boolean') {
-    data.criticMode = existing.criticMode;
-  }
-  if (prefs.reactMode === undefined && existing && typeof existing.reactMode === 'boolean') {
-    data.reactMode = existing.reactMode;
-  }
-  if (prefs.toolDetails === undefined && existing && typeof existing.toolDetails === 'boolean') {
-    data.toolDetails = existing.toolDetails;
+  const booleanKeys = ['autoUpdate', 'criticMode', 'reactMode', 'toolDetails'] as const;
+  for (const k of booleanKeys) {
+    if (prefs[k] === undefined && existing && typeof existing[k] === 'boolean') {
+      data[k] = existing[k];
+    }
   }
 
   // Preserve numeric options from existing prefs when callers don't pass them.

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,8 @@ export interface BernardConfig {
   criticMode: boolean;
   /** Whether coordinator (ReAct) mode is active for iterative reasoning with subagent delegation. */
   reactMode: boolean;
+  /** Whether full tool result output is shown in the terminal. Tool call lines are always shown. */
+  toolDetails: boolean;
   /** Whether to auto-create specialists above the confidence threshold. */
   autoCreateSpecialists: boolean;
   /** Confidence threshold for auto-creating specialists (0-1). */
@@ -122,6 +124,7 @@ export function savePreferences(prefs: {
   autoUpdate?: boolean;
   criticMode?: boolean;
   reactMode?: boolean;
+  toolDetails?: boolean;
   autoCreateSpecialists?: boolean;
   autoCreateThreshold?: number;
 }): void {
@@ -137,6 +140,7 @@ export function savePreferences(prefs: {
   if (prefs.theme !== undefined) data.theme = prefs.theme;
   if (prefs.criticMode !== undefined) data.criticMode = prefs.criticMode;
   if (prefs.reactMode !== undefined) data.reactMode = prefs.reactMode;
+  if (prefs.toolDetails !== undefined) data.toolDetails = prefs.toolDetails;
   if (prefs.autoCreateSpecialists !== undefined)
     data.autoCreateSpecialists = prefs.autoCreateSpecialists;
   if (prefs.autoCreateThreshold !== undefined) data.autoCreateThreshold = prefs.autoCreateThreshold;
@@ -159,6 +163,9 @@ export function savePreferences(prefs: {
   }
   if (prefs.reactMode === undefined && existing && typeof existing.reactMode === 'boolean') {
     data.reactMode = existing.reactMode;
+  }
+  if (prefs.toolDetails === undefined && existing && typeof existing.toolDetails === 'boolean') {
+    data.toolDetails = existing.toolDetails;
   }
 
   // Preserve numeric options from existing prefs when callers don't pass them.
@@ -208,6 +215,7 @@ export function loadPreferences(): {
   autoUpdate?: boolean;
   criticMode?: boolean;
   reactMode?: boolean;
+  toolDetails?: boolean;
   autoCreateSpecialists?: boolean;
   autoCreateThreshold?: number;
 } {
@@ -225,6 +233,7 @@ export function loadPreferences(): {
       autoUpdate: typeof parsed.autoUpdate === 'boolean' ? parsed.autoUpdate : undefined,
       criticMode: typeof parsed.criticMode === 'boolean' ? parsed.criticMode : undefined,
       reactMode: typeof parsed.reactMode === 'boolean' ? parsed.reactMode : undefined,
+      toolDetails: typeof parsed.toolDetails === 'boolean' ? parsed.toolDetails : undefined,
       autoCreateSpecialists:
         typeof parsed.autoCreateSpecialists === 'boolean'
           ? parsed.autoCreateSpecialists
@@ -525,6 +534,10 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     prefs.reactMode ??
     (process.env.BERNARD_REACT_MODE === 'true' || process.env.BERNARD_REACT_MODE === '1');
 
+  const toolDetails =
+    prefs.toolDetails ??
+    (process.env.BERNARD_TOOL_DETAILS === 'true' || process.env.BERNARD_TOOL_DETAILS === '1');
+
   const autoCreateSpecialists =
     prefs.autoCreateSpecialists ??
     (process.env.BERNARD_AUTO_CREATE_SPECIALISTS === 'true' ||
@@ -556,6 +569,7 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     theme,
     criticMode,
     reactMode,
+    toolDetails,
     autoCreateSpecialists,
     autoCreateThreshold,
     correctionEnabled,

--- a/src/critic.test.ts
+++ b/src/critic.test.ts
@@ -40,6 +40,9 @@ vi.mock('./output.js', () => ({
   }),
   startSpinner: vi.fn(),
   stopSpinner: vi.fn(),
+  buildSpinnerMessage: vi.fn(() => ''),
+  printWarning: vi.fn(),
+  clearPinnedRegion: vi.fn(),
 }));
 
 vi.mock('./context.js', () => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ program
   .option('-m, --model <model>', 'Model name')
   .option('-r, --resume', 'Resume the previous conversation')
   .option('--alert <id>', 'Open with cron alert context')
+  .option('--tool-details', 'Show full tool call args and result output (default: hidden)')
   .action(async (opts) => {
     try {
       await runFirstTimeSetup();
@@ -51,6 +52,8 @@ program
         provider: opts.provider,
         model: opts.model,
       });
+
+      if (opts.toolDetails) config.toolDetails = true;
 
       if (!setTheme(config.theme)) {
         config.theme = DEFAULT_THEME;

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -687,6 +687,30 @@ describe('output', () => {
   });
 
   describe('printPlan', () => {
+    // printPlan renders through the pinned-region system, which writes to
+    // process.stdout.write in TTY mode and no-ops otherwise. Force TTY so the
+    // writes are observable via stdoutWriteSpy.
+    let originalIsTTY: boolean | undefined;
+    beforeEach(() => {
+      originalIsTTY = process.stdout.isTTY;
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      stdoutWriteSpy.mockClear();
+    });
+    afterEach(() => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    });
+
+    function renderedLines(): string[] {
+      return stdoutWriteSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((s) => !s.startsWith('\x1b') && s !== '\r\x1b[J')
+        .flatMap((s) => s.split('\n'))
+        .filter((s) => s.length > 0);
+    }
+
     it('prints a header line and one line per step with the right icons and notes', () => {
       const steps: Step[] = [
         { id: 1, description: 'gather data', status: 'done', note: 'got it' },
@@ -694,7 +718,7 @@ describe('output', () => {
         { id: 3, description: 'report', status: 'pending' },
       ];
       printPlan(steps);
-      const lines = logSpy.mock.calls.map((c) => String(c[0]));
+      const lines = renderedLines();
       expect(lines[0]).toContain('Plan:');
       expect(lines[1]).toContain('\u2713');
       expect(lines[1]).toContain('1. gather data');
@@ -712,7 +736,7 @@ describe('output', () => {
         { id: 2, description: 'unachievable', status: 'error', note: 'no permission' },
       ];
       printPlan(steps);
-      const lines = logSpy.mock.calls.map((c) => String(c[0]));
+      const lines = renderedLines();
       expect(lines[1]).toContain('\u2298');
       expect(lines[1]).toContain('user pivoted');
       expect(lines[2]).toContain('\u2717');

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -704,10 +704,14 @@ describe('output', () => {
     });
 
     function renderedLines(): string[] {
+      // Pinned-region cursor control: CSI ? A (move-up-N) and `\r\x1b[J` (erase-to-end).
+      const pinnedControl = /^(?:\x1b\[\d*A|\r\x1b\[J)+$/;
+      const ansiColor = /\x1b\[[0-9;]*m/g;
       return stdoutWriteSpy.mock.calls
         .map((c) => String(c[0]))
-        .filter((s) => !s.startsWith('\x1b') && s !== '\r\x1b[J')
+        .filter((s) => !pinnedControl.test(s))
         .flatMap((s) => s.split('\n'))
+        .map((s) => s.replace(ansiColor, ''))
         .filter((s) => s.length > 0);
     }
 

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -22,6 +22,7 @@ import {
   startSpinner,
   stopSpinner,
   buildSpinnerMessage,
+  setToolDetailsVisible,
   type SpinnerStats,
 } from './output.js';
 import type { Step } from './plan-store.js';
@@ -37,6 +38,11 @@ describe('output', () => {
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stopSpinner(); // ensure clean state
     stdoutWriteSpy.mockClear();
+    setToolDetailsVisible(true);
+  });
+
+  afterEach(() => {
+    setToolDetailsVisible(false);
   });
 
   describe('printAssistantText', () => {
@@ -68,6 +74,22 @@ describe('output', () => {
       expect(output).toContain('memory');
       expect(output).toContain('"action"');
     });
+
+    it('omits args when tool details are hidden', () => {
+      setToolDetailsVisible(false);
+      printToolCall('shell', { command: 'ls -la' });
+      expect(logSpy).toHaveBeenCalled();
+      const output = logSpy.mock.calls[0][0];
+      expect(output).toContain('shell');
+      expect(output).not.toContain('ls -la');
+    });
+
+    it('prints nothing for silent tools (plan, think, evaluate)', () => {
+      printToolCall('plan', { action: 'view' });
+      printToolCall('think', { thought: 'x' });
+      printToolCall('evaluate', { evaluation: 'y' });
+      expect(logSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('printToolResult', () => {
@@ -98,6 +120,12 @@ describe('output', () => {
       expect(logSpy).toHaveBeenCalled();
       const output = logSpy.mock.calls[0][0];
       expect(output).toContain('truncated');
+    });
+
+    it('prints nothing when tool details are hidden', () => {
+      setToolDetailsVisible(false);
+      printToolResult('shell', 'file contents here');
+      expect(logSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -693,10 +721,10 @@ describe('output', () => {
   });
 
   describe('printThought', () => {
-    it('prints the thought with a thought-bubble marker', () => {
+    it('prints the thought text', () => {
       printThought('Next I will check deps.');
       const output = String(logSpy.mock.calls[0][0]);
-      expect(output).toContain('\uD83D\uDCAD');
+      expect(output).not.toContain('\uD83D\uDCAD');
       expect(output).toContain('Next I will check deps.');
     });
   });

--- a/src/output.ts
+++ b/src/output.ts
@@ -6,6 +6,110 @@ import type { Step, StepStatus } from './plan-store.js';
 const MAX_TOOL_OUTPUT_LENGTH = 2000;
 const MAX_REPLAY_LENGTH = 200;
 
+let toolDetailsVisible = false;
+
+/** Enables or disables printing of tool result bodies. Calls are always shown. */
+export function setToolDetailsVisible(enabled: boolean): void {
+  toolDetailsVisible = enabled;
+}
+
+/** Returns whether tool result bodies are currently printed to the terminal. */
+export function getToolDetailsVisible(): boolean {
+  return toolDetailsVisible;
+}
+
+// Tools whose call and result lines are suppressed from the chat flow.
+// Their output is rendered through dedicated channels (printPlan, printThought,
+// printEvaluation), so the generic ▶ toolName / result body would be duplicate
+// noise. Extend this set to mute additional tools.
+const silentTools = new Set<string>(['plan', 'think', 'evaluate']);
+
+/** Adds or removes a tool from the silent list. */
+export function setSilentTool(toolName: string, silent: boolean): void {
+  if (silent) silentTools.add(toolName);
+  else silentTools.delete(toolName);
+}
+
+/** Returns true when the given tool's call/result lines are suppressed. */
+export function isSilentTool(toolName: string): boolean {
+  return silentTools.has(toolName);
+}
+
+// ─── Pinned regions ──────────────────────────────────────────────────────────
+// A generic persistent-footer mechanism: each region is a block of lines
+// keyed by a string id that stays anchored just above the prompt (or above
+// the spinner while the agent is thinking). Adding or updating a region
+// repaints it in place via ANSI cursor control; chat-flow prints flow past
+// it by erasing the block, printing, then re-rendering.
+//
+// Fall back to plain console.log when stdout is not a TTY so output remains
+// intact under pipes / in tests.
+
+const pinnedRegions = new Map<string, string[]>();
+let pinnedLineCount = 0;
+
+function pinSupported(): boolean {
+  return !!process.stdout.isTTY;
+}
+
+function erasePinnedRegions(): void {
+  if (!pinSupported() || pinnedLineCount === 0) return;
+  process.stdout.write(`\x1b[${pinnedLineCount}A`);
+  process.stdout.write(`\r\x1b[J`);
+  pinnedLineCount = 0;
+}
+
+function renderPinnedRegions(): void {
+  if (pinnedRegions.size === 0) return;
+  let count = 0;
+  for (const lines of pinnedRegions.values()) {
+    for (const line of lines) {
+      if (pinSupported()) {
+        process.stdout.write(line + '\n');
+      } else {
+        console.log(line);
+      }
+      count++;
+    }
+  }
+  if (pinSupported()) pinnedLineCount = count;
+}
+
+/**
+ * Pins or updates a named region of lines above the prompt.
+ * Passing an empty array removes the region.
+ */
+export function setPinnedRegion(id: string, lines: string[]): void {
+  erasePinnedRegions();
+  if (lines.length === 0) {
+    pinnedRegions.delete(id);
+  } else {
+    pinnedRegions.set(id, lines);
+  }
+  renderPinnedRegions();
+}
+
+/** Removes a named pinned region. */
+export function clearPinnedRegion(id: string): void {
+  setPinnedRegion(id, []);
+}
+
+/** Clears every pinned region. */
+export function clearAllPinnedRegions(): void {
+  erasePinnedRegions();
+  pinnedRegions.clear();
+}
+
+/**
+ * Emits a line to the chat flow while preserving pinned regions below it.
+ * Used internally by chat-flow print* functions.
+ */
+function emit(message: string): void {
+  erasePinnedRegions();
+  console.log(message);
+  renderPinnedRegions();
+}
+
 /** Cumulative token-usage statistics displayed alongside the thinking spinner. */
 export interface SpinnerStats {
   /** Epoch timestamp (ms) when the current agent step began. */

--- a/src/output.ts
+++ b/src/output.ts
@@ -531,8 +531,7 @@ export function printHelp(): void {
     t.text('  /create-specialist') + t.muted(' — Create a specialist with guided AI assistance'),
     t.text('  /candidates') + t.muted(' — Review specialist suggestions'),
     t.text('  /critic') + t.muted('   — Toggle critic mode'),
-    t.text('  /tool-details') +
-      t.muted(' — Toggle visibility of tool call args and result output'),
+    t.text('  /tool-details') + t.muted(' — Toggle visibility of tool call args and result output'),
     t.text('  /options') +
       t.muted('  — View and set options (max-tokens, max-steps, shell-timeout, token-window)'),
     t.text('  /agent-options') + t.muted(' — Configure specialist auto-creation settings'),

--- a/src/output.ts
+++ b/src/output.ts
@@ -236,7 +236,7 @@ export function printAssistantText(text: string, prefix?: string): void {
   stopSpinner();
   if (text.trim()) {
     const label = formatPrefix(prefix);
-    console.log(label + getTheme().text(text));
+    emit(label + getTheme().text(text));
   }
 }
 
@@ -252,9 +252,14 @@ export function printToolCall(
   prefix?: string,
 ): void {
   stopSpinner();
+  if (silentTools.has(toolName)) return;
   const label = formatPrefix(prefix);
+  if (!toolDetailsVisible) {
+    emit(label + getTheme().toolCall(`  ▶ ${toolName}`));
+    return;
+  }
   const argsStr = toolName === 'shell' ? String(args.command || '') : JSON.stringify(args);
-  console.log(label + getTheme().toolCall(`  ▶ ${toolName}`) + getTheme().muted(`: ${argsStr}`));
+  emit(label + getTheme().toolCall(`  ▶ ${toolName}`) + getTheme().muted(`: ${argsStr}`));
 }
 
 /**
@@ -264,6 +269,8 @@ export function printToolCall(
  */
 export function printToolResult(toolName: string, result: unknown, prefix?: string): void {
   stopSpinner();
+  if (silentTools.has(toolName)) return;
+  if (!toolDetailsVisible) return;
   const label = formatPrefix(prefix);
   let output: string;
   if (typeof result === 'string') {
@@ -282,7 +289,7 @@ export function printToolResult(toolName: string, result: unknown, prefix?: stri
     .split('\n')
     .map((line) => label + getTheme().muted(`  ${line}`))
     .join('\n');
-  console.log(lines);
+  emit(lines);
 }
 
 /** Prints an error message to stderr in the theme's error color. */
@@ -299,7 +306,7 @@ export function printInfo(message: string): void {
 /** Prints a warning message in the theme's warning color. */
 export function printWarning(message: string): void {
   stopSpinner();
-  console.log(getTheme().warning(message));
+  emit(getTheme().warning(message));
 }
 
 /**
@@ -392,7 +399,7 @@ export function printEvaluation(evaluation: string, prefix?: string): void {
   stopSpinner();
   const t = getTheme();
   const label = formatPrefix(prefix);
-  console.log(label + t.warning(`  \uD83D\uDD0D ${evaluation}`));
+  emit(label + t.warning(`  \uD83D\uDD0D ${evaluation}`));
 }
 
 /** Prints a colored top-border line when a sub-agent begins executing a task. */
@@ -400,14 +407,14 @@ export function printSubAgentStart(id: number, task: string): void {
   const prefixColors = getTheme().prefixColors;
   const colorFn = prefixColors[(id - 1) % prefixColors.length];
   const displayTask = task.length > 80 ? task.slice(0, 80) + '…' : task;
-  console.log(colorFn(`┌─ sub:${id} — ${displayTask}`));
+  emit(colorFn(`┌─ sub:${id} — ${displayTask}`));
 }
 
 /** Prints a colored bottom-border line when a sub-agent finishes. */
 export function printSubAgentEnd(id: number): void {
   const prefixColors = getTheme().prefixColors;
   const colorFn = prefixColors[(id - 1) % prefixColors.length];
-  console.log(colorFn(`└─ sub:${id} done`));
+  emit(colorFn(`└─ sub:${id} done`));
 }
 
 /** Prints a colored top-border line when a specialist begins executing a task. */
@@ -415,21 +422,21 @@ export function printSpecialistStart(id: number, specialistName: string, task: s
   const prefixColors = getTheme().prefixColors;
   const colorFn = prefixColors[(id - 1) % prefixColors.length];
   const displayTask = task.length > 80 ? task.slice(0, 80) + '…' : task;
-  console.log(colorFn(`┌─ spec:${id} [${specialistName}] — ${displayTask}`));
+  emit(colorFn(`┌─ spec:${id} [${specialistName}] — ${displayTask}`));
 }
 
 /** Prints a colored bottom-border line when a specialist finishes. */
 export function printSpecialistEnd(id: number): void {
   const prefixColors = getTheme().prefixColors;
   const colorFn = prefixColors[(id - 1) % prefixColors.length];
-  console.log(colorFn(`└─ spec:${id} done`));
+  emit(colorFn(`└─ spec:${id} done`));
 }
 
 /** Prints a colored top-border line when a task begins executing. */
 export function printTaskStart(task: string): void {
   const t = getTheme();
   const displayTask = task.length > 80 ? task.slice(0, 80) + '…' : task;
-  console.log(t.accent(`┌─ task — ${displayTask}`));
+  emit(t.accent(`┌─ task — ${displayTask}`));
 }
 
 /** Prints a colored bottom-border line when a task finishes, showing structured result. */
@@ -442,9 +449,9 @@ export function printTaskEnd(result: string): void {
     const output = parsed.output
       ? `: ${parsed.output.length > MAX_TASK_OUTPUT_LENGTH ? parsed.output.slice(0, MAX_TASK_OUTPUT_LENGTH) + '…' : parsed.output}`
       : '';
-    console.log(statusColor(`└─ task ${parsed.status}${output}`));
+    emit(statusColor(`└─ task ${parsed.status}${output}`));
   } catch {
-    console.log(t.accent(`└─ task done`));
+    emit(t.accent(`└─ task done`));
   }
 }
 
@@ -453,7 +460,7 @@ export function printCriticStart(prefix?: string): void {
   stopSpinner();
   const t = getTheme();
   const label = formatPrefix(prefix);
-  console.log(label + t.accent('┌─ critic — verifying response...'));
+  emit(label + t.accent('┌─ critic — verifying response...'));
 }
 
 /** Prints a retry indicator when the critic triggers a correction loop. */
@@ -461,7 +468,7 @@ export function printCriticRetry(attempt: number, maxRetries: number, prefix?: s
   stopSpinner();
   const t = getTheme();
   const label = formatPrefix(prefix);
-  console.log(label + t.warning(`├─ critic — retrying (${attempt}/${maxRetries})...`));
+  emit(label + t.warning(`├─ critic — retrying (${attempt}/${maxRetries})...`));
 }
 
 /** Parses a critic response into a structured verdict and explanation. */
@@ -490,11 +497,11 @@ export function printCriticVerdict(text: string, prefix?: string): void {
     // Compact badge; include explanation only if single-line
     const isSingleLine = !!explanation && !explanation.includes('\n');
     const suffix = isSingleLine ? `: ${explanation}` : '';
-    console.log(label + colorFn(`└─ critic ${verdict}${suffix}`));
+    emit(label + colorFn(`└─ critic ${verdict}${suffix}`));
   } else {
     // FAIL/UNKNOWN: always show full explanation
     const suffix = explanation ? `: ${explanation}` : '';
-    console.log(label + colorFn(`└─ critic ${verdict}${suffix}`));
+    emit(label + colorFn(`└─ critic ${verdict}${suffix}`));
   }
 }
 
@@ -503,7 +510,7 @@ export function printCriticReVerify(prefix?: string): void {
   stopSpinner();
   const t = getTheme();
   const label = formatPrefix(prefix);
-  console.log(label + t.accent('├─ critic — re-verifying response...'));
+  emit(label + t.accent('├─ critic — re-verifying response...'));
 }
 
 /** Prints the REPL help menu listing all available slash commands. */

--- a/src/output.ts
+++ b/src/output.ts
@@ -13,37 +13,14 @@ export function setToolDetailsVisible(enabled: boolean): void {
   toolDetailsVisible = enabled;
 }
 
-/** Returns whether tool result bodies are currently printed to the terminal. */
-export function getToolDetailsVisible(): boolean {
-  return toolDetailsVisible;
-}
-
-// Tools whose call and result lines are suppressed from the chat flow.
-// Their output is rendered through dedicated channels (printPlan, printThought,
-// printEvaluation), so the generic ▶ toolName / result body would be duplicate
-// noise. Extend this set to mute additional tools.
+// Tools rendered through dedicated channels (printPlan, printThought,
+// printEvaluation) — their generic call/result lines would be duplicate noise.
 const silentTools = new Set<string>(['plan', 'think', 'evaluate']);
 
-/** Adds or removes a tool from the silent list. */
-export function setSilentTool(toolName: string, silent: boolean): void {
-  if (silent) silentTools.add(toolName);
-  else silentTools.delete(toolName);
-}
-
-/** Returns true when the given tool's call/result lines are suppressed. */
-export function isSilentTool(toolName: string): boolean {
-  return silentTools.has(toolName);
-}
-
-// ─── Pinned regions ──────────────────────────────────────────────────────────
-// A generic persistent-footer mechanism: each region is a block of lines
-// keyed by a string id that stays anchored just above the prompt (or above
-// the spinner while the agent is thinking). Adding or updating a region
-// repaints it in place via ANSI cursor control; chat-flow prints flow past
-// it by erasing the block, printing, then re-rendering.
-//
-// Fall back to plain console.log when stdout is not a TTY so output remains
-// intact under pipes / in tests.
+// Pinned regions: a generic persistent-footer mechanism. Each region is a
+// block of lines keyed by id that stays anchored just above the prompt.
+// Only active when stdout is a TTY; in pipe/test mode the regions are stored
+// but never rendered, so chat output stays clean.
 
 const pinnedRegions = new Map<string, string[]>();
 let pinnedLineCount = 0;
@@ -60,32 +37,39 @@ function erasePinnedRegions(): void {
 }
 
 function renderPinnedRegions(): void {
-  if (pinnedRegions.size === 0) return;
+  if (!pinSupported() || pinnedRegions.size === 0) return;
   let count = 0;
   for (const lines of pinnedRegions.values()) {
     for (const line of lines) {
-      if (pinSupported()) {
-        process.stdout.write(line + '\n');
-      } else {
-        console.log(line);
-      }
+      process.stdout.write(line + '\n');
       count++;
     }
   }
-  if (pinSupported()) pinnedLineCount = count;
+  pinnedLineCount = count;
+}
+
+function sameLines(a: string[] | undefined, b: string[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 }
 
 /**
  * Pins or updates a named region of lines above the prompt.
- * Passing an empty array removes the region.
+ * Passing an empty array removes the region. No-op when the new content
+ * matches what is already pinned under that id.
  */
 export function setPinnedRegion(id: string, lines: string[]): void {
-  erasePinnedRegions();
   if (lines.length === 0) {
+    if (!pinnedRegions.has(id)) return;
+    erasePinnedRegions();
     pinnedRegions.delete(id);
-  } else {
-    pinnedRegions.set(id, lines);
+    renderPinnedRegions();
+    return;
   }
+  if (sameLines(pinnedRegions.get(id), lines)) return;
+  erasePinnedRegions();
+  pinnedRegions.set(id, lines);
   renderPinnedRegions();
 }
 
@@ -94,16 +78,6 @@ export function clearPinnedRegion(id: string): void {
   setPinnedRegion(id, []);
 }
 
-/** Clears every pinned region. */
-export function clearAllPinnedRegions(): void {
-  erasePinnedRegions();
-  pinnedRegions.clear();
-}
-
-/**
- * Emits a line to the chat flow while preserving pinned regions below it.
- * Used internally by chat-flow print* functions.
- */
 function emit(message: string): void {
   erasePinnedRegions();
   console.log(message);
@@ -300,7 +274,7 @@ export function printError(message: string): void {
 
 /** Prints an informational message in the theme's muted color. */
 export function printInfo(message: string): void {
-  console.log(getTheme().muted(message));
+  emit(getTheme().muted(message));
 }
 
 /** Prints a warning message in the theme's warning color. */

--- a/src/output.ts
+++ b/src/output.ts
@@ -2,13 +2,17 @@ import type { CoreMessage } from 'ai';
 import { getContextWindow, COMPRESSION_THRESHOLD } from './context.js';
 import { getTheme } from './theme.js';
 import type { Step, StepStatus } from './plan-store.js';
+import { debugLog } from './logger.js';
 
 const MAX_TOOL_OUTPUT_LENGTH = 2000;
 const MAX_REPLAY_LENGTH = 200;
 
 let toolDetailsVisible = false;
 
-/** Enables or disables printing of tool result bodies. Calls are always shown. */
+/**
+ * Enables or disables printing of tool-call arguments and tool result bodies.
+ * Tool names and call lines (▶ toolName) are always shown regardless.
+ */
 export function setToolDetailsVisible(enabled: boolean): void {
   toolDetailsVisible = enabled;
 }
@@ -226,6 +230,9 @@ export function printToolCall(
   prefix?: string,
 ): void {
   stopSpinner();
+  // Debug log fires regardless of visibility so `.logs/<date>.log` keeps
+  // full tool args even when tool-details are hidden (see issue #116).
+  debugLog(`onStepFinish:toolCall:${toolName}`, args);
   if (silentTools.has(toolName)) return;
   const label = formatPrefix(prefix);
   if (!toolDetailsVisible) {
@@ -243,6 +250,7 @@ export function printToolCall(
  */
 export function printToolResult(toolName: string, result: unknown, prefix?: string): void {
   stopSpinner();
+  debugLog(`onStepFinish:toolResult:${toolName}`, result);
   if (silentTools.has(toolName)) return;
   if (!toolDetailsVisible) return;
   const label = formatPrefix(prefix);
@@ -501,49 +509,37 @@ export function printCriticReVerify(prefix?: string): void {
 /** Prints the REPL help menu listing all available slash commands. */
 export function printHelp(): void {
   const t = getTheme();
-  console.log(t.accent('\nCommands:'));
-  console.log(t.text('  /help') + t.muted('    — Show this help'));
-  console.log(
+  const lines = [
+    t.accent('\nCommands:'),
+    t.text('  /help') + t.muted('    — Show this help'),
     t.text('  /clear') + t.muted('   — Clear conversation (--save/-s to summarize first)'),
-  );
-  console.log(t.text('  /compact') + t.muted(' — Compress conversation history in-place'));
-  console.log(
+    t.text('  /compact') + t.muted(' — Compress conversation history in-place'),
     t.text('  /task') + t.muted('    — Run an isolated task (no history, structured output)'),
-  );
-  console.log(t.text('  /image') + t.muted('   — Attach an image: /image <path> [prompt]'));
-  console.log(t.text('  /memory') + t.muted('  — List persistent memories'));
-  console.log(t.text('  /scratch') + t.muted(' — List session scratch notes'));
-  console.log(t.text('  /mcp') + t.muted('      — List MCP servers and tools'));
-  console.log(t.text('  /cron') + t.muted('     — Show cron jobs and daemon status'));
-  console.log(t.text('  /facts') + t.muted('    — Show RAG facts in current context window'));
-  console.log(t.text('  /provider') + t.muted(' — Switch LLM provider'));
-  console.log(t.text('  /model') + t.muted('    — Switch model for current provider'));
-  console.log(t.text('  /theme') + t.muted('    — Switch color theme'));
-  console.log(t.text('  /routines') + t.muted(' — List saved routines'));
-  console.log(
+    t.text('  /image') + t.muted('   — Attach an image: /image <path> [prompt]'),
+    t.text('  /memory') + t.muted('  — List persistent memories'),
+    t.text('  /scratch') + t.muted(' — List session scratch notes'),
+    t.text('  /mcp') + t.muted('      — List MCP servers and tools'),
+    t.text('  /cron') + t.muted('     — Show cron jobs and daemon status'),
+    t.text('  /facts') + t.muted('    — Show RAG facts in current context window'),
+    t.text('  /provider') + t.muted(' — Switch LLM provider'),
+    t.text('  /model') + t.muted('    — Switch model for current provider'),
+    t.text('  /theme') + t.muted('    — Switch color theme'),
+    t.text('  /routines') + t.muted(' — List saved routines'),
     t.text('  /create-routine') + t.muted(' — Create a routine with guided AI assistance'),
-  );
-  console.log(
     t.text('  /create-task') + t.muted(' — Create a task routine with guided AI assistance'),
-  );
-  console.log(t.text('  /specialists') + t.muted(' — List specialist agents'));
-  console.log(
+    t.text('  /specialists') + t.muted(' — List specialist agents'),
     t.text('  /create-specialist') + t.muted(' — Create a specialist with guided AI assistance'),
-  );
-  console.log(t.text('  /candidates') + t.muted(' — Review specialist suggestions'));
-  console.log(t.text('  /critic') + t.muted('   — Toggle critic mode'));
-  console.log(
-    t.text('  /tool-details') + t.muted(' — Toggle visibility of tool call args and result output'),
-  );
-  console.log(
+    t.text('  /candidates') + t.muted(' — Review specialist suggestions'),
+    t.text('  /critic') + t.muted('   — Toggle critic mode'),
+    t.text('  /tool-details') +
+      t.muted(' — Toggle visibility of tool call args and result output'),
     t.text('  /options') +
       t.muted('  — View and set options (max-tokens, max-steps, shell-timeout, token-window)'),
-  );
-  console.log(
     t.text('  /agent-options') + t.muted(' — Configure specialist auto-creation settings'),
-  );
-  console.log(t.text('  /update') + t.muted('   — Check for and install updates'));
-  console.log(t.text('  /debug') + t.muted('    — Print diagnostic report for troubleshooting'));
-  console.log(t.text('  exit') + t.muted('      — Quit Bernard'));
-  console.log();
+    t.text('  /update') + t.muted('   — Check for and install updates'),
+    t.text('  /debug') + t.muted('    — Print diagnostic report for troubleshooting'),
+    t.text('  exit') + t.muted('      — Quit Bernard'),
+    '',
+  ];
+  emit(lines.join('\n'));
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -373,25 +373,36 @@ function iconForStatus(status: StepStatus): string {
   }
 }
 
-/** Prints the current plan as a bulleted, status-decorated list. */
+/**
+ * Pins the current plan as a bulleted, status-decorated list above the prompt.
+ *
+ * Uses the generic pinned-region mechanism keyed by `'plan'`, so the block
+ * stays anchored while other chat-flow output scrolls above it.
+ * Passing no steps removes the pinned plan.
+ */
 export function printPlan(steps: Step[], prefix?: string): void {
   stopSpinner();
+  if (steps.length === 0) {
+    clearPinnedRegion('plan');
+    return;
+  }
   const t = getTheme();
   const label = formatPrefix(prefix);
-  console.log(label + t.accent('  \u25C6 Plan:'));
+  const lines: string[] = [label + t.accent('  \u25C6 Plan:')];
   for (const s of steps) {
     const icon = iconForStatus(s.status);
     const note = s.note ? t.muted(` \u2014 ${s.note}`) : '';
-    console.log(label + t.muted(`    ${icon} ${s.id}. ${s.description}`) + note);
+    lines.push(label + t.muted(`    ${icon} ${s.id}. ${s.description}`) + note);
   }
+  setPinnedRegion('plan', lines);
 }
 
-/** Prints a visible thought line prefixed with a thought bubble. */
+/** Prints a visible thought line. */
 export function printThought(thought: string, prefix?: string): void {
   stopSpinner();
   const t = getTheme();
   const label = formatPrefix(prefix);
-  console.log(label + t.accent(`  \uD83D\uDCAD ${thought}`));
+  emit(label + t.accent(`  ${thought}`));
 }
 
 /** Prints a visible post-action self-evaluation prefixed with a magnifying glass. */
@@ -547,6 +558,9 @@ export function printHelp(): void {
   );
   console.log(t.text('  /candidates') + t.muted(' — Review specialist suggestions'));
   console.log(t.text('  /critic') + t.muted('   — Toggle critic mode'));
+  console.log(
+    t.text('  /tool-details') + t.muted(' — Toggle visibility of tool call args and result output'),
+  );
   console.log(
     t.text('  /options') +
       t.muted('  — View and set options (max-tokens, max-steps, shell-timeout, token-window)'),

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -124,6 +124,7 @@ vi.mock('./output.js', () => ({
   stopSpinner: (...args: any[]) => mockStopSpinner(...args),
   buildSpinnerMessage: (...args: any[]) => mockBuildSpinnerMessage(...args),
   formatTokenCount: (n: number) => String(n),
+  setToolDetailsVisible: vi.fn(),
 }));
 
 vi.mock('./providers/index.js', () => ({

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -302,6 +302,7 @@ export async function startRepl(
     label: string,
     onMsg: string,
     offMsg: string,
+    onToggle?: (value: boolean) => void,
   ): Promise<void> {
     const entries: MenuEntry[] = [
       { label: 'On', active: config[key] === true },
@@ -321,7 +322,7 @@ export async function startRepl(
           model: config.model,
           [key]: config[key],
         });
-        if (key === 'toolDetails') setToolDetailsVisible(config[key]);
+        onToggle?.(config[key]);
         printInfo(config[key] ? onMsg : offMsg);
       }
     } finally {
@@ -1435,6 +1436,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
           'Tool details',
           '  [TOOL-DETAILS:ON] Full tool call args and results will be shown.',
           '  [TOOL-DETAILS:OFF] Only tool names shown; args and results hidden.',
+          setToolDetailsVisible,
         );
         void prompt();
         return;

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -75,6 +75,7 @@ import {
   printToolResult,
   printAssistantText,
   printWarning,
+  setToolDetailsVisible,
 } from './output.js';
 import { buildMemoryContext } from './memory-context.js';
 import { debugLog } from './logger.js';
@@ -158,6 +159,7 @@ export async function startRepl(
   alertContext?: string,
   resume?: boolean,
 ): Promise<void> {
+  setToolDetailsVisible(config.toolDetails);
   const SLASH_COMMANDS = [
     { command: '/help', description: 'Show this help' },
     { command: '/clear', description: 'Clear conversation (--save/-s to summarize first)' },
@@ -185,6 +187,10 @@ export async function startRepl(
     { command: '/candidates', description: 'Review specialist suggestions' },
     { command: '/critic', description: 'Toggle critic mode' },
     { command: '/react', description: 'Toggle coordinator (ReAct) mode' },
+    {
+      command: '/tool-details',
+      description: 'Toggle visibility of tool call args and result output',
+    },
     { command: '/agent-options', description: 'Configure specialist auto-creation settings' },
     { command: '/image', description: 'Attach an image: /image <path> [prompt]' },
     { command: '/debug', description: 'Print diagnostic report for troubleshooting' },
@@ -292,7 +298,7 @@ export async function startRepl(
   }
 
   async function toggleBooleanPref(
-    key: 'criticMode' | 'reactMode',
+    key: 'criticMode' | 'reactMode' | 'toolDetails',
     label: string,
     onMsg: string,
     offMsg: string,
@@ -315,6 +321,7 @@ export async function startRepl(
           model: config.model,
           [key]: config[key],
         });
+        if (key === 'toolDetails') setToolDetailsVisible(config[key]);
         printInfo(config[key] ? onMsg : offMsg);
       }
     } finally {
@@ -1422,6 +1429,17 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         return;
       }
 
+      if (trimmed === '/tool-details') {
+        await toggleBooleanPref(
+          'toolDetails',
+          'Tool details',
+          '  [TOOL-DETAILS:ON] Full tool call args and results will be shown.',
+          '  [TOOL-DETAILS:OFF] Only tool names shown; args and results hidden.',
+        );
+        void prompt();
+        return;
+      }
+
       if (trimmed === '/agent-options') {
         const topEntries: MenuEntry[] = [
           {
@@ -1583,6 +1601,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         console.log(t.muted(`    Theme: ${getActiveThemeKey()}`));
         console.log(t.muted(`    Critic mode: ${config.criticMode ? 'on' : 'off'}`));
         console.log(t.muted(`    Coordinator mode: ${config.reactMode ? 'on' : 'off'}`));
+        console.log(t.muted(`    Tool details: ${config.toolDetails ? 'on' : 'off'}`));
         const debugEnabled =
           process.env.BERNARD_DEBUG === 'true' || process.env.BERNARD_DEBUG === '1';
         console.log(t.muted(`    Debug mode: ${debugEnabled ? 'on' : 'off'}`));


### PR DESCRIPTION
Implements a new configuration option that allows users to control the visibility of tool call arguments and result outputs in the terminal. Tool call names remain visible while detailed output can be hidden for cleaner display.

## Key Features

- Adds `--tool-details` CLI flag and `/tool-details` REPL command
- Introduces silent tool system for plan, think, and evaluate functions
- Implements pinned regions for persistent plan display above the prompt
- Updates output formatting to use new visibility controls

## Benefits

- Reduces terminal noise while preserving essential debugging information
- Provides better user experience with cleaner output display
- Maintains backward compatibility with existing debug workflows

Relates to #116