### PR TITLE
Adds persistent notes to cron jobs for state tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,12 @@ Behavioral evals live in `scripts/eval-*.ts`. They run real API calls and are ga
 
 Bernard follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/). All paths are centralized in `src/paths.ts`.
 
-| Category   | Default Location          | Contents                                                                                                                                                 |
-| ---------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Config** | `~/.config/bernard/`      | `preferences.json`, `keys.json`, `.env`, `mcp.json`                                                                                                      |
+| Category   | Default Location          | Contents                                                                                                                                                                      |
+| ---------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Config** | `~/.config/bernard/`      | `preferences.json`, `keys.json`, `.env`, `mcp.json`                                                                                                                           |
 | **Data**   | `~/.local/share/bernard/` | `memory/*.md`, `rag/`, `routines/*.json`, `specialists/*.json`, `correction-candidates/*.json`, `tool-profiles/*.json`, `cron/jobs.json`, `cron/alerts/`, `cron/notes/*.json` |
-| **Cache**  | `~/.cache/bernard/`       | `models/` (embeddings), `update-check.json`                                                                                                              |
-| **State**  | `~/.local/state/bernard/` | `conversation-history.json`, `logs/*.jsonl`, `cron-daemon.pid`, `cron-daemon.log`                                                                        |
+| **Cache**  | `~/.cache/bernard/`       | `models/` (embeddings), `update-check.json`                                                                                                                                   |
+| **State**  | `~/.local/state/bernard/` | `conversation-history.json`, `logs/*.jsonl`, `cron-daemon.pid`, `cron-daemon.log`                                                                                             |
 
 Override with `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, `XDG_STATE_HOME` (must be absolute).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ bernard -p openai -m gpt-4o  # Use specific provider/model
 - **src/builtin-specialists/** — Bundled specialists (shell/file/web wrappers + correction-agent + specialist-creator) seeded on first run
 - **src/tool-profiles.ts** — `ToolProfileStore`: per-tool profiles with guidelines and good/bad examples, auto-learned from errors
 - **src/tools/augment.ts** — `augmentTools()`: transparent execute-wrapper that observes every tool call, records errors, and patches fixes on retry
+- **src/cron/notes-store.ts** — `CronNotesStore`: per-job persistent notes (JSON per job, capped at 100 entries, atomic writes). Daemon runner injects `cron_notes_read` / `cron_notes_write` scoped to `job.id` + `runId` so cron runs can avoid duplicate work across restarts; `cron_logs_get` appends a `## Notes written during this run` section.
 - **src/critic.ts** — Standalone critic functions: `extractToolCallLog`, `runCritic`, and critic constants/types
 - **src/pac.ts** — Plan-Act-Critic loop wrapper (`runPACLoop`) for sub-agents and specialists
 - **src/overlap-checker.ts** — Token-based Jaccard overlap detection for specialist candidates
@@ -62,7 +63,7 @@ Bernard follows the [XDG Base Directory Specification](https://specifications.fr
 | Category   | Default Location          | Contents                                                                                                                                                 |
 | ---------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Config** | `~/.config/bernard/`      | `preferences.json`, `keys.json`, `.env`, `mcp.json`                                                                                                      |
-| **Data**   | `~/.local/share/bernard/` | `memory/*.md`, `rag/`, `routines/*.json`, `specialists/*.json`, `correction-candidates/*.json`, `tool-profiles/*.json`, `cron/jobs.json`, `cron/alerts/` |
+| **Data**   | `~/.local/share/bernard/` | `memory/*.md`, `rag/`, `routines/*.json`, `specialists/*.json`, `correction-candidates/*.json`, `tool-profiles/*.json`, `cron/jobs.json`, `cron/alerts/`, `cron/notes/*.json` |
 | **Cache**  | `~/.cache/bernard/`       | `models/` (embeddings), `update-check.json`                                                                                                              |
 | **State**  | `~/.local/state/bernard/` | `conversation-history.json`, `logs/*.jsonl`, `cron-daemon.pid`, `cron-daemon.log`                                                                        |
 

--- a/src/cron/notes-store.test.ts
+++ b/src/cron/notes-store.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  unlinkSync: vi.fn(),
+}));
+
+const fs = await import('node:fs');
+
+import { CronNotesStore, type CronNotes } from './notes-store.js';
+
+function lastWrittenPayload(): CronNotes {
+  const call = vi.mocked(fs.writeFileSync).mock.calls.at(-1);
+  if (!call) throw new Error('writeFileSync was not called');
+  return JSON.parse(call[1] as string) as CronNotes;
+}
+
+describe('CronNotesStore', () => {
+  let store: CronNotesStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new CronNotesStore();
+  });
+
+  it('creates notes directory on construction', () => {
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('notes'), {
+      recursive: true,
+    });
+  });
+
+  describe('append', () => {
+    it('writes a new file when none exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const entry = store.append('job-1', 'sent email');
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringMatching(/job-1\.json\.tmp$/),
+        expect.stringContaining('"sent email"'),
+        'utf-8',
+      );
+      expect(fs.renameSync).toHaveBeenCalled();
+      expect(entry.text).toBe('sent email');
+      expect(entry.timestamp).toMatch(/\d{4}-\d{2}-\d{2}T/);
+      expect(entry.runId).toBeUndefined();
+    });
+
+    it('tags entry with runId when provided', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const entry = store.append('job-1', 'created issue #42', 'run-abc');
+
+      expect(entry.runId).toBe('run-abc');
+      expect(lastWrittenPayload().entries[0].runId).toBe('run-abc');
+    });
+
+    it('appends to existing entries', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          jobId: 'job-1',
+          entries: [{ timestamp: '2025-01-01T00:00:00Z', text: 'old' }],
+        }),
+      );
+
+      store.append('job-1', 'new');
+
+      const payload = lastWrittenPayload();
+      expect(payload.entries).toHaveLength(2);
+      expect(payload.entries[0].text).toBe('old');
+      expect(payload.entries[1].text).toBe('new');
+    });
+
+    it('caps entries at 100 (drops oldest)', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      const existing = Array.from({ length: 100 }, (_, i) => ({
+        timestamp: `2025-01-01T00:00:${String(i).padStart(2, '0')}Z`,
+        text: `entry-${i}`,
+      }));
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ jobId: 'job-1', entries: existing }),
+      );
+
+      store.append('job-1', 'entry-100');
+
+      const payload = lastWrittenPayload();
+      expect(payload.entries).toHaveLength(100);
+      expect(payload.entries[0].text).toBe('entry-1');
+      expect(payload.entries[99].text).toBe('entry-100');
+    });
+  });
+
+  describe('read', () => {
+    it('returns empty notes when file does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const notes = store.read('job-1');
+
+      expect(notes).toEqual({ jobId: 'job-1', entries: [] });
+    });
+
+    it('parses a valid notes file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          jobId: 'job-1',
+          entries: [{ timestamp: '2025-01-01T00:00:00Z', text: 'hi', runId: 'r-1' }],
+        }),
+      );
+
+      const notes = store.read('job-1');
+
+      expect(notes.entries).toHaveLength(1);
+      expect(notes.entries[0].text).toBe('hi');
+      expect(notes.entries[0].runId).toBe('r-1');
+    });
+
+    it('returns empty notes on malformed JSON', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('not valid json');
+
+      const notes = store.read('job-1');
+
+      expect(notes.entries).toEqual([]);
+    });
+  });
+
+  describe('sanitizeJobId', () => {
+    it('strips path-traversal characters before reading', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const notes = store.read('../evil');
+
+      expect(notes.jobId).toBe('evil');
+    });
+
+    it('rejects jobIds that sanitize to empty', () => {
+      expect(() => store.read('../../')).toThrow(/Invalid jobId/);
+      expect(() => store.append('!@#', 'x')).toThrow(/Invalid jobId/);
+    });
+  });
+
+  describe('listJobIds', () => {
+    it('returns empty when directory does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(store.listJobIds()).toEqual([]);
+    });
+
+    it('returns job ids stripped of .json extension', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue(['job-1.json', 'job-2.json', 'ignore.txt'] as any);
+
+      expect(store.listJobIds()).toEqual(['job-1', 'job-2']);
+    });
+  });
+
+  describe('clear', () => {
+    it('returns false when no notes file exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(store.clear('job-1')).toBe(false);
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('unlinks the file and returns true when it exists', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      expect(store.clear('job-1')).toBe(true);
+      expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringMatching(/job-1\.json$/));
+    });
+  });
+
+  describe('entriesForRun', () => {
+    it('filters entries to only those with the given runId', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          jobId: 'job-1',
+          entries: [
+            { timestamp: 't1', text: 'a', runId: 'r-1' },
+            { timestamp: 't2', text: 'b', runId: 'r-2' },
+            { timestamp: 't3', text: 'c', runId: 'r-1' },
+            { timestamp: 't4', text: 'd' },
+          ],
+        }),
+      );
+
+      const matches = store.entriesForRun('job-1', 'r-1');
+
+      expect(matches.map((e) => e.text)).toEqual(['a', 'c']);
+    });
+  });
+});

--- a/src/cron/notes-store.test.ts
+++ b/src/cron/notes-store.test.ts
@@ -38,7 +38,7 @@ describe('CronNotesStore', () => {
     it('writes a new file when none exists', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const entry = store.append('job-1', 'sent email');
+      const { entry, total } = store.append('job-1', 'sent email');
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         expect.stringMatching(/job-1\.json\.tmp$/),
@@ -49,12 +49,13 @@ describe('CronNotesStore', () => {
       expect(entry.text).toBe('sent email');
       expect(entry.timestamp).toMatch(/\d{4}-\d{2}-\d{2}T/);
       expect(entry.runId).toBeUndefined();
+      expect(total).toBe(1);
     });
 
     it('tags entry with runId when provided', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const entry = store.append('job-1', 'created issue #42', 'run-abc');
+      const { entry } = store.append('job-1', 'created issue #42', 'run-abc');
 
       expect(entry.runId).toBe('run-abc');
       expect(lastWrittenPayload().entries[0].runId).toBe('run-abc');
@@ -87,12 +88,13 @@ describe('CronNotesStore', () => {
         JSON.stringify({ jobId: 'job-1', entries: existing }),
       );
 
-      store.append('job-1', 'entry-100');
+      const { total } = store.append('job-1', 'entry-100');
 
       const payload = lastWrittenPayload();
       expect(payload.entries).toHaveLength(100);
       expect(payload.entries[0].text).toBe('entry-1');
       expect(payload.entries[99].text).toBe('entry-100');
+      expect(total).toBe(100);
     });
   });
 

--- a/src/cron/notes-store.ts
+++ b/src/cron/notes-store.ts
@@ -64,8 +64,12 @@ export class CronNotesStore {
     }
   }
 
-  /** Appends a note entry, capping at {@link MAX_ENTRIES} (oldest dropped). */
-  append(jobId: string, text: string, runId?: string): CronNoteEntry {
+  /**
+   * Appends a note entry, capping at {@link MAX_ENTRIES} (oldest dropped).
+   * Returns the new entry and the post-append total so callers don't need a
+   * follow-up read to report counts.
+   */
+  append(jobId: string, text: string, runId?: string): { entry: CronNoteEntry; total: number } {
     const safeId = this.sanitizeJobId(jobId);
     const current = this.read(safeId);
     const entry: CronNoteEntry = {
@@ -76,7 +80,7 @@ export class CronNotesStore {
     const nextEntries = [...current.entries, entry].slice(-MAX_ENTRIES);
     const payload: CronNotes = { jobId: safeId, entries: nextEntries };
     atomicWriteFileSync(this.notesPath(safeId), JSON.stringify(payload, null, 2));
-    return entry;
+    return { entry, total: nextEntries.length };
   }
 
   /** Lists job IDs that have notes files on disk. */

--- a/src/cron/notes-store.ts
+++ b/src/cron/notes-store.ts
@@ -1,0 +1,103 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { CRON_NOTES_DIR } from '../paths.js';
+import { atomicWriteFileSync } from '../fs-utils.js';
+import { sanitizeKey } from '../memory.js';
+
+const MAX_ENTRIES = 100;
+
+/** Maximum characters per note entry (enforced by writers). */
+export const MAX_NOTE_LENGTH = 1000;
+
+/** A single persistent note entry for a cron job. */
+export interface CronNoteEntry {
+  timestamp: string;
+  runId?: string;
+  text: string;
+}
+
+/** On-disk shape of a cron job's notes file. */
+export interface CronNotes {
+  jobId: string;
+  entries: CronNoteEntry[];
+}
+
+/**
+ * Per-job persistent note store. Each job's notes live in their own JSON file
+ * under {@link CRON_NOTES_DIR} and survive daemon restarts. Entries are
+ * append-only with a bounded cap of {@link MAX_ENTRIES} (oldest dropped first).
+ */
+export class CronNotesStore {
+  constructor() {
+    fs.mkdirSync(CRON_NOTES_DIR, { recursive: true });
+  }
+
+  static get notesDir(): string {
+    return CRON_NOTES_DIR;
+  }
+
+  private sanitizeJobId(jobId: string): string {
+    const cleaned = sanitizeKey(jobId);
+    if (!cleaned) throw new Error(`Invalid jobId: ${JSON.stringify(jobId)}`);
+    return cleaned;
+  }
+
+  private notesPath(jobId: string): string {
+    return path.join(CRON_NOTES_DIR, `${this.sanitizeJobId(jobId)}.json`);
+  }
+
+  /** Reads all note entries for a job. Returns an empty record if no file exists. */
+  read(jobId: string): CronNotes {
+    const safeId = this.sanitizeJobId(jobId);
+    const filePath = this.notesPath(safeId);
+    if (!fs.existsSync(filePath)) return { jobId: safeId, entries: [] };
+
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as CronNotes;
+      return {
+        jobId: parsed.jobId ?? safeId,
+        entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+      };
+    } catch {
+      return { jobId: safeId, entries: [] };
+    }
+  }
+
+  /** Appends a note entry, capping at {@link MAX_ENTRIES} (oldest dropped). */
+  append(jobId: string, text: string, runId?: string): CronNoteEntry {
+    const safeId = this.sanitizeJobId(jobId);
+    const current = this.read(safeId);
+    const entry: CronNoteEntry = {
+      timestamp: new Date().toISOString(),
+      text,
+      ...(runId ? { runId } : {}),
+    };
+    const nextEntries = [...current.entries, entry].slice(-MAX_ENTRIES);
+    const payload: CronNotes = { jobId: safeId, entries: nextEntries };
+    atomicWriteFileSync(this.notesPath(safeId), JSON.stringify(payload, null, 2));
+    return entry;
+  }
+
+  /** Lists job IDs that have notes files on disk. */
+  listJobIds(): string[] {
+    if (!fs.existsSync(CRON_NOTES_DIR)) return [];
+    return fs
+      .readdirSync(CRON_NOTES_DIR)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.replace(/\.json$/, ''));
+  }
+
+  /** Deletes the notes file for a job. Returns `false` if nothing existed. */
+  clear(jobId: string): boolean {
+    const filePath = this.notesPath(jobId);
+    if (!fs.existsSync(filePath)) return false;
+    fs.unlinkSync(filePath);
+    return true;
+  }
+
+  /** Returns only entries tagged with the given runId. */
+  entriesForRun(jobId: string, runId: string): CronNoteEntry[] {
+    return this.read(jobId).entries.filter((e) => e.runId === runId);
+  }
+}

--- a/src/cron/notes-store.ts
+++ b/src/cron/notes-store.ts
@@ -59,8 +59,19 @@ export class CronNotesStore {
         jobId: parsed.jobId ?? safeId,
         entries: Array.isArray(parsed.entries) ? parsed.entries : [],
       };
-    } catch {
-      return { jobId: safeId, entries: [] };
+    } catch (error: unknown) {
+      if (error instanceof SyntaxError) {
+        return { jobId: safeId, entries: [] };
+      }
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code: string }).code === 'ENOENT'
+      ) {
+        return { jobId: safeId, entries: [] };
+      }
+      throw error;
     }
   }
 

--- a/src/cron/runner.test.ts
+++ b/src/cron/runner.test.ts
@@ -17,6 +17,14 @@ const mockLogStore = vi.hoisted(() => ({
   appendEntry: vi.fn(),
 }));
 
+const mockNotesStore = vi.hoisted(() => ({
+  read: vi.fn().mockReturnValue({ jobId: 'job-123', entries: [] }),
+  append: vi.fn(),
+  listJobIds: vi.fn().mockReturnValue([]),
+  clear: vi.fn(),
+  entriesForRun: vi.fn().mockReturnValue([]),
+}));
+
 const mockMcpManager = vi.hoisted(() => ({
   connect: vi.fn(),
   getTools: vi.fn().mockReturnValue({}),
@@ -49,6 +57,11 @@ vi.mock('./store.js', () => ({
 
 vi.mock('./log-store.js', () => ({
   CronLogStore: vi.fn(() => mockLogStore),
+}));
+
+vi.mock('./notes-store.js', () => ({
+  CronNotesStore: vi.fn(() => mockNotesStore),
+  MAX_NOTE_LENGTH: 1000,
 }));
 
 vi.mock('./notify.js', () => ({
@@ -308,5 +321,64 @@ describe('runJob', () => {
   it('includes error handling rule in system prompt', async () => {
     await runJob(testJob, vi.fn());
     expect(capturedSystem).toContain('NEVER retry the exact same command');
+  });
+
+  // --- Scoped cron_notes_* tools ---
+
+  it('includes scoped cron_notes_read and cron_notes_write in tools', async () => {
+    await runJob(testJob, vi.fn());
+
+    expect(capturedTools).toHaveProperty('cron_notes_read');
+    expect(capturedTools).toHaveProperty('cron_notes_write');
+  });
+
+  it('scoped cron_notes_write tags the entry with the current runId and job id', async () => {
+    await runJob(testJob, vi.fn());
+
+    const result = await capturedTools.cron_notes_write.execute({ text: 'sent email' });
+
+    expect(mockNotesStore.append).toHaveBeenCalledTimes(1);
+    const [jobIdArg, textArg, runIdArg] = mockNotesStore.append.mock.calls[0];
+    expect(jobIdArg).toBe('job-123');
+    expect(textArg).toBe('sent email');
+    expect(typeof runIdArg).toBe('string');
+    expect(runIdArg.length).toBeGreaterThan(0);
+    expect(result).toContain('Note appended');
+    expect(result).toContain(runIdArg.slice(0, 8));
+  });
+
+  it('scoped cron_notes_read reads only this job and returns formatted entries', async () => {
+    mockNotesStore.read.mockReturnValue({
+      jobId: 'job-123',
+      entries: [
+        { timestamp: '2026-04-19T10:00:00Z', text: 'earlier action', runId: 'abcdef12' },
+      ],
+    });
+
+    await runJob(testJob, vi.fn());
+
+    const result = await capturedTools.cron_notes_read.execute({});
+
+    expect(mockNotesStore.read).toHaveBeenCalledWith('job-123');
+    expect(result).toContain('1 entry');
+    expect(result).toContain('earlier action');
+    expect(result).toContain('run:abcdef12');
+  });
+
+  it('scoped cron_notes_read returns empty-state message when no prior notes', async () => {
+    mockNotesStore.read.mockReturnValue({ jobId: 'job-123', entries: [] });
+
+    await runJob(testJob, vi.fn());
+
+    const result = await capturedTools.cron_notes_read.execute({});
+    expect(result).toContain('No prior notes');
+  });
+
+  it('includes Persistent Notes section in system prompt', async () => {
+    await runJob(testJob, vi.fn());
+
+    expect(capturedSystem).toContain('## Persistent Notes');
+    expect(capturedSystem).toContain('cron_notes_read');
+    expect(capturedSystem).toContain('cron_notes_write');
   });
 });

--- a/src/cron/runner.test.ts
+++ b/src/cron/runner.test.ts
@@ -323,55 +323,13 @@ describe('runJob', () => {
     expect(capturedSystem).toContain('NEVER retry the exact same command');
   });
 
-  // --- Scoped cron_notes_* tools ---
+  // --- Scoped cron_notes_* tools (contract only; behavior covered in scoped-notes-tools.test.ts) ---
 
   it('includes scoped cron_notes_read and cron_notes_write in tools', async () => {
     await runJob(testJob, vi.fn());
 
     expect(capturedTools).toHaveProperty('cron_notes_read');
     expect(capturedTools).toHaveProperty('cron_notes_write');
-  });
-
-  it('scoped cron_notes_write tags the entry with the current runId and job id', async () => {
-    await runJob(testJob, vi.fn());
-
-    const result = await capturedTools.cron_notes_write.execute({ text: 'sent email' });
-
-    expect(mockNotesStore.append).toHaveBeenCalledTimes(1);
-    const [jobIdArg, textArg, runIdArg] = mockNotesStore.append.mock.calls[0];
-    expect(jobIdArg).toBe('job-123');
-    expect(textArg).toBe('sent email');
-    expect(typeof runIdArg).toBe('string');
-    expect(runIdArg.length).toBeGreaterThan(0);
-    expect(result).toContain('Note appended');
-    expect(result).toContain(runIdArg.slice(0, 8));
-  });
-
-  it('scoped cron_notes_read reads only this job and returns formatted entries', async () => {
-    mockNotesStore.read.mockReturnValue({
-      jobId: 'job-123',
-      entries: [
-        { timestamp: '2026-04-19T10:00:00Z', text: 'earlier action', runId: 'abcdef12' },
-      ],
-    });
-
-    await runJob(testJob, vi.fn());
-
-    const result = await capturedTools.cron_notes_read.execute({});
-
-    expect(mockNotesStore.read).toHaveBeenCalledWith('job-123');
-    expect(result).toContain('1 entry');
-    expect(result).toContain('earlier action');
-    expect(result).toContain('run:abcdef12');
-  });
-
-  it('scoped cron_notes_read returns empty-state message when no prior notes', async () => {
-    mockNotesStore.read.mockReturnValue({ jobId: 'job-123', entries: [] });
-
-    await runJob(testJob, vi.fn());
-
-    const result = await capturedTools.cron_notes_read.execute({});
-    expect(result).toContain('No prior notes');
   });
 
   it('includes Persistent Notes section in system prompt', async () => {

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -17,6 +17,8 @@ import { createTimeTools } from '../tools/time.js';
 import { MCPManager } from '../mcp.js';
 import { CronStore } from './store.js';
 import { CronLogStore, type CronLogStep } from './log-store.js';
+import { CronNotesStore, MAX_NOTE_LENGTH } from './notes-store.js';
+import { formatEntryCompact } from '../tools/cron-notes.js';
 import { sendNotification } from './notify.js';
 import type { CronJob } from './types.js';
 import { runPACLoop } from '../pac.js';
@@ -41,6 +43,14 @@ This keeps you focused and prevents wasted steps on long-running jobs.
 - **notify** — Send a desktop notification to alert the user. Clicking the notification opens a terminal with the alert context. Only use when you find something that genuinely requires user attention.
 - **cron_self_disable** — Disable this cron job so it won't run again. Use when a one-time task is complete.
 - You may also have access to **MCP tools** (email, calendar, etc.) depending on configuration.
+
+## Persistent Notes
+You have \`cron_notes_read\` and \`cron_notes_write\`, both scoped to this job.
+
+1. Before taking action, call \`cron_notes_read\` to see what prior runs did. Use the notes to avoid duplicate work (e.g. don't re-send an email that a prior run already sent).
+2. After any significant action, call \`cron_notes_write\` with a short factual summary (e.g. "Sent weekly summary to user@example.com", "Created issue #123").
+
+Notes persist across daemon restarts. Keep entries short — one line each — and concrete. Don't log routine checks that found nothing.
 
 ## Decision Rules
 - Be concise. Focus on actionable findings.
@@ -164,6 +174,41 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
       confirmDangerous: async () => false, // Auto-deny in daemon mode
     });
 
+    const notesStore = new CronNotesStore();
+
+    const scopedNotesRead = tool({
+      description:
+        'Read notes previously written for this cron job by prior runs. Call this before acting to avoid duplicate work.',
+      parameters: z.object({}),
+      execute: async (): Promise<string> => {
+        debugLog('cron_notes_read:scoped:execute', { jobId: job.id });
+        const notes = notesStore.read(job.id);
+        if (notes.entries.length === 0) {
+          return `No prior notes for this job.`;
+        }
+        const label = notes.entries.length === 1 ? 'entry' : 'entries';
+        const lines = notes.entries.map(formatEntryCompact);
+        return `Prior notes (${notes.entries.length} ${label}):\n${lines.join('\n')}`;
+      },
+    });
+
+    const scopedNotesWrite = tool({
+      description:
+        "Append a short factual note recording a significant action this run took (e.g. 'Sent email to user@example.com', 'Created issue #123'). Keep it to one line.",
+      parameters: z.object({
+        text: z
+          .string()
+          .min(1)
+          .max(MAX_NOTE_LENGTH)
+          .describe('Short factual description of the action'),
+      }),
+      execute: async ({ text }): Promise<string> => {
+        debugLog('cron_notes_write:scoped:execute', { jobId: job.id, runId, text });
+        notesStore.append(job.id, text, runId);
+        return `Note appended (run ${runId.slice(0, 8)}).`;
+      },
+    });
+
     const tools = {
       shell: shellTool,
       memory: createMemoryTool(memoryStore),
@@ -174,6 +219,8 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
       ...createTimeTools(),
       notify: notifyTool,
       cron_self_disable: selfDisableTool,
+      cron_notes_read: scopedNotesRead,
+      cron_notes_write: scopedNotesWrite,
       ...mcpTools,
     };
 

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -17,8 +17,8 @@ import { createTimeTools } from '../tools/time.js';
 import { MCPManager } from '../mcp.js';
 import { CronStore } from './store.js';
 import { CronLogStore, type CronLogStep } from './log-store.js';
-import { CronNotesStore, MAX_NOTE_LENGTH } from './notes-store.js';
-import { formatEntryCompact } from '../tools/cron-notes.js';
+import { CronNotesStore } from './notes-store.js';
+import { createScopedCronNotesTools } from './scoped-notes-tools.js';
 import { sendNotification } from './notify.js';
 import type { CronJob } from './types.js';
 import { runPACLoop } from '../pac.js';
@@ -176,39 +176,6 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
 
     const notesStore = new CronNotesStore();
 
-    const scopedNotesRead = tool({
-      description:
-        'Read notes previously written for this cron job by prior runs. Call this before acting to avoid duplicate work.',
-      parameters: z.object({}),
-      execute: async (): Promise<string> => {
-        debugLog('cron_notes_read:scoped:execute', { jobId: job.id });
-        const notes = notesStore.read(job.id);
-        if (notes.entries.length === 0) {
-          return `No prior notes for this job.`;
-        }
-        const label = notes.entries.length === 1 ? 'entry' : 'entries';
-        const lines = notes.entries.map(formatEntryCompact);
-        return `Prior notes (${notes.entries.length} ${label}):\n${lines.join('\n')}`;
-      },
-    });
-
-    const scopedNotesWrite = tool({
-      description:
-        "Append a short factual note recording a significant action this run took (e.g. 'Sent email to user@example.com', 'Created issue #123'). Keep it to one line.",
-      parameters: z.object({
-        text: z
-          .string()
-          .min(1)
-          .max(MAX_NOTE_LENGTH)
-          .describe('Short factual description of the action'),
-      }),
-      execute: async ({ text }): Promise<string> => {
-        debugLog('cron_notes_write:scoped:execute', { jobId: job.id, runId, text });
-        notesStore.append(job.id, text, runId);
-        return `Note appended (run ${runId.slice(0, 8)}).`;
-      },
-    });
-
     const tools = {
       shell: shellTool,
       memory: createMemoryTool(memoryStore),
@@ -219,8 +186,7 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
       ...createTimeTools(),
       notify: notifyTool,
       cron_self_disable: selfDisableTool,
-      cron_notes_read: scopedNotesRead,
-      cron_notes_write: scopedNotesWrite,
+      ...createScopedCronNotesTools(notesStore, job.id, runId),
       ...mcpTools,
     };
 

--- a/src/cron/scoped-notes-tools.test.ts
+++ b/src/cron/scoped-notes-tools.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CronNotesStore } from './notes-store.js';
+import { createScopedCronNotesTools } from './scoped-notes-tools.js';
+
+function makeMockStore(): CronNotesStore {
+  return {
+    read: vi.fn().mockReturnValue({ jobId: 'job-123', entries: [] }),
+    append: vi.fn(),
+    listJobIds: vi.fn().mockReturnValue([]),
+    clear: vi.fn(),
+    entriesForRun: vi.fn().mockReturnValue([]),
+  } as unknown as CronNotesStore;
+}
+
+describe('createScopedCronNotesTools', () => {
+  const jobId = 'job-123';
+  const runId = 'run-abcdef12-3456';
+  let store: CronNotesStore;
+
+  beforeEach(() => {
+    store = makeMockStore();
+  });
+
+  it('returns both scoped tools', () => {
+    const tools = createScopedCronNotesTools(store, jobId, runId);
+
+    expect(tools).toHaveProperty('cron_notes_read');
+    expect(tools).toHaveProperty('cron_notes_write');
+  });
+
+  describe('cron_notes_write', () => {
+    it('tags appended entry with the bound jobId and runId', async () => {
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      const result = await tools.cron_notes_write.execute!(
+        { text: 'sent email' },
+        {} as any,
+      );
+
+      expect(store.append).toHaveBeenCalledWith(jobId, 'sent email', runId);
+      expect(result).toContain('Note appended');
+      expect(result).toContain(runId.slice(0, 8));
+    });
+
+    it('passes the bound runId even when multiple writes occur', async () => {
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      await tools.cron_notes_write.execute!({ text: 'first' }, {} as any);
+      await tools.cron_notes_write.execute!({ text: 'second' }, {} as any);
+
+      expect(store.append).toHaveBeenNthCalledWith(1, jobId, 'first', runId);
+      expect(store.append).toHaveBeenNthCalledWith(2, jobId, 'second', runId);
+    });
+  });
+
+  describe('cron_notes_read', () => {
+    it('reads only the bound jobId', async () => {
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      await tools.cron_notes_read.execute!({}, {} as any);
+
+      expect(store.read).toHaveBeenCalledWith(jobId);
+    });
+
+    it('returns empty-state message when no prior notes exist', async () => {
+      vi.mocked(store.read).mockReturnValue({ jobId, entries: [] });
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      const result = await tools.cron_notes_read.execute!({}, {} as any);
+
+      expect(result).toContain('No prior notes');
+    });
+
+    it('formats a single entry with singular "entry"', async () => {
+      vi.mocked(store.read).mockReturnValue({
+        jobId,
+        entries: [
+          { timestamp: '2026-04-19T10:00:00Z', text: 'sent email', runId: 'abcdef12' },
+        ],
+      });
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      const result = await tools.cron_notes_read.execute!({}, {} as any);
+
+      expect(result).toContain('1 entry');
+      expect(result).toContain('sent email');
+      expect(result).toContain('run:abcdef12');
+    });
+
+    it('formats multiple entries with plural "entries"', async () => {
+      vi.mocked(store.read).mockReturnValue({
+        jobId,
+        entries: [
+          { timestamp: '2026-04-19T10:00:00Z', text: 'a', runId: 'abcdef12' },
+          { timestamp: '2026-04-19T10:00:01Z', text: 'b', runId: 'abcdef12' },
+        ],
+      });
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      const result = await tools.cron_notes_read.execute!({}, {} as any);
+
+      expect(result).toContain('2 entries');
+      expect(result).toContain('a');
+      expect(result).toContain('b');
+    });
+
+    it('omits the run prefix for entries without a runId', async () => {
+      vi.mocked(store.read).mockReturnValue({
+        jobId,
+        entries: [{ timestamp: '2026-04-19T10:00:00Z', text: 'orphan entry' }],
+      });
+      const tools = createScopedCronNotesTools(store, jobId, runId);
+
+      const result = await tools.cron_notes_read.execute!({}, {} as any);
+
+      expect(result).toContain('orphan entry');
+      expect(result).not.toContain('run:');
+    });
+  });
+});

--- a/src/cron/scoped-notes-tools.test.ts
+++ b/src/cron/scoped-notes-tools.test.ts
@@ -32,10 +32,7 @@ describe('createScopedCronNotesTools', () => {
     it('tags appended entry with the bound jobId and runId', async () => {
       const tools = createScopedCronNotesTools(store, jobId, runId);
 
-      const result = await tools.cron_notes_write.execute!(
-        { text: 'sent email' },
-        {} as any,
-      );
+      const result = await tools.cron_notes_write.execute!({ text: 'sent email' }, {} as any);
 
       expect(store.append).toHaveBeenCalledWith(jobId, 'sent email', runId);
       expect(result).toContain('Note appended');
@@ -74,9 +71,7 @@ describe('createScopedCronNotesTools', () => {
     it('formats a single entry with singular "entry"', async () => {
       vi.mocked(store.read).mockReturnValue({
         jobId,
-        entries: [
-          { timestamp: '2026-04-19T10:00:00Z', text: 'sent email', runId: 'abcdef12' },
-        ],
+        entries: [{ timestamp: '2026-04-19T10:00:00Z', text: 'sent email', runId: 'abcdef12' }],
       });
       const tools = createScopedCronNotesTools(store, jobId, runId);
 

--- a/src/cron/scoped-notes-tools.ts
+++ b/src/cron/scoped-notes-tools.ts
@@ -1,0 +1,55 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { CronNotesStore, MAX_NOTE_LENGTH } from './notes-store.js';
+import { formatEntryCompact } from '../tools/cron-notes.js';
+import { debugLog } from '../logger.js';
+
+/**
+ * Builds `cron_notes_read` and `cron_notes_write` tools pre-scoped to a single
+ * cron job and run. The daemon runner spreads these into its tools dict so the
+ * agent sees zero/one-arg versions that cannot read or write other jobs'
+ * notes and auto-tag writes with the current `runId`.
+ */
+export function createScopedCronNotesTools(
+  notesStore: CronNotesStore,
+  jobId: string,
+  runId: string,
+) {
+  const scopedNotesRead = tool({
+    description:
+      'Read notes previously written for this cron job by prior runs. Call this before acting to avoid duplicate work.',
+    parameters: z.object({}),
+    execute: async (): Promise<string> => {
+      debugLog('cron_notes_read:scoped:execute', { jobId });
+      const notes = notesStore.read(jobId);
+      if (notes.entries.length === 0) {
+        return `No prior notes for this job.`;
+      }
+      const label = notes.entries.length === 1 ? 'entry' : 'entries';
+      const lines = notes.entries.map(formatEntryCompact);
+      return `Prior notes (${notes.entries.length} ${label}):\n${lines.join('\n')}`;
+    },
+  });
+
+  const scopedNotesWrite = tool({
+    description:
+      "Append a short factual note recording a significant action this run took (e.g. 'Sent email to user@example.com', 'Created issue #123'). Keep it to one line.",
+    parameters: z.object({
+      text: z
+        .string()
+        .min(1)
+        .max(MAX_NOTE_LENGTH)
+        .describe('Short factual description of the action'),
+    }),
+    execute: async ({ text }): Promise<string> => {
+      debugLog('cron_notes_write:scoped:execute', { jobId, runId, text });
+      notesStore.append(jobId, text, runId);
+      return `Note appended (run ${runId.slice(0, 8)}).`;
+    },
+  });
+
+  return {
+    cron_notes_read: scopedNotesRead,
+    cron_notes_write: scopedNotesWrite,
+  };
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -38,6 +38,7 @@ export const LAST_SESSION_FILE = path.join(RAG_DIR, 'last-session.txt');
 export const CRON_DIR = path.join(DATA_DIR, 'cron');
 export const CRON_JOBS_FILE = path.join(CRON_DIR, 'jobs.json');
 export const CRON_ALERTS_DIR = path.join(CRON_DIR, 'alerts');
+export const CRON_NOTES_DIR = path.join(CRON_DIR, 'notes');
 export const ROUTINES_DIR = path.join(DATA_DIR, 'routines');
 export const SPECIALISTS_DIR = path.join(DATA_DIR, 'specialists');
 export const SPECIALIST_CANDIDATES_DIR = path.join(DATA_DIR, 'specialist-candidates');

--- a/src/tools/cron-logs.test.ts
+++ b/src/tools/cron-logs.test.ts
@@ -12,8 +12,16 @@ const mockLogStore = {
   deleteJobLogs: vi.fn(),
 };
 
+const mockNotesStore = {
+  entriesForRun: vi.fn().mockReturnValue([]),
+};
+
 vi.mock('../cron/log-store.js', () => ({
   CronLogStore: vi.fn(() => mockLogStore),
+}));
+
+vi.mock('../cron/notes-store.js', () => ({
+  CronNotesStore: vi.fn(() => mockNotesStore),
 }));
 
 import { createCronLogTools } from './cron-logs.js';
@@ -150,6 +158,38 @@ describe('cron log tools', () => {
 
       expect(result).toContain('Status: error');
       expect(result).toContain('Error: API timeout');
+    });
+
+    it('appends "Notes written during this run" section when notes exist for the run', async () => {
+      const entry = makeEntry();
+      mockLogStore.getEntry.mockReturnValue(entry);
+      mockNotesStore.entriesForRun.mockReturnValue([
+        { timestamp: '2025-01-01T00:00:00.500Z', text: 'sent email', runId: 'run-1' },
+        { timestamp: '2025-01-01T00:00:00.600Z', text: 'created issue #42', runId: 'run-1' },
+      ]);
+
+      const result = await tools.cron_logs_get.execute!(
+        { job_id: 'job-1', run_id: 'run-1' },
+        {} as any,
+      );
+
+      expect(mockNotesStore.entriesForRun).toHaveBeenCalledWith('job-1', 'run-1');
+      expect(result).toContain('## Notes written during this run');
+      expect(result).toContain('sent email');
+      expect(result).toContain('created issue #42');
+    });
+
+    it('omits notes section when no notes exist for the run', async () => {
+      const entry = makeEntry();
+      mockLogStore.getEntry.mockReturnValue(entry);
+      mockNotesStore.entriesForRun.mockReturnValue([]);
+
+      const result = await tools.cron_logs_get.execute!(
+        { job_id: 'job-1', run_id: 'run-1' },
+        {} as any,
+      );
+
+      expect(result).not.toContain('Notes written during this run');
     });
 
     it('truncates long tool results', async () => {

--- a/src/tools/cron-logs.ts
+++ b/src/tools/cron-logs.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { CronLogStore } from '../cron/log-store.js';
+import { CronNotesStore } from '../cron/notes-store.js';
 import { debugLog } from '../logger.js';
 
 /**
@@ -11,6 +12,7 @@ import { debugLog } from '../logger.js';
  */
 export function createCronLogTools() {
   const logStore = new CronLogStore();
+  const notesStore = new CronNotesStore();
 
   return {
     cron_logs_list: tool({
@@ -85,6 +87,13 @@ export function createCronLogTools() {
         }
 
         result += `\n--- Final Output ---\n${entry.finalOutput}`;
+
+        const notes = notesStore.entriesForRun(job_id, run_id);
+        if (notes.length > 0) {
+          result += `\n\n## Notes written during this run\n`;
+          result += notes.map((n) => `- ${n.timestamp} — ${n.text}`).join('\n');
+        }
+
         return result;
       },
     }),

--- a/src/tools/cron-notes.test.ts
+++ b/src/tools/cron-notes.test.ts
@@ -82,11 +82,8 @@ describe('cron notes tools', () => {
   });
 
   describe('cron_notes_write', () => {
-    it('appends note and returns confirmation', async () => {
-      mockNotesStore.read.mockReturnValue({
-        jobId: 'job-1',
-        entries: [makeEntry(), makeEntry()],
-      });
+    it('appends note and returns confirmation with the total from append', async () => {
+      mockNotesStore.append.mockReturnValue({ entry: makeEntry(), total: 2 });
 
       const result = await tools.cron_notes_write.execute!(
         { job_id: 'job-1', text: 'sent weekly summary' },
@@ -94,6 +91,7 @@ describe('cron notes tools', () => {
       );
 
       expect(mockNotesStore.append).toHaveBeenCalledWith('job-1', 'sent weekly summary');
+      expect(mockNotesStore.read).not.toHaveBeenCalled();
       expect(result).toContain('Appended note');
       expect(result).toContain('2 entries');
     });
@@ -113,7 +111,7 @@ describe('cron notes tools', () => {
     });
 
     it('accepts text exactly at the 1000 char limit', async () => {
-      mockNotesStore.read.mockReturnValue({ jobId: 'job-1', entries: [makeEntry()] });
+      mockNotesStore.append.mockReturnValue({ entry: makeEntry(), total: 1 });
       const text = 'x'.repeat(1000);
 
       const result = await tools.cron_notes_write.execute!(

--- a/src/tools/cron-notes.test.ts
+++ b/src/tools/cron-notes.test.ts
@@ -114,10 +114,7 @@ describe('cron notes tools', () => {
       mockNotesStore.append.mockReturnValue({ entry: makeEntry(), total: 1 });
       const text = 'x'.repeat(1000);
 
-      const result = await tools.cron_notes_write.execute!(
-        { job_id: 'job-1', text },
-        {} as any,
-      );
+      const result = await tools.cron_notes_write.execute!({ job_id: 'job-1', text }, {} as any);
 
       expect(mockNotesStore.append).toHaveBeenCalledWith('job-1', text);
       expect(result).toContain('Appended note');

--- a/src/tools/cron-notes.test.ts
+++ b/src/tools/cron-notes.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CronNoteEntry } from '../cron/notes-store.js';
+
+// --- Mocks ---
+
+const mockNotesStore = {
+  read: vi.fn(),
+  append: vi.fn(),
+  listJobIds: vi.fn(),
+  clear: vi.fn(),
+  entriesForRun: vi.fn(),
+};
+
+const mockCronStore = {
+  getJob: vi.fn(),
+};
+
+vi.mock('../cron/notes-store.js', () => ({
+  CronNotesStore: vi.fn(() => mockNotesStore),
+  MAX_NOTE_LENGTH: 1000,
+}));
+
+vi.mock('../cron/store.js', () => ({
+  CronStore: vi.fn(() => mockCronStore),
+}));
+
+import { createCronNotesTools } from './cron-notes.js';
+
+function makeEntry(overrides: Partial<CronNoteEntry> = {}): CronNoteEntry {
+  return {
+    timestamp: '2025-01-01T00:00:00.000Z',
+    text: 'sent email',
+    ...overrides,
+  };
+}
+
+describe('cron notes tools', () => {
+  let tools: ReturnType<typeof createCronNotesTools>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNotesStore.read.mockReturnValue({ jobId: 'job-1', entries: [] });
+    mockNotesStore.listJobIds.mockReturnValue([]);
+    mockCronStore.getJob.mockReturnValue(undefined);
+    tools = createCronNotesTools();
+  });
+
+  describe('cron_notes_read', () => {
+    it('returns message when no notes exist', async () => {
+      mockNotesStore.read.mockReturnValue({ jobId: 'job-1', entries: [] });
+
+      const result = await tools.cron_notes_read.execute!({ job_id: 'job-1' }, {} as any);
+
+      expect(result).toContain('No notes recorded');
+      expect(result).toContain('job-1');
+    });
+
+    it('formats entries with timestamp and text', async () => {
+      mockNotesStore.read.mockReturnValue({
+        jobId: 'job-1',
+        entries: [makeEntry({ text: 'created issue #42' })],
+      });
+
+      const result = await tools.cron_notes_read.execute!({ job_id: 'job-1' }, {} as any);
+
+      expect(result).toContain('1 entry');
+      expect(result).toContain('2025-01-01T00:00:00.000Z');
+      expect(result).toContain('created issue #42');
+    });
+
+    it('includes truncated runId when present', async () => {
+      mockNotesStore.read.mockReturnValue({
+        jobId: 'job-1',
+        entries: [makeEntry({ runId: 'abcdef12-3456-7890' })],
+      });
+
+      const result = await tools.cron_notes_read.execute!({ job_id: 'job-1' }, {} as any);
+
+      expect(result).toContain('run:abcdef12');
+      expect(result).not.toContain('abcdef12-3456-7890');
+    });
+  });
+
+  describe('cron_notes_write', () => {
+    it('appends note and returns confirmation', async () => {
+      mockNotesStore.read.mockReturnValue({
+        jobId: 'job-1',
+        entries: [makeEntry(), makeEntry()],
+      });
+
+      const result = await tools.cron_notes_write.execute!(
+        { job_id: 'job-1', text: 'sent weekly summary' },
+        {} as any,
+      );
+
+      expect(mockNotesStore.append).toHaveBeenCalledWith('job-1', 'sent weekly summary');
+      expect(result).toContain('Appended note');
+      expect(result).toContain('2 entries');
+    });
+
+    it('rejects text exceeding 1000 characters', async () => {
+      const longText = 'x'.repeat(1001);
+
+      const result = await tools.cron_notes_write.execute!(
+        { job_id: 'job-1', text: longText },
+        {} as any,
+      );
+
+      expect(result).toContain('Error:');
+      expect(result).toContain('1000');
+      expect(result).toContain('1001');
+      expect(mockNotesStore.append).not.toHaveBeenCalled();
+    });
+
+    it('accepts text exactly at the 1000 char limit', async () => {
+      mockNotesStore.read.mockReturnValue({ jobId: 'job-1', entries: [makeEntry()] });
+      const text = 'x'.repeat(1000);
+
+      const result = await tools.cron_notes_write.execute!(
+        { job_id: 'job-1', text },
+        {} as any,
+      );
+
+      expect(mockNotesStore.append).toHaveBeenCalledWith('job-1', text);
+      expect(result).toContain('Appended note');
+    });
+  });
+
+  describe('cron_notes_list', () => {
+    it('returns message when no jobs have notes', async () => {
+      mockNotesStore.listJobIds.mockReturnValue([]);
+
+      const result = await tools.cron_notes_list.execute!({}, {} as any);
+
+      expect(result).toContain('No cron jobs have notes');
+    });
+
+    it('lists job ids with entry counts', async () => {
+      mockNotesStore.listJobIds.mockReturnValue(['job-a', 'job-b']);
+      mockNotesStore.read
+        .mockReturnValueOnce({ jobId: 'job-a', entries: [makeEntry(), makeEntry()] })
+        .mockReturnValueOnce({ jobId: 'job-b', entries: [makeEntry()] });
+
+      const result = await tools.cron_notes_list.execute!({}, {} as any);
+
+      expect(result).toContain('job-a');
+      expect(result).toContain('2 entries');
+      expect(result).toContain('job-b');
+      expect(result).toContain('1 entry');
+    });
+
+    it('enriches job ids with names when CronStore knows them', async () => {
+      mockNotesStore.listJobIds.mockReturnValue(['job-a']);
+      mockNotesStore.read.mockReturnValue({ jobId: 'job-a', entries: [makeEntry()] });
+      mockCronStore.getJob.mockReturnValue({ id: 'job-a', name: 'Daily summary' });
+
+      const result = await tools.cron_notes_list.execute!({}, {} as any);
+
+      expect(result).toContain('job-a (Daily summary)');
+    });
+  });
+
+  describe('cron_notes_view', () => {
+    it('returns message when no notes exist', async () => {
+      mockNotesStore.read.mockReturnValue({ jobId: 'job-1', entries: [] });
+
+      const result = await tools.cron_notes_view.execute!({ job_id: 'job-1' }, {} as any);
+
+      expect(result).toContain('No notes recorded');
+    });
+
+    it('formats entries in human-friendly blocks', async () => {
+      mockNotesStore.read.mockReturnValue({
+        jobId: 'job-1',
+        entries: [
+          makeEntry({ text: 'first entry' }),
+          makeEntry({ text: 'second entry', runId: 'abcdef12-3456' }),
+        ],
+      });
+
+      const result = await tools.cron_notes_view.execute!({ job_id: 'job-1' }, {} as any);
+
+      expect(result).toContain('2 entries');
+      expect(result).toContain('first entry');
+      expect(result).toContain('second entry');
+      expect(result).toContain('(run abcdef12)');
+      // view uses bullet format, distinct from read's compact brackets
+      expect(result).toContain('•');
+    });
+
+    it('uses job name in header when available', async () => {
+      mockNotesStore.read.mockReturnValue({
+        jobId: 'job-1',
+        entries: [makeEntry()],
+      });
+      mockCronStore.getJob.mockReturnValue({ id: 'job-1', name: 'Daily summary' });
+
+      const result = await tools.cron_notes_view.execute!({ job_id: 'job-1' }, {} as any);
+
+      expect(result).toContain('Daily summary');
+      expect(result).toContain('job-1');
+    });
+  });
+});

--- a/src/tools/cron-notes.ts
+++ b/src/tools/cron-notes.ts
@@ -97,7 +97,7 @@ export function createCronNotesTools() {
 
     cron_notes_view: tool({
       description:
-        'View a cron job\'s persistent notes formatted for human reading (one entry per block). Prefer cron_notes_read for programmatic consumption.',
+        "View a cron job's persistent notes formatted for human reading (one entry per block). Prefer cron_notes_read for programmatic consumption.",
       parameters: z.object({
         job_id: z.string().describe('Job ID to view notes for'),
       }),

--- a/src/tools/cron-notes.ts
+++ b/src/tools/cron-notes.ts
@@ -63,8 +63,7 @@ export function createCronNotesTools() {
           return `Error: note text exceeds ${MAX_NOTE_LENGTH} characters (got ${text.length}). Summarize first.`;
         }
 
-        notesStore.append(job_id, text);
-        const total = notesStore.read(job_id).entries.length;
+        const { total } = notesStore.append(job_id, text);
         return `Appended note to job "${job_id}" (${pluralizeEntries(total)} total).`;
       },
     }),

--- a/src/tools/cron-notes.ts
+++ b/src/tools/cron-notes.ts
@@ -32,7 +32,7 @@ export function createCronNotesTools() {
   return {
     cron_notes_read: tool({
       description:
-        'Read all persistent notes for a cron job. Returns structured output of every note entry (timestamp, optional runId, text). Notes persist across daemon restarts and record actions prior runs took.',
+        'Read all persistent notes for a cron job. Returns a human-readable formatted list of note entries including timestamp, optional runId, and text. Notes persist across daemon restarts and record actions prior runs took.',
       parameters: z.object({
         job_id: z.string().describe('Job ID to read notes for'),
       }),
@@ -54,7 +54,11 @@ export function createCronNotesTools() {
         'Append a persistent note to a cron job. Use short factual entries recording significant actions (e.g. "Sent email to user@example.com", "Created issue #123"). Notes persist across daemon restarts.',
       parameters: z.object({
         job_id: z.string().describe('Job ID to attach the note to'),
-        text: z.string().min(1).describe('Short factual description of the action'),
+        text: z
+          .string()
+          .min(1)
+          .max(MAX_NOTE_LENGTH)
+          .describe('Short factual description of the action'),
       }),
       execute: async ({ job_id, text }): Promise<string> => {
         debugLog('cron_notes_write:execute', { job_id, text });

--- a/src/tools/cron-notes.ts
+++ b/src/tools/cron-notes.ts
@@ -1,0 +1,118 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { CronNotesStore, MAX_NOTE_LENGTH, type CronNoteEntry } from '../cron/notes-store.js';
+import { CronStore } from '../cron/store.js';
+import { debugLog } from '../logger.js';
+
+function pluralizeEntries(n: number): string {
+  return `${n} ${n === 1 ? 'entry' : 'entries'}`;
+}
+
+export function formatEntryCompact(e: CronNoteEntry): string {
+  const run = e.runId ? ` run:${e.runId.slice(0, 8)}` : '';
+  return `  [${e.timestamp}${run}] ${e.text}`;
+}
+
+function formatEntryView(e: CronNoteEntry): string {
+  const run = e.runId ? ` (run ${e.runId.slice(0, 8)})` : '';
+  return `• ${e.timestamp}${run}\n    ${e.text}`;
+}
+
+/**
+ * Creates tools for reading and maintaining persistent per-job cron notes.
+ *
+ * All tools take a `job_id` parameter. In daemon runs, these globals are
+ * overridden by job-scoped closures in {@link ../cron/runner} that auto-tag
+ * writes with the current runId; see runner.ts for the self-scoped variants.
+ */
+export function createCronNotesTools() {
+  const notesStore = new CronNotesStore();
+  const cronStore = new CronStore();
+
+  return {
+    cron_notes_read: tool({
+      description:
+        'Read all persistent notes for a cron job. Returns structured output of every note entry (timestamp, optional runId, text). Notes persist across daemon restarts and record actions prior runs took.',
+      parameters: z.object({
+        job_id: z.string().describe('Job ID to read notes for'),
+      }),
+      execute: async ({ job_id }): Promise<string> => {
+        debugLog('cron_notes_read:execute', { job_id });
+
+        const notes = notesStore.read(job_id);
+        if (notes.entries.length === 0) {
+          return `No notes recorded for job "${job_id}".`;
+        }
+
+        const lines = notes.entries.map(formatEntryCompact);
+        return `Notes for job "${job_id}" (${pluralizeEntries(notes.entries.length)}):\n${lines.join('\n')}`;
+      },
+    }),
+
+    cron_notes_write: tool({
+      description:
+        'Append a persistent note to a cron job. Use short factual entries recording significant actions (e.g. "Sent email to user@example.com", "Created issue #123"). Notes persist across daemon restarts.',
+      parameters: z.object({
+        job_id: z.string().describe('Job ID to attach the note to'),
+        text: z.string().min(1).describe('Short factual description of the action'),
+      }),
+      execute: async ({ job_id, text }): Promise<string> => {
+        debugLog('cron_notes_write:execute', { job_id, text });
+
+        if (text.length > MAX_NOTE_LENGTH) {
+          return `Error: note text exceeds ${MAX_NOTE_LENGTH} characters (got ${text.length}). Summarize first.`;
+        }
+
+        notesStore.append(job_id, text);
+        const total = notesStore.read(job_id).entries.length;
+        return `Appended note to job "${job_id}" (${pluralizeEntries(total)} total).`;
+      },
+    }),
+
+    cron_notes_list: tool({
+      description:
+        'List all cron jobs that have persistent notes, with an entry count per job. Use to discover which jobs are tracking state.',
+      parameters: z.object({}),
+      execute: async (): Promise<string> => {
+        debugLog('cron_notes_list:execute', {});
+
+        const jobIds = notesStore.listJobIds();
+        if (jobIds.length === 0) {
+          return 'No cron jobs have notes yet.';
+        }
+
+        const lines = jobIds.map((id) => {
+          const job = cronStore.getJob(id);
+          const label = job ? `${id} (${job.name})` : id;
+          const count = notesStore.read(id).entries.length;
+          return `  ${label}: ${pluralizeEntries(count)}`;
+        });
+
+        return `Jobs with notes:\n${lines.join('\n')}`;
+      },
+    }),
+
+    cron_notes_view: tool({
+      description:
+        'View a cron job\'s persistent notes formatted for human reading (one entry per block). Prefer cron_notes_read for programmatic consumption.',
+      parameters: z.object({
+        job_id: z.string().describe('Job ID to view notes for'),
+      }),
+      execute: async ({ job_id }): Promise<string> => {
+        debugLog('cron_notes_view:execute', { job_id });
+
+        const notes = notesStore.read(job_id);
+        if (notes.entries.length === 0) {
+          return `No notes recorded for job "${job_id}".`;
+        }
+
+        const job = cronStore.getJob(job_id);
+        const header = job
+          ? `Notes for "${job.name}" (${job_id}) — ${pluralizeEntries(notes.entries.length)}`
+          : `Notes for job ${job_id} — ${pluralizeEntries(notes.entries.length)}`;
+        const body = notes.entries.map(formatEntryView).join('\n\n');
+        return `${header}\n\n${body}`;
+      },
+    }),
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import { createMemoryTool, createScratchTool } from './memory.js';
 import { createDateTimeTool } from './datetime.js';
 import { createCronTools } from './cron.js';
 import { createCronLogTools } from './cron-logs.js';
+import { createCronNotesTools } from './cron-notes.js';
 import { createTimeTools } from './time.js';
 import { createMCPConfigTool } from './mcp.js';
 import { createMCPAddUrlTool } from './mcp-url.js';
@@ -48,6 +49,7 @@ export function createTools(
     datetime: createDateTimeTool(),
     ...createCronTools(),
     ...createCronLogTools(),
+    ...createCronNotesTools(),
     ...createTimeTools(),
     mcp_config: createMCPConfigTool(),
     mcp_add_url: createMCPAddUrlTool(),


### PR DESCRIPTION
Introduces a comprehensive notes system for cron jobs that persists across daemon restarts and helps prevent duplicate work:

- **State persistence**: Notes survive daemon restarts, allowing jobs to track what previous runs accomplished
- **Duplicate prevention**: Jobs can check prior notes before taking action to avoid repeating work like sending emails or creating issues
- **Scoped access**: Running jobs get auto-scoped read/write tools that tag entries with the current run ID
- **Bounded storage**: Caps entries at 100 per job with automatic cleanup of oldest entries
- **Atomic operations**: Uses atomic writes to prevent corruption during concurrent access

The system includes both global tools for managing notes across all jobs and scoped variants injected during job execution. Notes are stored as JSON files with timestamps and optional run IDs for easy debugging.

Closes #104