### PR TITLE
Replaces numbered menus with interactive arrow-key selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ bernard -p openai -m gpt-4o  # Use specific provider/model
 - **src/agent.ts** — Agent loop using AI SDK `generateText` + `maxSteps` + auto-continue on truncation + optional critic verification
 - **src/config.ts** — .env loading, defaults, validation
 - **src/output.ts** — Chalk-based terminal formatting
-- **src/menu.ts** — Reusable numbered-list selection UI (`printMenuList`, `selectFromMenu`, `promptValue`) with Escape/Enter-to-cancel support
+- **src/menu.ts** — Ephemeral arrow-key selection UI rendered via `setPinnedRegion('menu', ...)` (`selectFromMenu`, `promptValue`). Arrow keys move the highlight; Enter commits; Esc/q/Ctrl-C cancel; digits 1-9 commit immediately. Non-TTY or `BERNARD_PLAIN_MENU=1` falls back to a numbered-list + `rl.question` path.
 - **src/theme.ts** — Color theme definitions (bernard, ocean, forest, synthwave, high-contrast, colorblind)
 - **src/domains.ts** — Memory domain registry (tool-usage, user-preferences, general) with specialized extraction prompts
 - **src/routines.ts** — RoutineStore class: per-file JSON storage for named multi-step workflows

--- a/src/menu.test.ts
+++ b/src/menu.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import {
   countMenuItems,
   getMenuItem,
-  printMenuList,
   selectFromMenu,
   promptValue,
+  MENU_REGION_ID,
   type MenuEntry,
 } from './menu.js';
 
@@ -13,22 +13,42 @@ import {
 
 const mockPrintInfo = vi.fn();
 const mockPrintDim = vi.fn();
+const mockSetPinnedRegion = vi.fn();
+const mockClearPinnedRegion = vi.fn();
 vi.mock('./output.js', () => ({
   printInfo: (...args: any[]) => mockPrintInfo(...args),
   printDim: (...args: any[]) => mockPrintDim(...args),
+  setPinnedRegion: (...args: any[]) => mockSetPinnedRegion(...args),
+  clearPinnedRegion: (...args: any[]) => mockClearPinnedRegion(...args),
 }));
 
 vi.mock('./theme.js', () => ({
   getTheme: () => ({
     ansi: { prompt: '', reset: '' },
+    accent: (s: string) => s,
+    accentBold: (s: string) => s,
+    muted: (s: string) => s,
+    dim: (s: string) => s,
   }),
 }));
+
+// readline.emitKeypressEvents has real side effects on process.stdin
+// (attaches data listeners). Neutralize it so tests emit 'keypress' directly.
+vi.mock('node:readline', async () => {
+  const actual = await vi.importActual<typeof import('node:readline')>('node:readline');
+  return {
+    ...actual,
+    emitKeypressEvents: vi.fn(),
+  };
+});
 
 // ── Helpers ──────────────────────────────────────────────
 
 function makeRl() {
   const emitter = new EventEmitter() as any;
   emitter.question = vi.fn();
+  emitter.pause = vi.fn();
+  emitter.resume = vi.fn();
   return emitter;
 }
 
@@ -42,11 +62,6 @@ const groupedEntries: MenuEntry[] = [
   { type: 'section', title: 'Cool colors:' },
   { label: 'Blue', value: 'b' },
   { label: 'Purple', annotation: '(new)', value: 'p' },
-];
-
-const entriesWithDescription: MenuEntry[] = [
-  { label: 'max-tokens', annotation: '= 4096 (default)', description: 'Max response tokens' },
-  { label: 'shell-timeout', annotation: '= 30000 (custom)', description: 'Shell command timeout' },
 ];
 
 // ── Tests ────────────────────────────────────────────────
@@ -85,49 +100,25 @@ describe('getMenuItem', () => {
   });
 });
 
-describe('printMenuList', () => {
-  beforeEach(() => {
-    mockPrintInfo.mockClear();
-    mockPrintDim.mockClear();
-  });
+// ── selectFromMenu: fallback (non-TTY / BERNARD_PLAIN_MENU) ─
 
-  it('prints numbered items', () => {
-    printMenuList(simpleEntries);
-    expect(mockPrintInfo).toHaveBeenCalledWith('    1. Alpha');
-    expect(mockPrintInfo).toHaveBeenCalledWith('    2. Beta');
-    expect(mockPrintInfo).toHaveBeenCalledWith('    3. Gamma');
-  });
-
-  it('prints section headers without consuming a number', () => {
-    printMenuList(groupedEntries);
-    const calls = mockPrintInfo.mock.calls.map((c) => c[0]);
-    expect(calls).toContain('\n  Cool colors:');
-    expect(calls).toContain('    1. Red (active)');
-    expect(calls).toContain('    2. Green');
-    expect(calls).toContain('    3. Blue');
-    expect(calls).toContain('    4. Purple (new)');
-  });
-
-  it('prints descriptions on a second line via printDim (dimmer than labels)', () => {
-    printMenuList(entriesWithDescription);
-    expect(mockPrintDim).toHaveBeenCalledWith('       Max response tokens');
-    expect(mockPrintDim).toHaveBeenCalledWith('       Shell command timeout');
-    // Descriptions must not land on printInfo (same color as labels defeats the purpose).
-    expect(mockPrintInfo).not.toHaveBeenCalledWith('       Max response tokens');
-  });
-
-  it('handles empty entries without error', () => {
-    printMenuList([]);
-    expect(mockPrintInfo).not.toHaveBeenCalled();
-  });
-});
-
-describe('selectFromMenu', () => {
+describe('selectFromMenu (fallback path)', () => {
   let rl: any;
+  let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
     rl = makeRl();
     mockPrintInfo.mockClear();
+    mockPrintDim.mockClear();
+    originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
   });
 
   it('returns the selected item on valid input', async () => {
@@ -154,29 +145,24 @@ describe('selectFromMenu', () => {
 
   it('returns cancelled on non-numeric input', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('abc'));
-
     const result = await selectFromMenu(rl, simpleEntries);
     expect(result).toEqual({ cancelled: true });
   });
 
   it('returns cancelled on out-of-range input (too high)', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('99'));
-
     const result = await selectFromMenu(rl, simpleEntries);
     expect(result).toEqual({ cancelled: true });
   });
 
   it('returns cancelled on out-of-range input (zero)', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('0'));
-
     const result = await selectFromMenu(rl, simpleEntries);
     expect(result).toEqual({ cancelled: true });
   });
 
   it('skips section entries when resolving index', async () => {
-    // groupedEntries has: Red(0), Green(1), [section], Blue(2), Purple(3)
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('3'));
-
     const result = await selectFromMenu(rl, groupedEntries);
     expect(result).toEqual({
       cancelled: false,
@@ -187,16 +173,21 @@ describe('selectFromMenu', () => {
 
   it('uses custom promptLabel', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('1'));
-
     await selectFromMenu(rl, simpleEntries, { promptLabel: 'Pick one' });
     const promptStr = rl.question.mock.calls[0][0] as string;
     expect(promptStr).toContain('Pick one');
   });
 
+  it('renders title when provided', async () => {
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1](''));
+    await selectFromMenu(rl, simpleEntries, { title: 'My Menu' });
+    const calls = mockPrintInfo.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((c) => c.includes('My Menu'))).toBe(true);
+  });
+
   it('returns cancelled on pre-aborted signal', async () => {
     const ac = new AbortController();
     ac.abort();
-
     const result = await selectFromMenu(rl, simpleEntries, {}, ac.signal);
     expect(result).toEqual({ cancelled: true });
     expect(rl.question).not.toHaveBeenCalled();
@@ -204,17 +195,196 @@ describe('selectFromMenu', () => {
 
   it('returns cancelled when signal is aborted during prompt', async () => {
     const ac = new AbortController();
-
-    // Don't call callback immediately — simulate waiting for user input
     rl.question.mockImplementation(() => {});
-
     const resultPromise = selectFromMenu(rl, simpleEntries, {}, ac.signal);
-
-    // Abort while "waiting"
     ac.abort();
-
     const result = await resultPromise;
     expect(result).toEqual({ cancelled: true });
+  });
+});
+
+// ── selectFromMenu: interactive TTY path ─────────────────
+
+describe('selectFromMenu (interactive path)', () => {
+  let rl: any;
+  let originalIsTTY: boolean | undefined;
+  let originalSetRawMode: any;
+  let originalIsRaw: any;
+  let originalPlainMenu: string | undefined;
+
+  beforeEach(() => {
+    rl = makeRl();
+    mockPrintInfo.mockClear();
+    mockSetPinnedRegion.mockClear();
+    mockClearPinnedRegion.mockClear();
+
+    originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    originalPlainMenu = process.env.BERNARD_PLAIN_MENU;
+    delete process.env.BERNARD_PLAIN_MENU;
+
+    originalSetRawMode = (process.stdin as any).setRawMode;
+    (process.stdin as any).setRawMode = vi.fn();
+    originalIsRaw = (process.stdin as any).isRaw;
+    (process.stdin as any).isRaw = false;
+  });
+
+  afterEach(() => {
+    // Menu code owns the 'keypress' listener lifecycle; just in case a test
+    // leaks one, clean up the ones our test added.
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    if (originalPlainMenu !== undefined) process.env.BERNARD_PLAIN_MENU = originalPlainMenu;
+    (process.stdin as any).setRawMode = originalSetRawMode;
+    (process.stdin as any).isRaw = originalIsRaw;
+  });
+
+  // Wait a microtask so the menu's `repaint()` and keypress handler register
+  // before we synthesize input.
+  const tick = () => new Promise((r) => setImmediate(r));
+
+  it('commits the highlighted item on Enter', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '', { name: 'return' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: false, index: 0, item: { label: 'Alpha' } });
+    expect(mockPrintInfo).toHaveBeenCalledWith('  Selected: Alpha');
+  });
+
+  it('down-arrow then Enter selects the next item', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '', { name: 'down' });
+    process.stdin.emit('keypress', '', { name: 'return' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: false, index: 1, item: { label: 'Beta' } });
+  });
+
+  it('up-arrow clamps at the first item', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '', { name: 'up' });
+    process.stdin.emit('keypress', '', { name: 'up' });
+    process.stdin.emit('keypress', '', { name: 'return' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: false, index: 0, item: { label: 'Alpha' } });
+  });
+
+  it('down-arrow clamps at the last item', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    for (let i = 0; i < 10; i++) process.stdin.emit('keypress', '', { name: 'down' });
+    process.stdin.emit('keypress', '', { name: 'return' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: false, index: 2, item: { label: 'Gamma' } });
+  });
+
+  it('arrow navigation skips over sections implicitly (index counts only items)', async () => {
+    // groupedEntries items in order: Red, Green, Blue, Purple. Press down
+    // twice to land on Blue (item index 2).
+    const resultPromise = selectFromMenu(rl, groupedEntries);
+    await tick();
+    process.stdin.emit('keypress', '', { name: 'down' });
+    process.stdin.emit('keypress', '', { name: 'down' });
+    process.stdin.emit('keypress', '', { name: 'return' });
+    const result = await resultPromise;
+    expect(result.cancelled).toBe(false);
+    if (!result.cancelled) expect(result.item.label).toBe('Blue');
+  });
+
+  it('Escape cancels', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '', { name: 'escape' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: true });
+    // No "Selected:" line on cancel.
+    expect(mockPrintInfo).not.toHaveBeenCalledWith(expect.stringContaining('Selected:'));
+  });
+
+  it('q cancels', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', 'q', { name: 'q' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('Ctrl-C cancels', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '', { ctrl: true, name: 'c' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('digits 1-9 commit the corresponding item immediately', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '3', { name: '3' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: false, index: 2, item: { label: 'Gamma' } });
+  });
+
+  it('ignores digits beyond the item count', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries);
+    await tick();
+    process.stdin.emit('keypress', '9', { name: '9' }); // only 3 items
+    // Still waiting — commit with Enter.
+    process.stdin.emit('keypress', '', { name: 'return' });
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: false, index: 0, item: { label: 'Alpha' } });
+  });
+
+  it('pre-aborted signal short-circuits without entering raw mode', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const result = await selectFromMenu(rl, simpleEntries, {}, ac.signal);
+    expect(result).toEqual({ cancelled: true });
+    expect((process.stdin as any).setRawMode).not.toHaveBeenCalled();
+    expect(mockSetPinnedRegion).not.toHaveBeenCalled();
+  });
+
+  it('external signal abort cancels the menu', async () => {
+    const ac = new AbortController();
+    const resultPromise = selectFromMenu(rl, simpleEntries, {}, ac.signal);
+    await tick();
+    ac.abort();
+    const result = await resultPromise;
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('pins a menu region and clears it on exit', async () => {
+    const resultPromise = selectFromMenu(rl, simpleEntries, { title: 'Pick' });
+    await tick();
+    expect(mockSetPinnedRegion).toHaveBeenCalledWith(MENU_REGION_ID, expect.any(Array));
+    const lines = mockSetPinnedRegion.mock.calls[0][1] as string[];
+    expect(lines.some((l) => l.includes('Pick'))).toBe(true);
+    expect(lines.some((l) => l.includes('Alpha'))).toBe(true);
+    process.stdin.emit('keypress', '', { name: 'return' });
+    await resultPromise;
+    expect(mockClearPinnedRegion).toHaveBeenCalledWith(MENU_REGION_ID);
+  });
+
+  it('returns cancelled when entries have no selectable items', async () => {
+    const noItems: MenuEntry[] = [{ type: 'section', title: 'Header only' }];
+    const result = await selectFromMenu(rl, noItems);
+    expect(result).toEqual({ cancelled: true });
+    // No pin/raw-mode either.
+    expect(mockSetPinnedRegion).not.toHaveBeenCalled();
+    expect((process.stdin as any).setRawMode).not.toHaveBeenCalled();
+  });
+
+  it('BERNARD_PLAIN_MENU=1 forces the fallback path', async () => {
+    process.env.BERNARD_PLAIN_MENU = '1';
+    rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('2'));
+    const result = await selectFromMenu(rl, simpleEntries);
+    expect(result).toEqual({ cancelled: false, index: 1, item: { label: 'Beta' } });
+    // Interactive path would have called setRawMode; fallback path should not.
+    expect((process.stdin as any).setRawMode).not.toHaveBeenCalled();
   });
 });
 
@@ -228,14 +398,12 @@ describe('promptValue', () => {
 
   it('returns the raw value on non-empty input', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('  42  '));
-
     const result = await promptValue(rl, { label: 'Enter value' });
     expect(result).toEqual({ cancelled: false, raw: '42' });
   });
 
   it('returns cancelled on empty input', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1](''));
-
     const result = await promptValue(rl, { label: 'Enter value' });
     expect(result).toEqual({ cancelled: true });
     expect(mockPrintInfo).toHaveBeenCalledWith('  Cancelled.');
@@ -244,7 +412,6 @@ describe('promptValue', () => {
   it('returns cancelled on pre-aborted signal', async () => {
     const ac = new AbortController();
     ac.abort();
-
     const result = await promptValue(rl, { label: 'Enter value' }, ac.signal);
     expect(result).toEqual({ cancelled: true });
     expect(rl.question).not.toHaveBeenCalled();
@@ -253,17 +420,14 @@ describe('promptValue', () => {
   it('returns cancelled when signal is aborted during prompt', async () => {
     const ac = new AbortController();
     rl.question.mockImplementation(() => {});
-
     const resultPromise = promptValue(rl, { label: 'Enter value' }, ac.signal);
     ac.abort();
-
     const result = await resultPromise;
     expect(result).toEqual({ cancelled: true });
   });
 
   it('includes label in prompt string', async () => {
     rl.question.mockImplementation((...args: any[]) => args[args.length - 1]('x'));
-
     await promptValue(rl, { label: 'New threshold' });
     const promptStr = rl.question.mock.calls[0][0] as string;
     expect(promptStr).toContain('New threshold');

--- a/src/menu.test.ts
+++ b/src/menu.test.ts
@@ -5,6 +5,8 @@ import {
   getMenuItem,
   selectFromMenu,
   promptValue,
+  renderMenuLines,
+  buildLegacyLines,
   MENU_REGION_ID,
   type MenuEntry,
 } from './menu.js';
@@ -207,7 +209,8 @@ describe('selectFromMenu (fallback path)', () => {
 
 describe('selectFromMenu (interactive path)', () => {
   let rl: any;
-  let originalIsTTY: boolean | undefined;
+  let originalStdoutIsTTY: boolean | undefined;
+  let originalStdinIsTTY: boolean | undefined;
   let originalSetRawMode: any;
   let originalIsRaw: any;
   let originalPlainMenu: string | undefined;
@@ -218,8 +221,10 @@ describe('selectFromMenu (interactive path)', () => {
     mockSetPinnedRegion.mockClear();
     mockClearPinnedRegion.mockClear();
 
-    originalIsTTY = process.stdout.isTTY;
+    originalStdoutIsTTY = process.stdout.isTTY;
+    originalStdinIsTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     originalPlainMenu = process.env.BERNARD_PLAIN_MENU;
     delete process.env.BERNARD_PLAIN_MENU;
 
@@ -230,10 +235,12 @@ describe('selectFromMenu (interactive path)', () => {
   });
 
   afterEach(() => {
-    // Menu code owns the 'keypress' listener lifecycle; just in case a test
-    // leaks one, clean up the ones our test added.
     Object.defineProperty(process.stdout, 'isTTY', {
-      value: originalIsTTY,
+      value: originalStdoutIsTTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalStdinIsTTY,
       configurable: true,
     });
     if (originalPlainMenu !== undefined) process.env.BERNARD_PLAIN_MENU = originalPlainMenu;
@@ -431,5 +438,106 @@ describe('promptValue', () => {
     await promptValue(rl, { label: 'New threshold' });
     const promptStr = rl.question.mock.calls[0][0] as string;
     expect(promptStr).toContain('New threshold');
+  });
+});
+
+describe('renderMenuLines', () => {
+  it('renders the title as the first line when provided', () => {
+    const lines = renderMenuLines(simpleEntries, 0, { title: 'Pick one' });
+    expect(lines[0]).toContain('Pick one');
+  });
+
+  it('omits the title block when none is provided', () => {
+    const lines = renderMenuLines(simpleEntries, 0, undefined);
+    expect(lines[0]).not.toContain('Pick one');
+    expect(lines[0]).toContain('1. Alpha');
+  });
+
+  it('marks only the highlighted row with the > cursor', () => {
+    const lines = renderMenuLines(simpleEntries, 1, undefined);
+    const alpha = lines.find((l) => l.includes('Alpha'))!;
+    const beta = lines.find((l) => l.includes('Beta'))!;
+    const gamma = lines.find((l) => l.includes('Gamma'))!;
+    expect(alpha).not.toMatch(/^\s*>/);
+    expect(beta).toMatch(/^\s*>\s/);
+    expect(gamma).not.toMatch(/^\s*>/);
+  });
+
+  it('shows the description only under the highlighted item', () => {
+    const entries: MenuEntry[] = [
+      { label: 'One', description: 'first desc' },
+      { label: 'Two', description: 'second desc' },
+    ];
+    const lines = renderMenuLines(entries, 1, undefined);
+    expect(lines.some((l) => l.includes('second desc'))).toBe(true);
+    expect(lines.some((l) => l.includes('first desc'))).toBe(false);
+  });
+
+  it('renders section headers as unselectable rows', () => {
+    const lines = renderMenuLines(groupedEntries, 0, undefined);
+    expect(lines.some((l) => l.includes('Cool colors:'))).toBe(true);
+  });
+
+  it('appends active and annotation markers on item labels', () => {
+    const lines = renderMenuLines(groupedEntries, 0, undefined);
+    const redLine = lines.find((l) => l.includes('Red'))!;
+    expect(redLine).toContain('(active)');
+    const purpleLine = lines.find((l) => l.includes('Purple'))!;
+    expect(purpleLine).toContain('(new)');
+  });
+
+  it('includes the footer hint as the last line', () => {
+    const lines = renderMenuLines(simpleEntries, 0, undefined);
+    const footer = lines[lines.length - 1];
+    expect(footer).toContain('Enter');
+    expect(footer).toContain('Esc');
+  });
+
+  it('numbers items from 1 skipping sections', () => {
+    const lines = renderMenuLines(groupedEntries, 0, undefined);
+    expect(lines.some((l) => /1\. Red/.test(l))).toBe(true);
+    expect(lines.some((l) => /2\. Green/.test(l))).toBe(true);
+    expect(lines.some((l) => /3\. Blue/.test(l))).toBe(true);
+    expect(lines.some((l) => /4\. Purple/.test(l))).toBe(true);
+  });
+});
+
+describe('buildLegacyLines', () => {
+  it('numbers items and skips sections in numbering', () => {
+    const out = buildLegacyLines(groupedEntries);
+    const texts = out.map((l) => l.text);
+    expect(texts.some((t) => /1\. Red/.test(t))).toBe(true);
+    expect(texts.some((t) => /2\. Green/.test(t))).toBe(true);
+    expect(texts.some((t) => /3\. Blue/.test(t))).toBe(true);
+    expect(texts.some((t) => /4\. Purple/.test(t))).toBe(true);
+  });
+
+  it('includes section headers verbatim', () => {
+    const out = buildLegacyLines(groupedEntries);
+    expect(out.some((l) => l.text.includes('Cool colors:'))).toBe(true);
+  });
+
+  it('appends (active) and annotation markers', () => {
+    const out = buildLegacyLines(groupedEntries);
+    expect(out.some((l) => l.text.includes('Red (active)'))).toBe(true);
+    expect(out.some((l) => l.text.includes('Purple (new)'))).toBe(true);
+  });
+
+  it('tags description rows as dim', () => {
+    const entries: MenuEntry[] = [{ label: 'One', description: 'more info' }];
+    const out = buildLegacyLines(entries);
+    const desc = out.find((l) => l.text.includes('more info'))!;
+    expect(desc.dim).toBe(true);
+  });
+
+  it('does not tag label rows as dim', () => {
+    const out = buildLegacyLines(simpleEntries);
+    for (const line of out) {
+      expect(line.dim).toBeFalsy();
+    }
+  });
+
+  it('returns an empty array for empty entries', () => {
+    expect(buildLegacyLines([])).toEqual([]);
   });
 });

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,6 +1,20 @@
-import type * as readline from 'node:readline';
-import { printInfo, printDim } from './output.js';
+import * as readline from 'node:readline';
+import { printInfo, printDim, setPinnedRegion, clearPinnedRegion } from './output.js';
 import { getTheme } from './theme.js';
+
+/** Pinned-region id used by the interactive menu. Exported for tests. */
+export const MENU_REGION_ID = 'menu';
+
+const DIGIT_KEY_RE = /^[1-9]$/;
+
+/** Minimal shape of the keypress events emitted by node:readline. */
+interface KeyEvent {
+  name?: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+  sequence?: string;
+}
 
 /** A single selectable item in a menu. */
 export interface MenuItem {
@@ -30,6 +44,8 @@ export type MenuEntry = MenuItem | MenuSection;
 export interface MenuOptions {
   /** Prompt string override, e.g. "Select option". Default: "Select". */
   promptLabel?: string;
+  /** Optional heading rendered inside the ephemeral menu block. */
+  title?: string;
 }
 
 /** Options for promptValue(). */
@@ -72,8 +88,15 @@ export function getMenuItem(entries: MenuEntry[], index: number): MenuItem | und
   return undefined;
 }
 
-/** Print a numbered list with optional section headers. */
-export function printMenuList(entries: MenuEntry[]): void {
+/** True when we should skip the interactive renderer and use the legacy numbered-list path. */
+function useFallback(): boolean {
+  const flag = process.env.BERNARD_PLAIN_MENU;
+  const forcePlain = flag === 'true' || flag === '1';
+  return !process.stdout.isTTY || forcePlain;
+}
+
+/** Legacy numbered-list renderer (fallback path). */
+function renderLegacyList(entries: MenuEntry[]): void {
   let n = 1;
   for (const entry of entries) {
     if (isSection(entry)) {
@@ -126,16 +149,20 @@ function questionWithSignal(
   });
 }
 
-/**
- * Prompt the user to select from a numbered list.
- * Returns cancelled if input is empty, non-numeric, out of range, or signal aborted.
- */
-export async function selectFromMenu(
+/** Legacy numbered-list + rl.question selection flow. */
+async function legacySelect(
   rl: readline.Interface,
   entries: MenuEntry[],
-  options?: MenuOptions,
-  signal?: AbortSignal,
+  options: MenuOptions | undefined,
+  signal: AbortSignal | undefined,
 ): Promise<SelectResult> {
+  if (options?.title) {
+    printInfo(`\n  ${options.title}\n`);
+  }
+  renderLegacyList(entries);
+  // Blank line between list and prompt.
+  printInfo('');
+
   const items = entries.filter((e) => !isSection(e)) as MenuItem[];
   const label = options?.promptLabel ?? 'Select';
   const { ansi } = getTheme();
@@ -154,6 +181,173 @@ export async function selectFromMenu(
 
   printInfo('  Cancelled.');
   return { cancelled: true };
+}
+
+/**
+ * Build the lines array for the ephemeral menu block.
+ * The highlighted item gets a `>` cursor and accent styling; its description
+ * (if present) is shown below it. Other items show a plain numbered label.
+ */
+function renderMenuLines(
+  entries: MenuEntry[],
+  highlightItemIndex: number,
+  options: MenuOptions | undefined,
+): string[] {
+  const { accent, accentBold, dim, muted } = getTheme();
+  const lines: string[] = [];
+
+  if (options?.title) {
+    lines.push(`  ${accentBold(options.title)}`);
+    lines.push('');
+  }
+
+  let itemIndex = 0;
+  for (const entry of entries) {
+    if (isSection(entry)) {
+      lines.push(`  ${muted(entry.title)}`);
+      continue;
+    }
+    const n = itemIndex + 1;
+    const activeMarker = entry.active ? ' (active)' : '';
+    const annotation = entry.annotation ? ` ${entry.annotation}` : '';
+    const labelText = `${n}. ${entry.label}${activeMarker}${annotation}`;
+    const isHighlighted = itemIndex === highlightItemIndex;
+    if (isHighlighted) {
+      lines.push(`  ${accent('>')} ${accentBold(labelText)}`);
+      if (entry.description) {
+        lines.push(`       ${dim(entry.description)}`);
+      }
+    } else {
+      lines.push(`    ${labelText}`);
+    }
+    itemIndex++;
+  }
+
+  lines.push('');
+  lines.push(`  ${dim('\u2191/\u2193 move \u00B7 Enter select \u00B7 Esc cancel')}`);
+
+  return lines;
+}
+
+/** Interactive arrow-key menu rendered via the pinned region. */
+async function interactiveSelect(
+  rl: readline.Interface,
+  entries: MenuEntry[],
+  options: MenuOptions | undefined,
+  signal: AbortSignal | undefined,
+): Promise<SelectResult> {
+  if (signal?.aborted) {
+    return { cancelled: true };
+  }
+
+  const itemCount = countMenuItems(entries);
+  if (itemCount === 0) {
+    return { cancelled: true };
+  }
+
+  readline.emitKeypressEvents(process.stdin);
+  const wasRaw = process.stdin.isRaw ?? false;
+  process.stdin.setRawMode(true);
+  rl.pause();
+
+  let highlight = 0;
+
+  const repaint = () => {
+    setPinnedRegion(MENU_REGION_ID, renderMenuLines(entries, highlight, options));
+  };
+
+  return new Promise<SelectResult>((resolve) => {
+    let settled = false;
+    const finish = (result: SelectResult) => {
+      if (settled) return;
+      settled = true;
+      process.stdin.removeListener('keypress', onKeypress);
+      signal?.removeEventListener('abort', onAbort);
+      try {
+        process.stdin.setRawMode(wasRaw);
+      } catch {
+        // stdin may have been detached; ignore.
+      }
+      clearPinnedRegion(MENU_REGION_ID);
+      rl.resume();
+      if (!result.cancelled) {
+        printInfo(`  Selected: ${result.item.label}`);
+      }
+      resolve(result);
+    };
+
+    const commit = (idx: number) => {
+      const item = getMenuItem(entries, idx);
+      if (!item) {
+        finish({ cancelled: true });
+        return;
+      }
+      finish({ cancelled: false, index: idx, item });
+    };
+
+    const onKeypress = (_str: string, key: KeyEvent | undefined) => {
+      if (!key) return;
+
+      if (key.ctrl && key.name === 'c') {
+        finish({ cancelled: true });
+        return;
+      }
+      if (key.name === 'escape' || key.name === 'q') {
+        finish({ cancelled: true });
+        return;
+      }
+      if (key.name === 'return' || key.name === 'enter') {
+        commit(highlight);
+        return;
+      }
+      if (key.name === 'up') {
+        if (highlight > 0) {
+          highlight--;
+          repaint();
+        }
+        return;
+      }
+      if (key.name === 'down') {
+        if (highlight < itemCount - 1) {
+          highlight++;
+          repaint();
+        }
+        return;
+      }
+      if (key.name && DIGIT_KEY_RE.test(key.name)) {
+        const n = parseInt(key.name, 10) - 1;
+        if (n < itemCount) {
+          commit(n);
+        }
+      }
+    };
+
+    const onAbort = () => finish({ cancelled: true });
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    process.stdin.on('keypress', onKeypress);
+    repaint();
+  });
+}
+
+/**
+ * Prompt the user to select from a menu.
+ *
+ * In a TTY without `BERNARD_PLAIN_MENU=1`, renders as an ephemeral arrow-key
+ * menu above the prompt. Otherwise falls back to a numbered list + rl.question.
+ * Returns cancelled on Esc/Ctrl-C/q, on external signal abort, or on empty /
+ * out-of-range input in fallback mode.
+ */
+export async function selectFromMenu(
+  rl: readline.Interface,
+  entries: MenuEntry[],
+  options?: MenuOptions,
+  signal?: AbortSignal,
+): Promise<SelectResult> {
+  if (useFallback()) {
+    return legacySelect(rl, entries, options, signal);
+  }
+  return interactiveSelect(rl, entries, options, signal);
 }
 
 /**

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -11,9 +11,6 @@ const DIGIT_KEY_RE = /^[1-9]$/;
 interface KeyEvent {
   name?: string;
   ctrl?: boolean;
-  shift?: boolean;
-  meta?: boolean;
-  sequence?: string;
 }
 
 /** A single selectable item in a menu. */
@@ -92,25 +89,36 @@ export function getMenuItem(entries: MenuEntry[], index: number): MenuItem | und
 function useFallback(): boolean {
   const flag = process.env.BERNARD_PLAIN_MENU;
   const forcePlain = flag === 'true' || flag === '1';
-  return !process.stdout.isTTY || forcePlain;
+  // setRawMode throws on non-TTY stdin, so both streams must be TTY.
+  return !process.stdout.isTTY || !process.stdin.isTTY || forcePlain;
 }
 
-/** Legacy numbered-list renderer (fallback path). */
-function renderLegacyList(entries: MenuEntry[]): void {
+/**
+ * A single line of the fallback numbered-list rendering, tagged with whether
+ * it should be emitted via `printDim` (description rows) or `printInfo`.
+ */
+export interface LegacyLine {
+  text: string;
+  dim?: boolean;
+}
+
+export function buildLegacyLines(entries: MenuEntry[]): LegacyLine[] {
+  const out: LegacyLine[] = [];
   let n = 1;
   for (const entry of entries) {
     if (isSection(entry)) {
-      printInfo(`\n  ${entry.title}`);
+      out.push({ text: `\n  ${entry.title}` });
     } else {
       const activeMarker = entry.active ? ' (active)' : '';
       const annotation = entry.annotation ? ` ${entry.annotation}` : '';
-      printInfo(`    ${n}. ${entry.label}${activeMarker}${annotation}`);
+      out.push({ text: `    ${n}. ${entry.label}${activeMarker}${annotation}` });
       if (entry.description) {
-        printDim(`       ${entry.description}`);
+        out.push({ text: `       ${entry.description}`, dim: true });
       }
       n++;
     }
   }
+  return out;
 }
 
 /**
@@ -159,8 +167,10 @@ async function legacySelect(
   if (options?.title) {
     printInfo(`\n  ${options.title}\n`);
   }
-  renderLegacyList(entries);
-  // Blank line between list and prompt.
+  for (const line of buildLegacyLines(entries)) {
+    if (line.dim) printDim(line.text);
+    else printInfo(line.text);
+  }
   printInfo('');
 
   const items = entries.filter((e) => !isSection(e)) as MenuItem[];
@@ -187,8 +197,10 @@ async function legacySelect(
  * Build the lines array for the ephemeral menu block.
  * The highlighted item gets a `>` cursor and accent styling; its description
  * (if present) is shown below it. Other items show a plain numbered label.
+ *
+ * Exported for direct testing; production callers go through selectFromMenu.
  */
-function renderMenuLines(
+export function renderMenuLines(
   entries: MenuEntry[],
   highlightItemIndex: number,
   options: MenuOptions | undefined,
@@ -249,6 +261,8 @@ async function interactiveSelect(
   const wasRaw = process.stdin.isRaw ?? false;
   process.stdin.setRawMode(true);
   rl.pause();
+  // rl.pause() pauses the underlying stdin; resume so 'keypress' events fire.
+  process.stdin.resume();
 
   let highlight = 0;
 

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -23,6 +23,8 @@ import {
   stopSpinner,
   buildSpinnerMessage,
   setToolDetailsVisible,
+  setPinnedRegion,
+  clearPinnedRegion,
   type SpinnerStats,
 } from './output.js';
 import type { Step } from './plan-store.js';
@@ -745,6 +747,86 @@ describe('output', () => {
       expect(lines[1]).toContain('user pivoted');
       expect(lines[2]).toContain('\u2717');
       expect(lines[2]).toContain('no permission');
+    });
+  });
+
+  describe('pinned region visual-row counting', () => {
+    let originalIsTTY: boolean | undefined;
+    let originalColumns: number | undefined;
+
+    beforeEach(() => {
+      originalIsTTY = process.stdout.isTTY;
+      originalColumns = process.stdout.columns;
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
+      // Clear any regions left over from earlier tests (e.g. printPlan).
+      clearPinnedRegion('plan');
+      clearPinnedRegion('test');
+      stdoutWriteSpy.mockClear();
+    });
+
+    afterEach(() => {
+      clearPinnedRegion('plan');
+      clearPinnedRegion('test');
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, 'columns', {
+        value: originalColumns,
+        configurable: true,
+      });
+    });
+
+    function eraseUpCount(): number {
+      // After the second setPinnedRegion call we expect an erase sequence
+      // `\x1b[<N>A` followed by `\r\x1b[J`. Return N, or 0 if no erase was issued.
+      for (const call of stdoutWriteSpy.mock.calls) {
+        const s = String(call[0]);
+        const match = s.match(/^\x1b\[(\d+)A$/);
+        if (match) return parseInt(match[1], 10);
+      }
+      return 0;
+    }
+
+    it('short lines: erase count equals logical line count', () => {
+      setPinnedRegion('test', ['short', 'also short']);
+      stdoutWriteSpy.mockClear();
+      setPinnedRegion('test', []); // triggers erase
+      expect(eraseUpCount()).toBe(2);
+    });
+
+    it('wrapped line counts as multiple visual rows', () => {
+      // columns=40, a 95-char line wraps to 3 rows.
+      const long = 'a'.repeat(95);
+      setPinnedRegion('test', [long]);
+      stdoutWriteSpy.mockClear();
+      setPinnedRegion('test', []);
+      expect(eraseUpCount()).toBe(3);
+    });
+
+    it('ANSI escape codes excluded from width', () => {
+      // 35 visible chars wrapped in color codes; shouldn't wrap at 40 cols.
+      const colored = `\x1b[31m${'x'.repeat(35)}\x1b[0m`;
+      setPinnedRegion('test', [colored]);
+      stdoutWriteSpy.mockClear();
+      setPinnedRegion('test', []);
+      expect(eraseUpCount()).toBe(1);
+    });
+
+    it('empty string counts as one row', () => {
+      setPinnedRegion('test', ['', '']);
+      stdoutWriteSpy.mockClear();
+      setPinnedRegion('test', []);
+      expect(eraseUpCount()).toBe(2);
+    });
+
+    it('mixed short and wrapped lines sum correctly', () => {
+      // columns=40: short(1) + 80-char(2) + short(1) = 4 rows.
+      setPinnedRegion('test', ['short', 'b'.repeat(80), 'tail']);
+      stdoutWriteSpy.mockClear();
+      setPinnedRegion('test', []);
+      expect(eraseUpCount()).toBe(4);
     });
   });
 

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -25,6 +25,7 @@ import {
   setToolDetailsVisible,
   setPinnedRegion,
   clearPinnedRegion,
+  visualRowCount,
   type SpinnerStats,
 } from './output.js';
 import type { Step } from './plan-store.js';
@@ -750,7 +751,36 @@ describe('output', () => {
     });
   });
 
-  describe('pinned region visual-row counting', () => {
+  describe('visualRowCount', () => {
+    it('counts a short line as one row', () => {
+      expect(visualRowCount('abc', 80)).toBe(1);
+    });
+
+    it('counts an empty string as one row', () => {
+      expect(visualRowCount('', 40)).toBe(1);
+    });
+
+    it('counts a line exactly equal to columns as one row', () => {
+      expect(visualRowCount('x'.repeat(40), 40)).toBe(1);
+    });
+
+    it('wraps a long line across multiple rows', () => {
+      expect(visualRowCount('a'.repeat(95), 40)).toBe(3);
+    });
+
+    it('excludes ANSI escape codes from width calculation', () => {
+      const colored = `\x1b[31m${'x'.repeat(35)}\x1b[0m`;
+      expect(visualRowCount(colored, 40)).toBe(1);
+    });
+
+    it('handles multiple ANSI sequences per line', () => {
+      const line = `\x1b[1m\x1b[31mhello\x1b[0m world \x1b[32mthere\x1b[0m`;
+      // Visible: "hello world there" = 17 chars, fits in 40 cols.
+      expect(visualRowCount(line, 40)).toBe(1);
+    });
+  });
+
+  describe('pinned region integration', () => {
     let originalIsTTY: boolean | undefined;
     let originalColumns: number | undefined;
 
@@ -759,7 +789,6 @@ describe('output', () => {
       originalColumns = process.stdout.columns;
       Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
       Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
-      // Clear any regions left over from earlier tests (e.g. printPlan).
       clearPinnedRegion('plan');
       clearPinnedRegion('test');
       stdoutWriteSpy.mockClear();
@@ -778,55 +807,60 @@ describe('output', () => {
       });
     });
 
-    function eraseUpCount(): number {
-      // After the second setPinnedRegion call we expect an erase sequence
-      // `\x1b[<N>A` followed by `\r\x1b[J`. Return N, or 0 if no erase was issued.
-      for (const call of stdoutWriteSpy.mock.calls) {
-        const s = String(call[0]);
-        const match = s.match(/^\x1b\[(\d+)A$/);
-        if (match) return parseInt(match[1], 10);
-      }
-      return 0;
-    }
-
-    it('short lines: erase count equals logical line count', () => {
-      setPinnedRegion('test', ['short', 'also short']);
-      stdoutWriteSpy.mockClear();
-      setPinnedRegion('test', []); // triggers erase
-      expect(eraseUpCount()).toBe(2);
-    });
-
-    it('wrapped line counts as multiple visual rows', () => {
-      // columns=40, a 95-char line wraps to 3 rows.
-      const long = 'a'.repeat(95);
-      setPinnedRegion('test', [long]);
-      stdoutWriteSpy.mockClear();
-      setPinnedRegion('test', []);
-      expect(eraseUpCount()).toBe(3);
-    });
-
-    it('ANSI escape codes excluded from width', () => {
-      // 35 visible chars wrapped in color codes; shouldn't wrap at 40 cols.
-      const colored = `\x1b[31m${'x'.repeat(35)}\x1b[0m`;
-      setPinnedRegion('test', [colored]);
-      stdoutWriteSpy.mockClear();
-      setPinnedRegion('test', []);
-      expect(eraseUpCount()).toBe(1);
-    });
-
-    it('empty string counts as one row', () => {
-      setPinnedRegion('test', ['', '']);
-      stdoutWriteSpy.mockClear();
-      setPinnedRegion('test', []);
-      expect(eraseUpCount()).toBe(2);
-    });
-
-    it('mixed short and wrapped lines sum correctly', () => {
-      // columns=40: short(1) + 80-char(2) + short(1) = 4 rows.
+    it('emits an erase sequence summing visual rows across mixed lines', () => {
+      // columns=40: short(1) + 80-char wrap(2) + short(1) = 4 visual rows.
       setPinnedRegion('test', ['short', 'b'.repeat(80), 'tail']);
       stdoutWriteSpy.mockClear();
-      setPinnedRegion('test', []);
-      expect(eraseUpCount()).toBe(4);
+      setPinnedRegion('test', []); // triggers erase
+      const moveUp = stdoutWriteSpy.mock.calls
+        .map((c) => String(c[0]))
+        .find((s) => /^\x1b\[\d+A$/.test(s));
+      expect(moveUp).toBe('\x1b[4A');
+    });
+  });
+
+  describe('resize handler', () => {
+    it('re-renders pinned content without emitting an erase sequence', async () => {
+      const originalIsTTY = process.stdout.isTTY;
+      const originalColumns = process.stdout.columns;
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
+
+      // Snapshot resize listeners so we can strip any added by the re-imported module.
+      const preListeners = process.stdout.listeners('resize');
+      vi.resetModules();
+      const mod = await import('./output.js');
+
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      try {
+        mod.setPinnedRegion('test', ['hello world']);
+        writeSpy.mockClear();
+
+        Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
+        process.stdout.emit('resize');
+
+        const writes = writeSpy.mock.calls.map((c) => String(c[0]));
+        expect(writes.some((s) => /^\x1b\[\d+A$/.test(s))).toBe(false);
+        expect(writes.join('')).toContain('hello world');
+
+        mod.clearPinnedRegion('test');
+      } finally {
+        writeSpy.mockRestore();
+        for (const l of process.stdout.listeners('resize')) {
+          if (!preListeners.includes(l)) {
+            process.stdout.removeListener('resize', l as (...args: unknown[]) => void);
+          }
+        }
+        Object.defineProperty(process.stdout, 'isTTY', {
+          value: originalIsTTY,
+          configurable: true,
+        });
+        Object.defineProperty(process.stdout, 'columns', {
+          value: originalColumns,
+          configurable: true,
+        });
+        vi.resetModules();
+      }
     });
   });
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -27,29 +27,62 @@ const silentTools = new Set<string>(['plan', 'think', 'evaluate']);
 // but never rendered, so chat output stays clean.
 
 const pinnedRegions = new Map<string, string[]>();
-let pinnedLineCount = 0;
+let pinnedVisualRowCount = 0;
 
 function pinSupported(): boolean {
   return !!process.stdout.isTTY;
 }
 
+// CSI escapes contribute to `.length` but occupy zero cells on screen, so
+// they must be removed before computing how many visual rows a line wraps to.
+const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+function currentColumns(): number {
+  return process.stdout.columns || 80;
+}
+
+function visualRowCount(line: string, columns: number): number {
+  const width = stripAnsi(line).length;
+  if (width === 0) return 1;
+  return Math.ceil(width / columns);
+}
+
 function erasePinnedRegions(): void {
-  if (!pinSupported() || pinnedLineCount === 0) return;
-  process.stdout.write(`\x1b[${pinnedLineCount}A`);
+  if (!pinSupported() || pinnedVisualRowCount === 0) return;
+  process.stdout.write(`\x1b[${pinnedVisualRowCount}A`);
   process.stdout.write(`\r\x1b[J`);
-  pinnedLineCount = 0;
+  pinnedVisualRowCount = 0;
 }
 
 function renderPinnedRegions(): void {
   if (!pinSupported() || pinnedRegions.size === 0) return;
-  let count = 0;
+  const columns = currentColumns();
+  let rows = 0;
   for (const lines of pinnedRegions.values()) {
     for (const line of lines) {
       process.stdout.write(line + '\n');
-      count++;
+      rows += visualRowCount(line, columns);
     }
   }
-  pinnedLineCount = count;
+  pinnedVisualRowCount = rows;
+}
+
+if (process.stdout.isTTY) {
+  process.stdout.on('resize', () => {
+    // On resize the row math for the currently-rendered pinned content is
+    // based on the old column count. Redraw from scratch using the new width.
+    if (pinnedRegions.size === 0) return;
+    // Can't reliably erase since cursor position relative to the wrapped
+    // lines is now ambiguous. Just reset the counter and re-render below the
+    // current cursor; scrollback picks up the old copy but the live region
+    // stays correct going forward.
+    pinnedVisualRowCount = 0;
+    renderPinnedRegions();
+  });
 }
 
 function sameLines(a: string[] | undefined, b: string[]): boolean {

--- a/src/output.ts
+++ b/src/output.ts
@@ -45,7 +45,12 @@ function currentColumns(): number {
   return process.stdout.columns || 80;
 }
 
-function visualRowCount(line: string, columns: number): number {
+/**
+ * Number of visual terminal rows a single logical line will occupy, given
+ * the current column width. Strips ANSI CSI escapes so zero-width control
+ * codes don't inflate the count. Exported for direct testing.
+ */
+export function visualRowCount(line: string, columns: number): number {
   const width = stripAnsi(line).length;
   if (width === 0) return 1;
   return Math.ceil(width / columns);
@@ -584,6 +589,10 @@ export function printHelp(): void {
       t.muted(' — Configure agent behavior (toggles, thresholds, saved assets)'),
     '  ' + t.accent('/update') + t.muted('   — Check for and install updates'),
     '  ' + t.accent('exit') + t.muted('      — Quit Bernard'),
+    '',
+    t.muted(
+      '  Tip: set BERNARD_PLAIN_MENU=1 for a static numbered-list menu (better for screen readers).',
+    ),
     '',
   ];
   emit(lines.join('\n'));

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -98,7 +98,6 @@ import {
   type ImageAttachment,
 } from './image.js';
 import {
-  printMenuList,
   selectFromMenu,
   promptValue,
   type MenuEntry,
@@ -316,12 +315,14 @@ export async function startRepl(
       { label: 'On', active: config[key] === true },
       { label: 'Off', active: config[key] === false },
     ];
-    printInfo(`\n  ${label}: ${config[key] ? 'ON' : 'OFF'}\n`);
-    printMenuList(entries);
-    console.log();
     const signal = createMenuSignal();
     try {
-      const result = await selectFromMenu(rl, entries, {}, signal);
+      const result = await selectFromMenu(
+        rl,
+        entries,
+        { title: `${label}: ${config[key] ? 'ON' : 'OFF'}` },
+        signal,
+      );
       if (!result.cancelled) {
         config[key] = result.index === 0;
         savePreferences({
@@ -490,13 +491,14 @@ export async function startRepl(
       entries.push({ label: `Remember: "${reference}" → ${c.label}` });
     }
 
-    printInfo(`\n  Ambiguous reference: "${reference}"\n`);
-    printMenuList(entries);
-    console.log();
-
     const signal = createMenuSignal();
     try {
-      const result = await selectFromMenu(rl, entries, { promptLabel: 'Resolve to' }, signal);
+      const result = await selectFromMenu(
+        rl,
+        entries,
+        { title: `Ambiguous reference: "${reference}"`, promptLabel: 'Resolve to' },
+        signal,
+      );
       if (result.cancelled) return { cancelled: true };
 
       const idx = result.index;
@@ -1414,13 +1416,14 @@ export async function startRepl(
           return;
         }
         const entries: MenuEntry[] = available.map((p) => ({ label: p }));
-        printInfo(`\n  Current: ${config.provider} (${config.model})\n`);
-        printInfo('  Available providers:');
-        printMenuList(entries);
-        console.log();
         const signal = createMenuSignal();
         try {
-          const result = await selectFromMenu(rl, entries, {}, signal);
+          const result = await selectFromMenu(
+            rl,
+            entries,
+            { title: `Providers — current: ${config.provider} (${config.model})` },
+            signal,
+          );
           if (!result.cancelled) {
             config.provider = available[result.index];
             config.model = getDefaultModel(config.provider);
@@ -1450,13 +1453,14 @@ export async function startRepl(
           return;
         }
         const entries: MenuEntry[] = models.map((m) => ({ label: m }));
-        printInfo(`\n  Current: ${config.provider} / ${config.model}\n`);
-        printInfo('  Available models:');
-        printMenuList(entries);
-        console.log();
         const signal = createMenuSignal();
         try {
-          const result = await selectFromMenu(rl, entries, {}, signal);
+          const result = await selectFromMenu(
+            rl,
+            entries,
+            { title: `Models — current: ${config.provider} / ${config.model}` },
+            signal,
+          );
           if (!result.cancelled) {
             config.model = models[result.index];
             savePreferences({
@@ -1497,14 +1501,14 @@ export async function startRepl(
           })),
         ];
 
-        printInfo(`\n  Current theme: ${THEMES[currentKey].name}\n`);
-        printInfo('  Themes:');
-        printMenuList(entries);
-        console.log();
-
         const signal = createMenuSignal();
         try {
-          const result = await selectFromMenu(rl, entries, {}, signal);
+          const result = await selectFromMenu(
+            rl,
+            entries,
+            { title: `Themes — current: ${THEMES[currentKey].name}` },
+            signal,
+          );
           if (!result.cancelled) {
             const chosen = result.item.value as string;
             setTheme(chosen);
@@ -1542,17 +1546,13 @@ export async function startRepl(
           { type: 'section', title: 'Info' },
           { label: 'Debug report', description: 'Print a diagnostic report for troubleshooting' },
         ];
-        printInfo('\n  Options:');
-        printMenuList(menuEntries);
-        console.log();
-
         const signal1 = createMenuSignal();
         let optResult: SelectResult;
         try {
           optResult = await selectFromMenu(
             rl,
             menuEntries,
-            { promptLabel: 'Select option' },
+            { title: 'Options', promptLabel: 'Select option' },
             signal1,
           );
         } finally {
@@ -1892,14 +1892,10 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         );
         const itemActions = rows.flatMap((r) => (r.kind === 'item' ? [r.action] : []));
 
-        printInfo('\n  Agent Options:\n');
-        printMenuList(topEntries);
-        console.log();
-
         const signal1 = createMenuSignal();
         let topResult: SelectResult;
         try {
-          topResult = await selectFromMenu(rl, topEntries, {}, signal1);
+          topResult = await selectFromMenu(rl, topEntries, { title: 'Agent Options' }, signal1);
         } finally {
           clearMenuSignal();
         }


### PR DESCRIPTION
Transforms the menu system from static numbered lists to an interactive arrow-key interface:

- Renders menus as ephemeral pinned regions above the prompt with real-time highlighting
- Supports arrow keys for navigation, Enter to select, Esc/q/Ctrl-C to cancel
- Enables immediate selection via digit keys (1-9)
- Maintains backward compatibility through fallback mode for non-TTY environments
- Improves visual row counting for proper terminal wrapping and ANSI escape handling

Falls back to legacy numbered list behavior when `BERNARD_PLAIN_MENU=1` is set or when not running in a TTY.

closes #122