### PR TITLE
docs: refresh site for v0.9.0 release

### DIFF
--- a/docs/domain-specific-memory.md
+++ b/docs/domain-specific-memory.md
@@ -1,5 +1,7 @@
 # How Domain-Specific Memory Works
 
+_Current as of Bernard v0.9.0._
+
 Bernard's memory system learns from your conversations and organizes what it learns into four specialized domains. Instead of treating every fact the same, it categorizes knowledge so it can extract better facts and recall the right ones at the right time.
 
 This document walks through the full lifecycle — from how facts get extracted, to how they're stored, to how they show up in future conversations. It covers both the conceptual design and the technical implementation.

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
         "operatingSystem": "Linux, macOS, Windows",
         "url": "https://phillt.github.io/bernard/",
         "downloadUrl": "https://www.npmjs.com/package/bernard-agent",
-        "softwareVersion": "0.8.0",
+        "softwareVersion": "0.9.0",
         "license": "https://opensource.org/licenses/MIT",
         "offers": {
           "@type": "Offer",
@@ -973,10 +973,10 @@
         </button>
         <div class="badges">
           <a
-            href="https://github.com/phillt/bernard/releases/tag/0.8.0"
+            href="https://github.com/phillt/bernard/releases/tag/0.9.0"
             target="_blank"
             class="badge"
-            ><span class="dot"></span>v0.8.0</a
+            ><span class="dot"></span>v0.9.0</a
           >
           <span class="badge">MIT</span>
           <span class="badge">Node &ge; 20</span>
@@ -1010,6 +1010,10 @@
           <button class="feature-tab" data-feature="4">MCP Support</button>
           <button class="feature-tab" data-feature="5">Sub-Agents</button>
           <button class="feature-tab" data-feature="6">Tasks</button>
+          <button class="feature-tab" data-feature="7">Reference Resolution</button>
+          <button class="feature-tab" data-feature="8">Coordinator Mode</button>
+          <button class="feature-tab" data-feature="9">Specialists &amp; Auto-Dispatch</button>
+          <button class="feature-tab" data-feature="10">Image Attachment</button>
         </div>
         <div class="feature-desc" id="feature-desc">
           Switch between Anthropic, OpenAI, and xAI with a flag. One interface, any model.
@@ -1036,7 +1040,8 @@
           <span class="comment"># Install globally</span><br />
           <span class="cmd-prefix">$ </span>npm install -g bernard-agent<br />
           <br />
-          <span class="comment"># Store your API key securely</span><br />
+          <span class="comment"># Store your API key securely (or set ANTHROPIC_API_KEY /</span><br />
+          <span class="comment"># OPENAI_API_KEY / XAI_API_KEY in ~/.config/bernard/.env)</span><br />
           <span class="cmd-prefix">$ </span>bernard add-key anthropic sk-ant-...<br />
           <br />
           <span class="comment"># Start the REPL</span><br />
@@ -1226,7 +1231,7 @@
                 </svg>
               </div>
               <h3>OpenAI</h3>
-              <div class="model">gpt-4o</div>
+              <div class="model">gpt-5.2</div>
             </div>
           </a>
           <a
@@ -1244,7 +1249,7 @@
                 </svg>
               </div>
               <h3>xAI</h3>
-              <div class="model">grok-3</div>
+              <div class="model">grok-4-fast</div>
             </div>
           </a>
         </div>
@@ -1290,7 +1295,7 @@
     <footer>
       <div class="container">
         <div class="footer-left">
-          bernard-agent &copy; <span id="year">2025</span> &middot; MIT License
+          bernard-agent &copy; <span id="year">2026</span> &middot; MIT License
         </div>
         <div class="footer-links">
           <a href="https://github.com/phillt/bernard" target="_blank" rel="noopener noreferrer"
@@ -1586,7 +1591,7 @@
             { type: 'line' },
             { type: 'instant', text: '  Switching to openai...', cls: 'tool' },
             { type: 'pause', ms: 400 },
-            { type: 'instant', text: '  \u2713 Now using openai (gpt-4o)', cls: 'output' },
+            { type: 'instant', text: '  \u2713 Now using openai (gpt-5.2)', cls: 'output' },
           ],
         },
         {
@@ -1730,6 +1735,145 @@
             {
               type: 'instant',
               text: '  \u2514\u2500 task success: Found 23 .ts files',
+              cls: 'output',
+            },
+          ],
+        },
+        {
+          desc: 'Bernard resolves named entities ("my brother", "the staging cluster") against memory before each turn. Unknown? It tries one read-only tool first.',
+          seq: [
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: 'email my brother about the trip', cls: 'cmd' },
+            { type: 'pause', ms: 400 },
+            { type: 'line' },
+            {
+              type: 'instant',
+              text: '  resolver: "my brother" not in memory \u2014 trying lookup',
+              cls: 'sub',
+            },
+            { type: 'pause', ms: 300 },
+            {
+              type: 'instant',
+              text: '  \u25B6 google_contacts__search { query: "brother" }',
+              cls: 'tool',
+            },
+            { type: 'pause', ms: 400 },
+            {
+              type: 'instant',
+              text: '  \u2514\u2500 found: Daniel Pereira <daniel@example.com>',
+              cls: 'output',
+            },
+            { type: 'pause', ms: 600 },
+            { type: 'line' },
+            { type: 'instant', text: '  ? Save this for next time?', cls: 'sub' },
+            { type: 'instant', text: '  \u276F Save  Edit  Skip', cls: 'output' },
+            { type: 'pause', ms: 500 },
+            { type: 'line' },
+            {
+              type: 'instant',
+              text: '  \u25B6 gmail__send_email { to: "daniel@example.com", \u2026 }',
+              cls: 'tool',
+            },
+            { type: 'instant', text: '  \u2713 sent', cls: 'output' },
+          ],
+        },
+        {
+          desc: 'Coordinator (ReAct) mode runs a think \u2192 act \u2192 evaluate \u2192 decide loop with new plan, think, and evaluate tools. Built for hard multi-step work.',
+          seq: [
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: '/agent-options', cls: 'cmd' },
+            { type: 'pause', ms: 400 },
+            { type: 'line' },
+            {
+              type: 'instant',
+              text: '  ReAct (coordinator) mode  [on]',
+              cls: 'output',
+            },
+            { type: 'pause', ms: 600 },
+            { type: 'line' },
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: 'ship a release: build, test, tag, push', cls: 'cmd' },
+            { type: 'pause', ms: 400 },
+            { type: 'line' },
+            { type: 'instant', text: '  \u25B6 plan: 4 steps drafted', cls: 'tool' },
+            { type: 'instant', text: '  \u25B6 think: tests must pass before tagging', cls: 'sub' },
+            {
+              type: 'instant',
+              text: '  \u25B6 shell: npm test \u2014 2074 passed',
+              cls: 'tool',
+            },
+            { type: 'instant', text: '  \u25B6 evaluate: step 1/4 done, advancing', cls: 'sub' },
+            { type: 'instant', text: '  \u2026 (think \u2192 act \u2192 evaluate, repeated)', cls: 'sub' },
+            { type: 'pause', ms: 400 },
+            { type: 'instant', text: '  \u2713 all 4 steps verified', cls: 'output' },
+          ],
+        },
+        {
+          desc: 'Specialists are reusable expert profiles. Auto-dispatch routes matching prompts; the candidates queue lets you review what Bernard suggested.',
+          seq: [
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: '/specialists', cls: 'cmd' },
+            { type: 'pause', ms: 300 },
+            { type: 'line' },
+            {
+              type: 'instant',
+              text: '  3 specialists \u2014 code-reviewer, sql-helper, release-driver',
+              cls: 'output',
+            },
+            { type: 'pause', ms: 600 },
+            { type: 'line' },
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: 'review the diff in src/agent.ts', cls: 'cmd' },
+            { type: 'pause', ms: 300 },
+            { type: 'line' },
+            {
+              type: 'instant',
+              text: '  auto-dispatch \u2192 code-reviewer (confidence 0.91)',
+              cls: 'sub',
+            },
+            { type: 'instant', text: '  \u25B6 shell: git diff src/agent.ts', cls: 'tool' },
+            { type: 'pause', ms: 400 },
+            {
+              type: 'instant',
+              text: '  spec:1 [Code Reviewer] \u2014 3 suggestions, 0 blockers',
+              cls: 'output',
+            },
+            { type: 'pause', ms: 600 },
+            { type: 'line' },
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: '/candidates', cls: 'cmd' },
+            { type: 'pause', ms: 300 },
+            { type: 'line' },
+            {
+              type: 'instant',
+              text: '  1 pending \u2014 "k8s-debugger" (confidence 0.74)',
+              cls: 'output',
+            },
+          ],
+        },
+        {
+          desc: 'Attach an image to the next turn with /image. Works with any vision-capable model.',
+          seq: [
+            { type: 'prompt', text: 'bernard> ' },
+            { type: 'type', text: '/image ./screenshot.png describe this UI', cls: 'cmd' },
+            { type: 'pause', ms: 400 },
+            { type: 'line' },
+            { type: 'instant', text: '  attached: screenshot.png (412 KB)', cls: 'sub' },
+            { type: 'instant', text: '  \u25B6 reading image \u2026', cls: 'tool' },
+            { type: 'pause', ms: 500 },
+            {
+              type: 'instant',
+              text: '  \u2514\u2500 A dark dashboard with three tabs:',
+              cls: 'output',
+            },
+            {
+              type: 'instant',
+              text: '    Memory, Cron, MCP. The Memory tab shows 142 facts',
+              cls: 'output',
+            },
+            {
+              type: 'instant',
+              text: '    across 4 domains. The header reads "bernard 0.9.0".',
               cls: 'output',
             },
           ],

--- a/docs/index.html
+++ b/docs/index.html
@@ -1040,8 +1040,10 @@
           <span class="comment"># Install globally</span><br />
           <span class="cmd-prefix">$ </span>npm install -g bernard-agent<br />
           <br />
-          <span class="comment"># Store your API key securely (or set ANTHROPIC_API_KEY /</span><br />
-          <span class="comment"># OPENAI_API_KEY / XAI_API_KEY in ~/.config/bernard/.env)</span><br />
+          <span class="comment"># Store your API key securely (or set ANTHROPIC_API_KEY /</span
+          ><br />
+          <span class="comment"># OPENAI_API_KEY / XAI_API_KEY in ~/.config/bernard/.env)</span
+          ><br />
           <span class="cmd-prefix">$ </span>bernard add-key anthropic sk-ant-...<br />
           <br />
           <span class="comment"># Start the REPL</span><br />
@@ -1803,7 +1805,11 @@
               cls: 'tool',
             },
             { type: 'instant', text: '  \u25B6 evaluate: step 1/4 done, advancing', cls: 'sub' },
-            { type: 'instant', text: '  \u2026 (think \u2192 act \u2192 evaluate, repeated)', cls: 'sub' },
+            {
+              type: 'instant',
+              text: '  \u2026 (think \u2192 act \u2192 evaluate, repeated)',
+              cls: 'sub',
+            },
             { type: 'pause', ms: 400 },
             { type: 'instant', text: '  \u2713 all 4 steps verified', cls: 'output' },
           ],

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -804,7 +804,10 @@
 <span class="accent">$</span> bernard providers</code></pre>
         <p>
           Bernard follows the
-          <a href="https://specifications.freedesktop.org/basedir/latest/" target="_blank" rel="noopener noreferrer"
+          <a
+            href="https://specifications.freedesktop.org/basedir/latest/"
+            target="_blank"
+            rel="noopener noreferrer"
             >XDG Base Directory Specification</a
           >. Default locations:
         </p>
@@ -814,13 +817,11 @@
             <code>keys.json</code> (0600), <code>.env</code>, <code>mcp.json</code>
           </li>
           <li>
-            <code>~/.local/share/bernard/</code> &mdash; <code>memory/</code>,
-            <code>rag/</code>, <code>routines/</code>, <code>specialists/</code>,
-            <code>tool-profiles/</code>, <code>cron/</code>
+            <code>~/.local/share/bernard/</code> &mdash; <code>memory/</code>, <code>rag/</code>,
+            <code>routines/</code>, <code>specialists/</code>, <code>tool-profiles/</code>,
+            <code>cron/</code>
           </li>
-          <li>
-            <code>~/.cache/bernard/</code> &mdash; embeddings models, update-check cache
-          </li>
+          <li><code>~/.cache/bernard/</code> &mdash; embeddings models, update-check cache</li>
           <li>
             <code>~/.local/state/bernard/</code> &mdash; conversation history, logs, daemon PID
           </li>
@@ -962,8 +963,9 @@
               <tr>
                 <td><code>BERNARD_REACT_MODE</code> <span class="vtag">v0.9.0+</span></td>
                 <td>
-                  Coordinator (ReAct) mode &mdash; think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide
-                  loop. Per-turn step budget grows to <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code>.
+                  Coordinator (ReAct) mode &mdash;
+                  think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide loop.
+                  Per-turn step budget grows to <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code>.
                 </td>
                 <td><code>false</code></td>
               </tr>
@@ -1040,8 +1042,8 @@
               <tr>
                 <td><code>TAVILY_API_KEY</code></td>
                 <td>
-                  Optional &mdash; Tavily API key for <code>web_search</code> (fallback when Brave is
-                  absent)
+                  Optional &mdash; Tavily API key for <code>web_search</code> (fallback when Brave
+                  is absent)
                 </td>
                 <td>&mdash;</td>
               </tr>
@@ -1073,8 +1075,8 @@
             <strong>Current working directory</strong> &mdash; <code>./.env</code> (checked first)
           </li>
           <li>
-            <strong>XDG config</strong> &mdash; <code>$XDG_CONFIG_HOME/bernard/.env</code>
-            (defaults to <code>~/.config/bernard/.env</code>)
+            <strong>XDG config</strong> &mdash; <code>$XDG_CONFIG_HOME/bernard/.env</code> (defaults
+            to <code>~/.config/bernard/.env</code>)
           </li>
           <li>
             <strong>Legacy</strong> &mdash; <code>~/.bernard/.env</code> (fallback for migrations
@@ -1464,8 +1466,8 @@
 
         <h3 id="tool-memory">Memory</h3>
         <p>
-          Persistent, disk-backed storage at <code>~/.local/share/bernard/memory/</code>. Survives across
-          sessions. The agent can list, read, write, and delete memory entries by key.
+          Persistent, disk-backed storage at <code>~/.local/share/bernard/memory/</code>. Survives
+          across sessions. The agent can list, read, write, and delete memory entries by key.
         </p>
         <p>
           Use this for things like project conventions, server addresses, or personal preferences.
@@ -1561,9 +1563,7 @@
             Supported formats: PNG, JPEG, GIF, WebP &mdash; resolved relative to the current working
             directory
           </li>
-          <li>
-            Optional inline prompt: <code>/image diagram.png explain the data flow</code>
-          </li>
+          <li>Optional inline prompt: <code>/image diagram.png explain the data flow</code></li>
           <li>
             Switch to a vision-capable model with <code>/model</code> first if your current default
             doesn't support images
@@ -2008,9 +2008,7 @@
         </p>
 
         <h3 id="references-resolver">Resolver</h3>
-        <p>
-          A short LLM pass returns one of four outcomes:
-        </p>
+        <p>A short LLM pass returns one of four outcomes:</p>
         <ul>
           <li>
             <code>resolved</code> &mdash; the entity matches one memory; Bernard inlines the value
@@ -2023,7 +2021,9 @@
             <code>unknown</code> &mdash; no match; Bernard either tries a tool lookup (see below) or
             asks for free-form text
           </li>
-          <li><code>noop</code> &mdash; no entities to resolve, or the LLM call failed (fail-open)</li>
+          <li>
+            <code>noop</code> &mdash; no entities to resolve, or the LLM call failed (fail-open)
+          </li>
         </ul>
         <p>
           Confirmed answers are written to <code>memory/rewriter-hints.md</code> so the same
@@ -2034,11 +2034,11 @@
         <p>
           When the resolver returns <code>unknown</code> and
           <code>BERNARD_REFERENCE_LOOKUP</code> is on (the default), Bernard picks one read-only
-          allowlisted tool &mdash; e.g.&nbsp;<code>contacts__search</code>,
-          <code>web_search</code>, an MCP <code>*_list</code> / <code>*_read</code> &mdash; and runs
-          it with a hard 5-second timeout enforced via <code>Promise.race</code> against a real
-          timer (resilient to tools that ignore <code>abortSignal</code>). The result is parsed into
-          one of <code>none</code> / <code>found</code> / <code>ambiguous</code>; on
+          allowlisted tool &mdash; e.g.&nbsp;<code>contacts__search</code>, <code>web_search</code>,
+          an MCP <code>*_list</code> / <code>*_read</code> &mdash; and runs it with a hard 5-second
+          timeout enforced via <code>Promise.race</code> against a real timer (resilient to tools
+          that ignore <code>abortSignal</code>). The result is parsed into one of
+          <code>none</code> / <code>found</code> / <code>ambiguous</code>; on
           <code>found</code> Bernard shows a Save / Edit / Skip menu before persisting to memory.
           Every stage fails open &mdash; if anything goes wrong, you simply get the original prompt
           for the value.
@@ -2055,18 +2055,18 @@
           <code>src/providers/profiles.ts</code>. Resolved entities can be inlined inline, jargon is
           smoothed, and instructions are normalised. Temperature is 0, output falls back to the
           original prompt on any error, and the toggle lives at
-          <code>BERNARD_PROMPT_REWRITER</code> (also flippable from
-          <code>/agent-options</code>).
+          <code>BERNARD_PROMPT_REWRITER</code> (also flippable from <code>/agent-options</code>).
         </p>
 
         <!-- ═══════════════ 11. Coordinator (ReAct) Mode ═══════════════ -->
         <h2 id="react">11. Coordinator (ReAct) Mode <span class="vtag">v0.9.0+</span></h2>
         <p>
-          Coordinator mode turns each turn into a structured think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide
-          loop. Bernard plans the work with a <code>plan</code> tool, talks itself through the
-          rationale with <code>think</code>, and re-checks the plan after each step with
-          <code>evaluate</code>. It's slower per turn but dramatically better at multi-step work
-          that combines tool calls and reasoning.
+          Coordinator mode turns each turn into a structured
+          think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide loop. Bernard
+          plans the work with a <code>plan</code> tool, talks itself through the rationale with
+          <code>think</code>, and re-checks the plan after each step with <code>evaluate</code>.
+          It's slower per turn but dramatically better at multi-step work that combines tool calls
+          and reasoning.
         </p>
         <ul>
           <li>
@@ -2075,14 +2075,17 @@
           </li>
           <li>
             Per-turn step budget grows to
-            <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code> &mdash; sub-agents and specialists are
-            unaffected
+            <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code> &mdash; sub-agents and specialists
+            are unaffected
           </li>
           <li>
             Worst-case step count per turn is <code>effectiveMaxSteps &times; 3</code>; the
             enforcement loop may re-prompt up to 2 extra times if a plan step is still unresolved
           </li>
-          <li>New tools available to the agent: <code>plan</code>, <code>think</code>, <code>evaluate</code></li>
+          <li>
+            New tools available to the agent: <code>plan</code>, <code>think</code>,
+            <code>evaluate</code>
+          </li>
         </ul>
         <div class="callout callout-tip">
           <div class="callout-title">When to use</div>
@@ -2228,8 +2231,8 @@
           Notes live in <code>~/.local/share/bernard/cron/notes/&lt;job-id&gt;.json</code>, capped
           at 100 entries per job with atomic writes. Anything written during a run is appended to
           the matching <code>cron_logs_get</code> output as a
-          <code>## Notes written during this run</code> section, so you can read the run log and
-          the notes in one place.
+          <code>## Notes written during this run</code> section, so you can read the run log and the
+          notes in one place.
         </p>
 
         <h3 id="cron-cli">CLI Commands</h3>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -683,6 +683,8 @@
               <li><a href="#tool-web">Web Read</a></li>
               <li><a href="#tool-subagent">Sub-Agents</a></li>
               <li><a href="#tool-task">Tasks</a></li>
+              <li><a href="#tool-image">Image Attachment</a></li>
+              <li><a href="#tool-augmentation">Tool Augmentation Layer</a></li>
               <li><a href="#tool-datetime">Date/Time</a></li>
               <li><a href="#tool-wait">Wait</a></li>
             </ul>
@@ -715,6 +717,17 @@
             </ul>
           </li>
           <li>
+            <a href="#references">Reference Resolution</a>
+            <ul class="toc-sub">
+              <li><a href="#references-resolver">Resolver</a></li>
+              <li><a href="#references-lookup">Tool Lookup</a></li>
+              <li><a href="#references-rewriter">Prompt Rewriter</a></li>
+            </ul>
+          </li>
+          <li>
+            <a href="#react">Coordinator (ReAct) Mode</a>
+          </li>
+          <li>
             <a href="#context">Context Management</a>
             <ul class="toc-sub">
               <li><a href="#context-auto-continue">Auto-Continue</a></li>
@@ -731,6 +744,7 @@
               <li><a href="#cron-daemon">Daemon</a></li>
               <li><a href="#cron-alerts">Alerts</a></li>
               <li><a href="#cron-logs">Logs</a></li>
+              <li><a href="#cron-notes">Notes</a></li>
               <li><a href="#cron-cli">CLI Commands</a></li>
             </ul>
           </li>
@@ -788,12 +802,35 @@
 
 <span class="comment"># Verify it's configured</span>
 <span class="accent">$</span> bernard providers</code></pre>
-        <p>All configuration is stored in <code>~/.bernard/</code>:</p>
+        <p>
+          Bernard follows the
+          <a href="https://specifications.freedesktop.org/basedir/latest/" target="_blank" rel="noopener noreferrer"
+            >XDG Base Directory Specification</a
+          >. Default locations:
+        </p>
         <ul>
-          <li><code>keys.json</code> &mdash; Stored API keys (file permissions set to 0600)</li>
-          <li><code>preferences.json</code> &mdash; Provider, model, theme, and option choices</li>
-          <li><code>.env</code> &mdash; Fallback environment variable file</li>
+          <li>
+            <code>~/.config/bernard/</code> &mdash; <code>preferences.json</code>,
+            <code>keys.json</code> (0600), <code>.env</code>, <code>mcp.json</code>
+          </li>
+          <li>
+            <code>~/.local/share/bernard/</code> &mdash; <code>memory/</code>,
+            <code>rag/</code>, <code>routines/</code>, <code>specialists/</code>,
+            <code>tool-profiles/</code>, <code>cron/</code>
+          </li>
+          <li>
+            <code>~/.cache/bernard/</code> &mdash; embeddings models, update-check cache
+          </li>
+          <li>
+            <code>~/.local/state/bernard/</code> &mdash; conversation history, logs, daemon PID
+          </li>
         </ul>
+        <p>
+          Override with the standard <code>XDG_*_HOME</code> variables, or use
+          <code>BERNARD_HOME=/path</code> to force the legacy flat layout (everything under one
+          directory, like the old <code>~/.bernard/</code>). On first run, files are auto-migrated
+          from <code>~/.bernard/</code> if present.
+        </p>
 
         <h3 id="basic-usage">Basic Usage</h3>
         <p>
@@ -923,6 +960,92 @@
                 <td><code>0.8</code></td>
               </tr>
               <tr>
+                <td><code>BERNARD_REACT_MODE</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Coordinator (ReAct) mode &mdash; think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide
+                  loop. Per-turn step budget grows to <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code>.
+                </td>
+                <td><code>false</code></td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_PROMPT_REWRITER</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Pre-turn LLM pass that rewrites the user message for the active model family
+                  (fail-open)
+                </td>
+                <td><code>true</code></td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_REFERENCE_LOOKUP</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  When the resolver returns <code>unknown</code>, attempt one read-only tool lookup
+                  before prompting (5&thinsp;s timeout, fail-open)
+                </td>
+                <td><code>true</code></td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_LOOKUP_TOOLS</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Comma-separated tool-name allowlist additions for the resolver lookup pass (use
+                  read-only tools only)
+                </td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_TOOL_DETAILS</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Show full tool-call input/output (off collapses each call to a one-line summary)
+                </td>
+                <td><code>true</code></td>
+              </tr>
+              <tr>
+                <td>
+                  <code>BERNARD_SUBAGENT_RESULT_MAX_CHARS</code>
+                  <span class="vtag">v0.9.0+</span>
+                </td>
+                <td>
+                  Max characters returned from a sub-agent / specialist into the parent agent's
+                  context (the user still sees full output)
+                </td>
+                <td><code>4000</code></td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_PLAIN_MENU</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Force the classic numbered-list menu fallback instead of the arrow-key UI (also
+                  used automatically in non-TTY shells)
+                </td>
+                <td><code>0</code></td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_CORRECTION_ENABLED</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Run the correction agent at session close to learn from tool-wrapper failures
+                </td>
+                <td><code>true</code></td>
+              </tr>
+              <tr>
+                <td><code>BERNARD_HOME</code></td>
+                <td>
+                  Override every XDG directory with one flat path (legacy <code>~/.bernard/</code>
+                  layout)
+                </td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <td><code>BRAVE_API_KEY</code></td>
+                <td>Optional &mdash; Brave Search API key for <code>web_search</code></td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <td><code>TAVILY_API_KEY</code></td>
+                <td>
+                  Optional &mdash; Tavily API key for <code>web_search</code> (fallback when Brave is
+                  absent)
+                </td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
                 <td><code>ANTHROPIC_API_KEY</code></td>
                 <td>Anthropic API key</td>
                 <td>&mdash;</td>
@@ -949,7 +1072,14 @@
           <li>
             <strong>Current working directory</strong> &mdash; <code>./.env</code> (checked first)
           </li>
-          <li><strong>Home config</strong> &mdash; <code>~/.bernard/.env</code> (fallback)</li>
+          <li>
+            <strong>XDG config</strong> &mdash; <code>$XDG_CONFIG_HOME/bernard/.env</code>
+            (defaults to <code>~/.config/bernard/.env</code>)
+          </li>
+          <li>
+            <strong>Legacy</strong> &mdash; <code>~/.bernard/.env</code> (fallback for migrations
+            from older installs)
+          </li>
         </ol>
         <p>
           API keys stored via <code>bernard add-key</code> take precedence over
@@ -966,8 +1096,9 @@
 <span class="comment"># Check key status for all providers</span>
 <span class="accent">$</span> bernard providers</code></pre>
         <p>
-          Keys are stored in <code>~/.bernard/keys.json</code> with file permissions set to
-          <code>0600</code> (owner read/write only).
+          Keys are stored in <code>$XDG_CONFIG_HOME/bernard/keys.json</code> (defaults to
+          <code>~/.config/bernard/keys.json</code>) with file permissions set to <code>0600</code>
+          (owner read/write only).
         </p>
 
         <h3 id="options">Options Management</h3>
@@ -1003,6 +1134,22 @@
                 <td><code>BERNARD_TOKEN_WINDOW</code></td>
                 <td>0</td>
                 <td>Context window size for compression (0 = auto-detect from model)</td>
+              </tr>
+              <tr>
+                <td><code>max-steps</code></td>
+                <td><code>BERNARD_MAX_STEPS</code></td>
+                <td>25</td>
+                <td>
+                  Max agent loop iterations per request. ReAct mode triples this (capped at 150).
+                </td>
+              </tr>
+              <tr>
+                <td><code>tool-details</code> <span class="vtag">v0.9.0+</span></td>
+                <td><code>BERNARD_TOOL_DETAILS</code></td>
+                <td>true</td>
+                <td>
+                  Show full tool-call input/output (off collapses each call to a one-line summary)
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1164,7 +1311,8 @@
               <tr>
                 <td><code>/task</code></td>
                 <td>
-                  Run an isolated task with structured JSON output (no history, 5-step budget)
+                  Run an isolated task with structured JSON output (no history, proportional step
+                  budget &mdash; minimum 2)
                 </td>
               </tr>
               <tr>
@@ -1204,10 +1352,6 @@
                 <td>Interactively switch color theme</td>
               </tr>
               <tr>
-                <td><code>/options</code></td>
-                <td>View and set options (max-tokens, shell-timeout, token-window)</td>
-              </tr>
-              <tr>
                 <td><code>/update</code></td>
                 <td>Check for and install updates</td>
               </tr>
@@ -1230,16 +1374,19 @@
                 <td>List all saved specialists</td>
               </tr>
               <tr>
+                <td><code>/create-specialist</code></td>
+                <td>Create a specialist with guided AI assistance</td>
+              </tr>
+              <tr>
                 <td><code>/candidates</code></td>
                 <td>Review auto-detected specialist suggestions</td>
               </tr>
               <tr>
-                <td><code>/critic</code></td>
-                <td>Toggle critic mode for response verification (on/off)</td>
-              </tr>
-              <tr>
-                <td><code>/agent-options</code></td>
-                <td>Configure auto-creation for specialist agents</td>
+                <td><code>/agent-options</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Configure agent behavior &mdash; toggles for critic mode, ReAct/coordinator mode,
+                  prompt rewriter, tool-details, plus auto-create thresholds
+                </td>
               </tr>
               <tr>
                 <td><code>/options</code></td>
@@ -1249,8 +1396,11 @@
                 </td>
               </tr>
               <tr>
-                <td><code>/debug</code></td>
-                <td>Print a diagnostic report for troubleshooting (no secrets leaked)</td>
+                <td><code>/image</code> <span class="vtag">v0.9.0+</span></td>
+                <td>
+                  Attach an image to the next turn: <code>/image &lt;path&gt; [prompt]</code>
+                  (vision-capable model required)
+                </td>
               </tr>
               <tr>
                 <td><code>/{routine-id}</code></td>
@@ -1314,7 +1464,7 @@
 
         <h3 id="tool-memory">Memory</h3>
         <p>
-          Persistent, disk-backed storage at <code>~/.bernard/memory/</code>. Survives across
+          Persistent, disk-backed storage at <code>~/.local/share/bernard/memory/</code>. Survives across
           sessions. The agent can list, read, write, and delete memory entries by key.
         </p>
         <p>
@@ -1399,6 +1549,58 @@
           sub-steps and use the structured JSON result to decide next steps &mdash; enabling
           conditional branching and output chaining within routines.
         </div>
+
+        <h3 id="tool-image">Image Attachment <span class="vtag">v0.9.0+</span></h3>
+        <p>
+          Use <code>/image &lt;path&gt; [prompt]</code> in the REPL to attach an image to the next
+          turn. The image is loaded into the message as a vision content block, so it works only
+          with vision-capable models (Anthropic Claude, OpenAI GPT-4o family, etc.).
+        </p>
+        <ul>
+          <li>
+            Supported formats: PNG, JPEG, GIF, WebP &mdash; resolved relative to the current working
+            directory
+          </li>
+          <li>
+            Optional inline prompt: <code>/image diagram.png explain the data flow</code>
+          </li>
+          <li>
+            Switch to a vision-capable model with <code>/model</code> first if your current default
+            doesn't support images
+          </li>
+        </ul>
+
+        <h3 id="tool-augmentation">Tool Augmentation Layer <span class="vtag">v0.9.0+</span></h3>
+        <p>
+          Every tool's <code>execute</code> function is wrapped in a transparent layer that observes
+          calls, records errors, and patches the system prompt with concrete bad-example fixes the
+          next turn. The invariant is strict: only real observed failures become bad examples
+          &mdash; no hallucinated guidance.
+        </p>
+        <ul>
+          <li>
+            One JSON profile per tool at <code>tool-profiles/&lt;key&gt;.json</code>, capped at 5
+            good and 5 bad examples (oldest drops first)
+          </li>
+          <li>
+            Shell commands are split by prefix into <code>shell.git</code>, <code>shell.gh</code>,
+            <code>shell.docker</code>, <code>shell.npm</code>, <code>shell.fs</code>,
+            <code>shell.http</code> &mdash; each sub-category gets scoped guidance
+          </li>
+          <li>
+            MCP tools are augmented automatically (identified by the <code>__</code> separator) and
+            stored at <code>mcp.&lt;name&gt;.json</code>
+          </li>
+          <li>
+            When a retry succeeds, the bad example's <code>fix</code> field is patched with the
+            working args
+          </li>
+          <li>
+            Seeded defaults ship for <code>shell.git</code>, <code>shell.fs</code>,
+            <code>shell.npm</code>, <code>web_read</code>, <code>file_read_lines</code>,
+            <code>file_edit_lines</code>
+          </li>
+        </ul>
 
         <h3 id="tool-datetime">Date/Time</h3>
         <p>
@@ -1674,9 +1876,7 @@
           Critic mode adds planning, proactive scratch/memory usage, and post-response verification.
           Toggle it during a session:
         </p>
-        <pre><code><span class="accent">bernard&gt;</span> /critic on     <span class="dim"># Enable critic mode</span>
-<span class="accent">bernard&gt;</span> /critic off    <span class="dim"># Disable critic mode</span>
-<span class="accent">bernard&gt;</span> /critic        <span class="dim"># Show current status</span></code></pre>
+        <pre><code><span class="accent">bernard&gt;</span> /agent-options   <span class="dim"># Toggle critic mode (and the other behavior toggles)</span></code></pre>
         <p>When enabled:</p>
         <ul>
           <li>
@@ -1698,7 +1898,7 @@
           answers are not verified.
         </p>
         <p>
-          Enable via <code>/critic on</code> in the REPL or set
+          Enable from <code>/agent-options</code> in the REPL or set
           <code>BERNARD_CRITIC_MODE=true</code>
           in your environment. Recommended for high-stakes work (deployments, git operations,
           multi-file edits).
@@ -1784,7 +1984,7 @@
 
         <h3 id="context-diagnostics">Diagnostics</h3>
         <p>
-          Use <code>/debug</code> in the REPL to print a diagnostic report useful for
+          Use <code>/options debug</code> in the REPL to print a diagnostic report useful for
           troubleshooting. The report includes:
         </p>
         <ul>
@@ -1798,8 +1998,101 @@
         </ul>
         <p>No secrets are included in the output.</p>
 
-        <!-- ═══════════════ 10. Cron Jobs ═══════════════ -->
-        <h2 id="cron">10. Cron Jobs</h2>
+        <!-- ═══════════════ 10. Reference Resolution ═══════════════ -->
+        <h2 id="references">10. Reference Resolution <span class="vtag">v0.9.0+</span></h2>
+        <p>
+          Before each turn Bernard resolves the named entities in your message ("my brother", "the
+          staging cluster") against persistent memory. Anything that resolves is appended to the
+          system prompt as a hidden <code>## Resolved References</code> block, so the agent sees
+          concrete identifiers without you having to repeat them.
+        </p>
+
+        <h3 id="references-resolver">Resolver</h3>
+        <p>
+          A short LLM pass returns one of four outcomes:
+        </p>
+        <ul>
+          <li>
+            <code>resolved</code> &mdash; the entity matches one memory; Bernard inlines the value
+          </li>
+          <li>
+            <code>ambiguous</code> &mdash; multiple candidates; Bernard shows an arrow-key menu so
+            you can pick
+          </li>
+          <li>
+            <code>unknown</code> &mdash; no match; Bernard either tries a tool lookup (see below) or
+            asks for free-form text
+          </li>
+          <li><code>noop</code> &mdash; no entities to resolve, or the LLM call failed (fail-open)</li>
+        </ul>
+        <p>
+          Confirmed answers are written to <code>memory/rewriter-hints.md</code> so the same
+          reference resolves silently next time.
+        </p>
+
+        <h3 id="references-lookup">Tool Lookup</h3>
+        <p>
+          When the resolver returns <code>unknown</code> and
+          <code>BERNARD_REFERENCE_LOOKUP</code> is on (the default), Bernard picks one read-only
+          allowlisted tool &mdash; e.g.&nbsp;<code>contacts__search</code>,
+          <code>web_search</code>, an MCP <code>*_list</code> / <code>*_read</code> &mdash; and runs
+          it with a hard 5-second timeout enforced via <code>Promise.race</code> against a real
+          timer (resilient to tools that ignore <code>abortSignal</code>). The result is parsed into
+          one of <code>none</code> / <code>found</code> / <code>ambiguous</code>; on
+          <code>found</code> Bernard shows a Save / Edit / Skip menu before persisting to memory.
+          Every stage fails open &mdash; if anything goes wrong, you simply get the original prompt
+          for the value.
+        </p>
+        <p>
+          Use <code>BERNARD_LOOKUP_TOOLS=tool_a,tool_b</code> to extend the allowlist. Only allow
+          tools that are read-only.
+        </p>
+
+        <h3 id="references-rewriter">Prompt Rewriter</h3>
+        <p>
+          After reference resolution, a second LLM pass rewrites the user's message for the active
+          model family using the per-model <code>rewriterHint</code> in
+          <code>src/providers/profiles.ts</code>. Resolved entities can be inlined inline, jargon is
+          smoothed, and instructions are normalised. Temperature is 0, output falls back to the
+          original prompt on any error, and the toggle lives at
+          <code>BERNARD_PROMPT_REWRITER</code> (also flippable from
+          <code>/agent-options</code>).
+        </p>
+
+        <!-- ═══════════════ 11. Coordinator (ReAct) Mode ═══════════════ -->
+        <h2 id="react">11. Coordinator (ReAct) Mode <span class="vtag">v0.9.0+</span></h2>
+        <p>
+          Coordinator mode turns each turn into a structured think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide
+          loop. Bernard plans the work with a <code>plan</code> tool, talks itself through the
+          rationale with <code>think</code>, and re-checks the plan after each step with
+          <code>evaluate</code>. It's slower per turn but dramatically better at multi-step work
+          that combines tool calls and reasoning.
+        </p>
+        <ul>
+          <li>
+            Toggle with <code>BERNARD_REACT_MODE=true</code> or interactively from
+            <code>/agent-options</code>
+          </li>
+          <li>
+            Per-turn step budget grows to
+            <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code> &mdash; sub-agents and specialists are
+            unaffected
+          </li>
+          <li>
+            Worst-case step count per turn is <code>effectiveMaxSteps &times; 3</code>; the
+            enforcement loop may re-prompt up to 2 extra times if a plan step is still unresolved
+          </li>
+          <li>New tools available to the agent: <code>plan</code>, <code>think</code>, <code>evaluate</code></li>
+        </ul>
+        <div class="callout callout-tip">
+          <div class="callout-title">When to use</div>
+          Turn ReAct on for "ship a release", "diagnose this flaky test", "migrate the database
+          schema" &mdash; tasks that need a plan and verification. Leave it off for chat or
+          single-tool requests; the extra overhead isn't worth it.
+        </div>
+
+        <!-- ═══════════════ 12. Cron Jobs ═══════════════ -->
+        <h2 id="cron">12. Cron Jobs <span class="vtag">v0.5.0+</span></h2>
         <p>
           Bernard can schedule recurring tasks that run in the background on a timer. Cron jobs
           execute an AI prompt through the agent on each run, with access to all tools.
@@ -1919,6 +2212,26 @@
           </li>
         </ul>
 
+        <h3 id="cron-notes">Notes <span class="vtag">v0.9.0+</span></h3>
+        <p>
+          Each cron job has a private notebook so long-running schedules don't redo work after
+          restarts or learn the same lesson twice. The daemon injects a scoped variant of these
+          tools into every run, bound to the current <code>job.id</code> and <code>runId</code>:
+        </p>
+        <ul>
+          <li><code>cron_notes_read</code> &mdash; Read the latest notes for the current job</li>
+          <li><code>cron_notes_write</code> &mdash; Append a note to the current job's notebook</li>
+          <li><code>cron_notes_list</code> &mdash; List jobs that have at least one note</li>
+          <li><code>cron_notes_view</code> &mdash; View notes for a specific job by id</li>
+        </ul>
+        <p>
+          Notes live in <code>~/.local/share/bernard/cron/notes/&lt;job-id&gt;.json</code>, capped
+          at 100 entries per job with atomic writes. Anything written during a run is appended to
+          the matching <code>cron_logs_get</code> output as a
+          <code>## Notes written during this run</code> section, so you can read the run log and
+          the notes in one place.
+        </p>
+
         <h3 id="cron-cli">CLI Commands</h3>
         <p>Cron jobs can also be managed from the command line without entering the REPL:</p>
         <div class="table-wrap">
@@ -1959,7 +2272,7 @@
         </div>
 
         <!-- ═══════════════ 11. MCP ═══════════════ -->
-        <h2 id="mcp">11. MCP (Model Context Protocol)</h2>
+        <h2 id="mcp">13. MCP (Model Context Protocol)</h2>
         <p>
           Bernard supports the
           <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer"
@@ -1971,7 +2284,7 @@
 
         <h3 id="mcp-config">Configuration</h3>
         <p>
-          MCP servers are configured in <code>~/.bernard/mcp.json</code>. The file uses a
+          MCP servers are configured in <code>~/.config/bernard/mcp.json</code>. The file uses a
           <code>mcpServers</code> object where each key is the server name:
         </p>
         <pre><code>{
@@ -2103,7 +2416,7 @@
         </div>
 
         <!-- ═══════════════ 12. RAG Memory ═══════════════ -->
-        <h2 id="rag">12. RAG Memory</h2>
+        <h2 id="rag">14. RAG Memory</h2>
         <p>
           Bernard automatically builds a long-term knowledge base from your conversations using
           local embeddings and retrieval-augmented generation (RAG). No data leaves your machine.
@@ -2125,7 +2438,7 @@
               >fastembed</a
             >
             &mdash; no API calls required. Embeddings and facts are stored in
-            <code>~/.bernard/rag/memories.json</code>.
+            <code>~/.local/share/bernard/rag/memories.json</code>.
           </li>
           <li>
             <strong>Retrieval</strong> &mdash; On each new message, Bernard searches the RAG store
@@ -2233,7 +2546,7 @@
         </ul>
 
         <!-- ═══════════════ 13. Auto-Updates ═══════════════ -->
-        <h2 id="updates">13. Auto-Updates <span class="vtag">v0.3.0+</span></h2>
+        <h2 id="updates">15. Auto-Updates <span class="vtag">v0.3.0+</span></h2>
         <p>
           Bernard can check for new versions on npm and install them for you. Update checks are
           cached for 24 hours.
@@ -2260,7 +2573,7 @@
     <footer>
       <div class="container">
         <div class="footer-left">
-          bernard-agent &copy; <span id="year">2025</span> &middot; MIT License
+          bernard-agent &copy; <span id="year">2026</span> &middot; MIT License
         </div>
         <div class="footer-links">
           <a href="https://github.com/phillt/bernard" target="_blank" rel="noopener noreferrer"

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -728,7 +728,7 @@
     <section class="version-section" id="v0.9.0">
       <div class="container">
         <div class="major-release">
-          <div class="major-release-badge">Major release</div>
+          <div class="major-release-badge">Milestone release</div>
           <h2 class="version-heading">
             v0.9.0
             <span class="version-date">2026-05-07</span>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -452,10 +452,8 @@
         content: '';
         position: absolute;
         inset: 0;
-        background-image: linear-gradient(
-            rgba(249, 115, 22, 0.04) 1px,
-            transparent 1px
-          ),
+        background-image:
+          linear-gradient(rgba(249, 115, 22, 0.04) 1px, transparent 1px),
           linear-gradient(90deg, rgba(249, 115, 22, 0.04) 1px, transparent 1px);
         background-size: 32px 32px;
         pointer-events: none;
@@ -494,8 +492,13 @@
       }
 
       @keyframes pulse {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.5; }
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.5;
+        }
       }
 
       .major-release h2.version-heading {
@@ -736,11 +739,10 @@
           </h2>
           <p class="major-release-intro">
             The largest update since launch. v0.9.0 reshapes how Bernard handles ambiguity:
-            references resolve against memory before each turn, unknown entities trigger a
-            read-only tool lookup, and prompts get rewritten for the active model family. A
-            new coordinator (ReAct) mode adds iterative reasoning with verifiable plans, the
-            UI moves to arrow-key menus, and a tool augmentation layer learns from every
-            error your tools throw.
+            references resolve against memory before each turn, unknown entities trigger a read-only
+            tool lookup, and prompts get rewritten for the active model family. A new coordinator
+            (ReAct) mode adds iterative reasoning with verifiable plans, the UI moves to arrow-key
+            menus, and a tool augmentation layer learns from every error your tools throw.
           </p>
           <div class="release-stats">
             <div class="release-stat">
@@ -763,295 +765,319 @@
         </div>
 
         <div class="feature-grid">
-        <!-- Theme: Smarter conversations -->
-        <div class="feature feature-wide">
-          <div class="feature-header">
-            <div class="feature-icon">
-              <!-- message-square icon -->
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                style="fill: none; stroke: var(--accent)"
-              >
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-              </svg>
+          <!-- Theme: Smarter conversations -->
+          <div class="feature feature-wide">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <!-- message-square icon -->
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                </svg>
+              </div>
+              <h2>Smarter conversations <span class="tag">new</span></h2>
             </div>
-            <h2>Smarter conversations <span class="tag">new</span></h2>
+            <p>
+              Bernard now understands references the same way a human collaborator does. Before each
+              turn, a reference resolver scans your message for named entities ("my brother", "the
+              staging cluster") and looks them up in persistent memory. If the answer is missing,
+              Bernard tries one read-only tool (e.g.&nbsp;a Google Contacts MCP) before asking you,
+              then offers a Save / Edit / Skip menu so the answer sticks. A model-specific prompt
+              rewriter then reshapes the message for the active model family, and a
+              context-gathering protocol keeps the agent from inventing numbers it could have just
+              looked up.
+            </p>
+            <div class="terminal">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <span class="terminal-title">bernard</span>
+              </div>
+              <div class="terminal-body">
+                <span class="prompt">bernard&gt;</span> email my brother about the trip<br />
+                <span class="muted"
+                  >// resolver: "my brother" not in memory &mdash; trying lookup</span
+                ><br />
+                &nbsp;&nbsp;&#x25B6; google_contacts__search { query: "brother" }<br />
+                &nbsp;&nbsp;&#x2514;&#x2500; <span class="success">found</span>: Daniel Pereira
+                &lt;daniel@example.com&gt;<br />
+                <br />
+                <span class="muted">? Save this for next time?</span><br />
+                &nbsp;&nbsp;&#x276F;
+                <span class="success">Save</span> &nbsp;&nbsp;Edit&nbsp;&nbsp;Skip<br />
+                <br />
+                &nbsp;&nbsp;&#x25B6; gmail__send_email { to: "daniel@example.com", &hellip; }<br />
+                &nbsp;&nbsp;<span class="success">&#x2713;</span> sent
+              </div>
+            </div>
+            <ul>
+              <li>
+                Reference resolver with four outcomes: resolved, ambiguous, unknown, no-op (#128)
+              </li>
+              <li>
+                Reference tool-lookup pass with read-only allowlist + 5&thinsp;s timeout (#138)
+              </li>
+              <li>
+                Model-specific prompt rewriter using <code>ModelProfile.rewriterHint</code>,
+                fail-open (#125, #131)
+              </li>
+              <li>Context-gathering protocol baked into the base system prompt (#126)</li>
+            </ul>
           </div>
-          <p>
-            Bernard now understands references the same way a human collaborator does. Before each
-            turn, a reference resolver scans your message for named entities ("my brother", "the
-            staging cluster") and looks them up in persistent memory. If the answer is missing,
-            Bernard tries one read-only tool (e.g.&nbsp;a Google Contacts MCP) before asking you,
-            then offers a Save / Edit / Skip menu so the answer sticks. A model-specific prompt
-            rewriter then reshapes the message for the active model family, and a context-gathering
-            protocol keeps the agent from inventing numbers it could have just looked up.
-          </p>
-          <div class="terminal">
-            <div class="terminal-bar">
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <span class="terminal-title">bernard</span>
-            </div>
-            <div class="terminal-body">
-              <span class="prompt">bernard&gt;</span> email my brother about the trip<br />
-              <span class="muted">// resolver: "my brother" not in memory &mdash; trying lookup</span><br />
-              &nbsp;&nbsp;&#x25B6; google_contacts__search { query: "brother" }<br />
-              &nbsp;&nbsp;&#x2514;&#x2500; <span class="success">found</span>: Daniel Pereira
-              &lt;daniel@example.com&gt;<br />
-              <br />
-              <span class="muted">? Save this for next time?</span><br />
-              &nbsp;&nbsp;&#x276F; <span class="success">Save</span>
-              &nbsp;&nbsp;Edit&nbsp;&nbsp;Skip<br />
-              <br />
-              &nbsp;&nbsp;&#x25B6; gmail__send_email { to: "daniel@example.com", &hellip; }<br />
-              &nbsp;&nbsp;<span class="success">&#x2713;</span> sent
-            </div>
-          </div>
-          <ul>
-            <li>Reference resolver with four outcomes: resolved, ambiguous, unknown, no-op (#128)</li>
-            <li>Reference tool-lookup pass with read-only allowlist + 5&thinsp;s timeout (#138)</li>
-            <li>
-              Model-specific prompt rewriter using <code>ModelProfile.rewriterHint</code>, fail-open
-              (#125, #131)
-            </li>
-            <li>Context-gathering protocol baked into the base system prompt (#126)</li>
-          </ul>
-        </div>
 
-        <!-- Theme: Better reasoning -->
-        <div class="feature feature-wide">
-          <div class="feature-header">
-            <div class="feature-icon">
-              <!-- brain icon -->
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                style="fill: none; stroke: var(--accent)"
-              >
-                <path
-                  d="M12 5a3 3 0 1 0-5.997.142 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
-                ></path>
-                <path
-                  d="M12 5a3 3 0 1 1 5.997.142 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
-                ></path>
-              </svg>
+          <!-- Theme: Better reasoning -->
+          <div class="feature feature-wide">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <!-- brain icon -->
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path
+                    d="M12 5a3 3 0 1 0-5.997.142 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
+                  ></path>
+                  <path
+                    d="M12 5a3 3 0 1 1 5.997.142 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
+                  ></path>
+                </svg>
+              </div>
+              <h2>Better reasoning <span class="tag">new</span></h2>
             </div>
-            <h2>Better reasoning <span class="tag">new</span></h2>
+            <p>
+              Coordinator (ReAct) mode turns Bernard into an iterative thinker. With
+              <code>BERNARD_REACT_MODE=true</code>, every turn runs a
+              think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide loop with
+              new <code>plan</code>, <code>think</code>, and <code>evaluate</code> tools. The step
+              budget triples (capped at 150) so multi-step plans actually finish, and a post-run
+              verifier re-checks the plan if any step is still unresolved. Turn it on for hard
+              tasks; leave it off for chat &mdash; you can flip the toggle live in
+              <code>/agent-options</code>.
+            </p>
+            <div class="terminal">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <span class="terminal-title">bernard</span>
+              </div>
+              <div class="terminal-body">
+                <span class="prompt">bernard&gt;</span> /agent-options<br />
+                &nbsp;&nbsp;ReAct (coordinator) mode&nbsp;&nbsp;<span class="success">[on]</span
+                ><br />
+                <br />
+                <span class="prompt">bernard&gt;</span> ship a release: build, test, tag, push<br />
+                &nbsp;&nbsp;&#x25B6; plan: 4 steps drafted<br />
+                &nbsp;&nbsp;&#x25B6; think: tests must pass before tagging<br />
+                &nbsp;&nbsp;&#x25B6; shell: npm test &mdash; <span class="success">2074 passed</span
+                ><br />
+                &nbsp;&nbsp;&#x25B6; evaluate: step 1/4 done, advancing<br />
+                &nbsp;&nbsp;&hellip; (think &rarr; act &rarr; evaluate, repeated)<br />
+                &nbsp;&nbsp;<span class="success">&#x2713;</span> all 4 steps verified
+              </div>
+            </div>
+            <ul>
+              <li>
+                Coordinator / ReAct loop with <code>plan</code>, <code>think</code>,
+                <code>evaluate</code> tools (#117)
+              </li>
+              <li>
+                Per-turn step budget grows to
+                <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code> when ReAct is on
+              </li>
+              <li>
+                Post-run activity logs and plan verification with up to 2 enforcement re-prompts
+                (#137)
+              </li>
+            </ul>
           </div>
-          <p>
-            Coordinator (ReAct) mode turns Bernard into an iterative thinker. With
-            <code>BERNARD_REACT_MODE=true</code>, every turn runs a think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide
-            loop with new <code>plan</code>, <code>think</code>, and <code>evaluate</code> tools.
-            The step budget triples (capped at 150) so multi-step plans actually finish, and a
-            post-run verifier re-checks the plan if any step is still unresolved. Turn it on for
-            hard tasks; leave it off for chat &mdash; you can flip the toggle live in
-            <code>/agent-options</code>.
-          </p>
-          <div class="terminal">
-            <div class="terminal-bar">
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <span class="terminal-title">bernard</span>
-            </div>
-            <div class="terminal-body">
-              <span class="prompt">bernard&gt;</span> /agent-options<br />
-              &nbsp;&nbsp;ReAct (coordinator) mode&nbsp;&nbsp;<span class="success">[on]</span><br />
-              <br />
-              <span class="prompt">bernard&gt;</span> ship a release: build, test, tag, push<br />
-              &nbsp;&nbsp;&#x25B6; plan: 4 steps drafted<br />
-              &nbsp;&nbsp;&#x25B6; think: tests must pass before tagging<br />
-              &nbsp;&nbsp;&#x25B6; shell: npm test &mdash; <span class="success">2074 passed</span><br />
-              &nbsp;&nbsp;&#x25B6; evaluate: step 1/4 done, advancing<br />
-              &nbsp;&nbsp;&hellip; (think &rarr; act &rarr; evaluate, repeated)<br />
-              &nbsp;&nbsp;<span class="success">&#x2713;</span> all 4 steps verified
-            </div>
-          </div>
-          <ul>
-            <li>
-              Coordinator / ReAct loop with <code>plan</code>, <code>think</code>,
-              <code>evaluate</code> tools (#117)
-            </li>
-            <li>
-              Per-turn step budget grows to <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code> when
-              ReAct is on
-            </li>
-            <li>Post-run activity logs and plan verification with up to 2 enforcement re-prompts (#137)</li>
-          </ul>
-        </div>
 
-        <!-- Theme: New UI surface -->
-        <div class="feature feature-wide">
-          <div class="feature-header">
-            <div class="feature-icon">
-              <!-- monitor icon -->
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                style="fill: none; stroke: var(--accent)"
-              >
-                <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-                <line x1="8" y1="21" x2="16" y2="21"></line>
-                <line x1="12" y1="17" x2="12" y2="21"></line>
-              </svg>
+          <!-- Theme: New UI surface -->
+          <div class="feature feature-wide">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <!-- monitor icon -->
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+                  <line x1="8" y1="21" x2="16" y2="21"></line>
+                  <line x1="12" y1="17" x2="12" y2="21"></line>
+                </svg>
+              </div>
+              <h2>New UI surface <span class="tag">new</span></h2>
             </div>
-            <h2>New UI surface <span class="tag">new</span></h2>
+            <p>
+              Menus are now arrow-key driven by default. Bernard pins the menu region with
+              <code>setPinnedRegion</code>, you move with arrows or digits 1&ndash;9, and Enter
+              commits. Non-TTY environments and <code>BERNARD_PLAIN_MENU=1</code> still get the
+              classic numbered prompt as a fallback.
+              <code>/image &lt;path&gt; [prompt]</code> attaches an image to the next turn, and a
+              <code>/options tool-details</code> toggle collapses the per-call tool noise into
+              compact one-liners.
+            </p>
+            <div class="terminal">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <span class="terminal-title">bernard</span>
+              </div>
+              <div class="terminal-body">
+                <span class="prompt">bernard&gt;</span> /image ./screenshot.png describe this UI<br />
+                <span class="muted">// attached: screenshot.png (412 KB)</span><br />
+                &nbsp;&nbsp;&#x25B6; reading image &hellip;<br />
+                &nbsp;&nbsp;&#x2514;&#x2500; A dark dashboard with three tabs: Memory, Cron, MCP.
+                The Memory tab&hellip;<br />
+                <br />
+                <span class="prompt">bernard&gt;</span> /theme<br />
+                &nbsp;&nbsp;<span class="muted">? Pick a theme &mdash; &uarr;/&darr; Enter</span
+                ><br />
+                &nbsp;&nbsp;&#x276F; <span class="success">bernard</span><br />
+                &nbsp;&nbsp;&nbsp;&nbsp;ocean<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;forest<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;synthwave
+              </div>
+            </div>
+            <ul>
+              <li>
+                Arrow-key menu component with <code>BERNARD_PLAIN_MENU</code> fallback (#113, #132)
+              </li>
+              <li>Image attachment via <code>/image</code> on vision-capable models (#112)</li>
+              <li>
+                <code>/options tool-details</code> compact / verbose toggle &mdash;
+                <code>BERNARD_TOOL_DETAILS</code> (#119)
+              </li>
+            </ul>
           </div>
-          <p>
-            Menus are now arrow-key driven by default. Bernard pins the menu region with
-            <code>setPinnedRegion</code>, you move with arrows or digits 1&ndash;9, and Enter
-            commits. Non-TTY environments and <code>BERNARD_PLAIN_MENU=1</code> still get the
-            classic numbered prompt as a fallback. <code>/image &lt;path&gt; [prompt]</code>
-            attaches an image to the next turn, and a <code>/options tool-details</code> toggle
-            collapses the per-call tool noise into compact one-liners.
-          </p>
-          <div class="terminal">
-            <div class="terminal-bar">
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <span class="terminal-title">bernard</span>
-            </div>
-            <div class="terminal-body">
-              <span class="prompt">bernard&gt;</span> /image ./screenshot.png describe this UI<br />
-              <span class="muted">// attached: screenshot.png (412 KB)</span><br />
-              &nbsp;&nbsp;&#x25B6; reading image &hellip;<br />
-              &nbsp;&nbsp;&#x2514;&#x2500; A dark dashboard with three tabs: Memory, Cron, MCP. The
-              Memory tab&hellip;<br />
-              <br />
-              <span class="prompt">bernard&gt;</span> /theme<br />
-              &nbsp;&nbsp;<span class="muted">? Pick a theme &mdash; &uarr;/&darr; Enter</span><br />
-              &nbsp;&nbsp;&#x276F; <span class="success">bernard</span><br />
-              &nbsp;&nbsp;&nbsp;&nbsp;ocean<br />
-              &nbsp;&nbsp;&nbsp;&nbsp;forest<br />
-              &nbsp;&nbsp;&nbsp;&nbsp;synthwave
-            </div>
-          </div>
-          <ul>
-            <li>Arrow-key menu component with <code>BERNARD_PLAIN_MENU</code> fallback (#113, #132)</li>
-            <li>Image attachment via <code>/image</code> on vision-capable models (#112)</li>
-            <li>
-              <code>/options tool-details</code> compact / verbose toggle &mdash;
-              <code>BERNARD_TOOL_DETAILS</code> (#119)
-            </li>
-          </ul>
-        </div>
 
-        <!-- Theme: Operators & infra -->
-        <div class="feature feature-wide">
-          <div class="feature-header">
-            <div class="feature-icon">
-              <!-- server icon -->
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                style="fill: none; stroke: var(--accent)"
-              >
-                <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
-                <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
-                <line x1="6" y1="6" x2="6.01" y2="6"></line>
-                <line x1="6" y1="18" x2="6.01" y2="18"></line>
-              </svg>
+          <!-- Theme: Operators & infra -->
+          <div class="feature feature-wide">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <!-- server icon -->
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+                  <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+                  <line x1="6" y1="6" x2="6.01" y2="6"></line>
+                  <line x1="6" y1="18" x2="6.01" y2="18"></line>
+                </svg>
+              </div>
+              <h2>Operators &amp; infra <span class="tag">new</span></h2>
             </div>
-            <h2>Operators &amp; infra <span class="tag">new</span></h2>
+            <p>
+              A new tool augmentation layer wraps every tool's <code>execute</code> to observe
+              errors and patch the system prompt with concrete bad-example fixes &mdash; no
+              hallucination, only real observed failures. Shell commands are split into
+              sub-categories (<code>shell.git</code>, <code>shell.gh</code>,
+              <code>shell.docker</code>, <code>shell.npm</code>, <code>shell.fs</code>,
+              <code>shell.http</code>) so guidance stays scoped. Cron jobs gained persistent notes:
+              the daemon injects <code>cron_notes_read</code> / <code>cron_notes_write</code> scoped
+              to the current job so long-running schedules don't redo work after restarts.
+            </p>
+            <div class="terminal">
+              <div class="terminal-bar">
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <div class="terminal-dot"></div>
+                <span class="terminal-title">bernard</span>
+              </div>
+              <div class="terminal-body">
+                <span class="muted"
+                  >// In a cron job, Bernard reads notes from the previous run:</span
+                ><br />
+                &nbsp;&nbsp;&#x25B6; cron_notes_read &mdash; 3 entries<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;1. last sync cursor: 2026-05-07T03:14Z<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;2. skip account #482 &mdash; flagged for review<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;3. retry budget reset to 0<br />
+                &nbsp;&nbsp;&#x25B6; sync_accounts { since: "2026-05-07T03:14Z" }<br />
+                &nbsp;&nbsp;&#x25B6; cron_notes_write { entry: "synced 12 accounts, cursor &rarr;
+                &hellip;" }<br />
+                &nbsp;&nbsp;<span class="success">&#x2713;</span> run finished &mdash; notes saved
+              </div>
+            </div>
+            <ul>
+              <li>
+                Tool augmentation layer with auto-learned bad-example fixes &mdash; tool-wrapper
+                specialists (<code>shell-wrapper</code>, <code>file-wrapper</code>,
+                <code>web-wrapper</code>), correction agent, and specialist creator (#111)
+              </li>
+              <li>
+                Cron persistent notes: per-job JSON store, 100-entry cap, atomic writes, and a
+                <code>## Notes written during this run</code> section in
+                <code>cron_logs_get</code> (#130)
+              </li>
+            </ul>
           </div>
-          <p>
-            A new tool augmentation layer wraps every tool's <code>execute</code> to observe errors
-            and patch the system prompt with concrete bad-example fixes &mdash; no hallucination,
-            only real observed failures. Shell commands are split into sub-categories
-            (<code>shell.git</code>, <code>shell.gh</code>, <code>shell.docker</code>,
-            <code>shell.npm</code>, <code>shell.fs</code>, <code>shell.http</code>) so guidance
-            stays scoped. Cron jobs gained persistent notes: the daemon injects
-            <code>cron_notes_read</code> / <code>cron_notes_write</code> scoped to the current job
-            so long-running schedules don't redo work after restarts.
-          </p>
-          <div class="terminal">
-            <div class="terminal-bar">
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <div class="terminal-dot"></div>
-              <span class="terminal-title">bernard</span>
-            </div>
-            <div class="terminal-body">
-              <span class="muted">// In a cron job, Bernard reads notes from the previous run:</span><br />
-              &nbsp;&nbsp;&#x25B6; cron_notes_read &mdash; 3 entries<br />
-              &nbsp;&nbsp;&nbsp;&nbsp;1. last sync cursor: 2026-05-07T03:14Z<br />
-              &nbsp;&nbsp;&nbsp;&nbsp;2. skip account #482 &mdash; flagged for review<br />
-              &nbsp;&nbsp;&nbsp;&nbsp;3. retry budget reset to 0<br />
-              &nbsp;&nbsp;&#x25B6; sync_accounts { since: "2026-05-07T03:14Z" }<br />
-              &nbsp;&nbsp;&#x25B6; cron_notes_write { entry: "synced 12 accounts, cursor &rarr; &hellip;" }<br />
-              &nbsp;&nbsp;<span class="success">&#x2713;</span> run finished &mdash; notes saved
-            </div>
-          </div>
-          <ul>
-            <li>
-              Tool augmentation layer with auto-learned bad-example fixes &mdash; tool-wrapper
-              specialists (<code>shell-wrapper</code>, <code>file-wrapper</code>,
-              <code>web-wrapper</code>), correction agent, and specialist creator (#111)
-            </li>
-            <li>
-              Cron persistent notes: per-job JSON store, 100-entry cap, atomic writes, and a
-              <code>## Notes written during this run</code> section in <code>cron_logs_get</code> (#130)
-            </li>
-          </ul>
-        </div>
 
-        <!-- Reliability & polish -->
-        <div class="feature feature-wide">
-          <div class="feature-header">
-            <div class="feature-icon">
-              <!-- check-circle icon -->
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                style="fill: none; stroke: var(--accent)"
-              >
-                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-                <polyline points="22 4 12 14.01 9 11.01"></polyline>
-              </svg>
+          <!-- Reliability & polish -->
+          <div class="feature feature-wide">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <!-- check-circle icon -->
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+                  <polyline points="22 4 12 14.01 9 11.01"></polyline>
+                </svg>
+              </div>
+              <h2>Reliability &amp; polish <span class="tag">fix</span></h2>
             </div>
-            <h2>Reliability &amp; polish <span class="tag">fix</span></h2>
+            <ul>
+              <li>
+                Auto-create startup race fixed &mdash; pending candidates are promoted on enable
+                (#135)
+              </li>
+              <li>Critic and ReAct toggles now have round-trip test coverage (#129)</li>
+              <li>
+                MCP-tool schema extraction handles both <code>jsonSchema</code> and the
+                <code>_jsonSchema</code> shape produced by <code>@ai-sdk/ui-utils</code>
+              </li>
+              <li>
+                Reference-lookup timeout enforced via <code>Promise.race</code> against a real timer
+                &mdash; resilient to tools that ignore <code>abortSignal</code>
+              </li>
+            </ul>
           </div>
-          <ul>
-            <li>Auto-create startup race fixed &mdash; pending candidates are promoted on enable (#135)</li>
-            <li>Critic and ReAct toggles now have round-trip test coverage (#129)</li>
-            <li>
-              MCP-tool schema extraction handles both <code>jsonSchema</code> and the
-              <code>_jsonSchema</code> shape produced by <code>@ai-sdk/ui-utils</code>
-            </li>
-            <li>
-              Reference-lookup timeout enforced via <code>Promise.race</code> against a real timer
-              &mdash; resilient to tools that ignore <code>abortSignal</code>
-            </li>
-          </ul>
-        </div>
         </div>
         <!-- /feature-grid (themes) -->
 
@@ -1107,16 +1133,18 @@
                   style="fill: none; stroke: var(--accent)"
                 >
                   <polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline>
-                  <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path>
+                  <path
+                    d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                  ></path>
                 </svg>
               </div>
               <h2><code>tool_wrapper_run</code> dispatch</h2>
             </div>
             <p>
-              The main agent talks to specialists through one strict-typed dispatch tool.
-              Each call is isolated to its <code>targetTools</code> &mdash; the
-              <code>shell-wrapper</code> can't accidentally browse the web. Output is
-              guaranteed JSON: <code>{status, result, error?, reasoning?}</code>.
+              The main agent talks to specialists through one strict-typed dispatch tool. Each call
+              is isolated to its <code>targetTools</code> &mdash; the
+              <code>shell-wrapper</code> can't accidentally browse the web. Output is guaranteed
+              JSON: <code>{status, result, error?, reasoning?}</code>.
             </p>
           </div>
 
@@ -1142,9 +1170,9 @@
             </div>
             <p>
               A new built-in <code>web_search</code> tool tries Brave first
-              (<code>BRAVE_API_KEY</code>), falls back to Tavily
-              (<code>TAVILY_API_KEY</code>), and finally to a DuckDuckGo scrape so search
-              keeps working without keys. Returns <code>[{title, url, snippet}]</code>.
+              (<code>BRAVE_API_KEY</code>), falls back to Tavily (<code>TAVILY_API_KEY</code>), and
+              finally to a DuckDuckGo scrape so search keeps working without keys. Returns
+              <code>[{title, url, snippet}]</code>.
             </p>
           </div>
 
@@ -1171,11 +1199,10 @@
               <h2>Correction loop with validation</h2>
             </div>
             <p>
-              When a tool-wrapper returns <code>status: 'error'</code>, the args land in a
-              candidate queue. At REPL shutdown the <code>correction-agent</code> proposes a
-              fix and <em>actually executes</em> it via <code>tool_wrapper_run</code>. Only
-              validated fixes get appended to the specialist's good/bad examples (capped at
-              10 each).
+              When a tool-wrapper returns <code>status: 'error'</code>, the args land in a candidate
+              queue. At REPL shutdown the <code>correction-agent</code> proposes a fix and
+              <em>actually executes</em> it via <code>tool_wrapper_run</code>. Only validated fixes
+              get appended to the specialist's good/bad examples (capped at 10 each).
             </p>
           </div>
 
@@ -1204,9 +1231,9 @@
             </div>
             <p>
               Every tool-wrapper run appends one JSONL entry to
-              <code>logs/tool-wrappers.jsonl</code>. Easy to <code>jq</code>, easy to grep,
-              easy to ship to a log aggregator. Pairs naturally with the new post-run
-              activity logs to give you a full audit trail of what Bernard actually did.
+              <code>logs/tool-wrappers.jsonl</code>. Easy to <code>jq</code>, easy to grep, easy to
+              ship to a log aggregator. Pairs naturally with the new post-run activity logs to give
+              you a full audit trail of what Bernard actually did.
             </p>
           </div>
 
@@ -1232,10 +1259,10 @@
               <h2>OS-aware tool prompts</h2>
             </div>
             <p>
-              <code>osPromptBlock()</code> detects the host OS and injects shell hints
-              (Linux, macOS, Windows) into every tool-wrapper system prompt &mdash; so the
-              <code>shell-wrapper</code> doesn't suggest <code>brew</code> on Ubuntu or
-              GNU-only flags on macOS.
+              <code>osPromptBlock()</code> detects the host OS and injects shell hints (Linux,
+              macOS, Windows) into every tool-wrapper system prompt &mdash; so the
+              <code>shell-wrapper</code> doesn't suggest <code>brew</code> on Ubuntu or GNU-only
+              flags on macOS.
             </p>
           </div>
 
@@ -1253,16 +1280,18 @@
                   stroke-linejoin="round"
                   style="fill: none; stroke: var(--accent)"
                 >
-                  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                  <path
+                    d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+                  ></path>
                 </svg>
               </div>
               <h2>XDG paths everywhere</h2>
             </div>
             <p>
               All file paths now follow the XDG Base Directory Specification, centralized in
-              <code>src/paths.ts</code>. Set <code>BERNARD_HOME</code> for the legacy flat
-              layout. Existing <code>~/.bernard/</code> installs auto-migrate on first run
-              and leave a <code>MIGRATED</code> marker behind.
+              <code>src/paths.ts</code>. Set <code>BERNARD_HOME</code> for the legacy flat layout.
+              Existing <code>~/.bernard/</code> installs auto-migrate on first run and leave a
+              <code>MIGRATED</code> marker behind.
             </p>
           </div>
 
@@ -1287,10 +1316,10 @@
               <h2>Sub-agent context guard</h2>
             </div>
             <p>
-              <code>BERNARD_SUBAGENT_RESULT_MAX_CHARS</code> (default 4000) caps how much of
-              a sub-agent or specialist's output gets fed back into the parent context. The
-              user still sees the full output in the terminal &mdash; only the parent's
-              memory budget gets protected.
+              <code>BERNARD_SUBAGENT_RESULT_MAX_CHARS</code> (default 4000) caps how much of a
+              sub-agent or specialist's output gets fed back into the parent context. The user still
+              sees the full output in the terminal &mdash; only the parent's memory budget gets
+              protected.
             </p>
           </div>
         </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -434,10 +434,200 @@
         fill: currentColor;
       }
 
+      /* ── Major Release Hero (v0.9.0 special header) ── */
+      .major-release {
+        position: relative;
+        padding: 48px 40px;
+        margin-bottom: 32px;
+        border-radius: 16px;
+        background:
+          radial-gradient(circle at 0% 0%, rgba(249, 115, 22, 0.18), transparent 55%),
+          radial-gradient(circle at 100% 100%, rgba(249, 115, 22, 0.08), transparent 50%),
+          linear-gradient(180deg, rgba(249, 115, 22, 0.05), rgba(22, 27, 34, 0.6));
+        border: 1px solid rgba(249, 115, 22, 0.35);
+        overflow: hidden;
+      }
+
+      .major-release::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image: linear-gradient(
+            rgba(249, 115, 22, 0.04) 1px,
+            transparent 1px
+          ),
+          linear-gradient(90deg, rgba(249, 115, 22, 0.04) 1px, transparent 1px);
+        background-size: 32px 32px;
+        pointer-events: none;
+        mask-image: radial-gradient(ellipse at top right, black 20%, transparent 70%);
+      }
+
+      .major-release > * {
+        position: relative;
+      }
+
+      .major-release-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.15em;
+        color: var(--accent);
+        background: var(--accent-dim);
+        border: 1px solid rgba(249, 115, 22, 0.4);
+        border-radius: 999px;
+        padding: 6px 14px;
+        margin-bottom: 20px;
+        text-transform: uppercase;
+      }
+
+      .major-release-badge::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 10px var(--accent);
+        animation: pulse 2s ease-in-out infinite;
+      }
+
+      @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+      }
+
+      .major-release h2.version-heading {
+        font-size: clamp(28px, 6vw, 48px);
+        margin-bottom: 12px;
+        padding-bottom: 0;
+        border-bottom: 0;
+        line-height: 1.15;
+        flex-wrap: wrap;
+      }
+
+      .major-release .version-tagline {
+        flex-basis: 100%;
+        font-size: clamp(15px, 2vw, 18px);
+        font-weight: 400;
+        color: var(--text-secondary);
+        font-family: var(--sans);
+        margin-top: 6px;
+      }
+
+      .major-release-intro {
+        max-width: 720px;
+        font-size: 16px;
+        color: var(--text-secondary);
+        line-height: 1.7;
+        margin: 20px 0 24px;
+      }
+
+      .release-stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 24px;
+      }
+
+      .release-stat {
+        background: rgba(13, 17, 23, 0.6);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 12px 18px;
+        min-width: 110px;
+      }
+
+      .release-stat .stat-value {
+        display: block;
+        font-family: var(--mono);
+        font-size: 22px;
+        font-weight: 800;
+        color: var(--accent);
+        line-height: 1;
+      }
+
+      .release-stat .stat-label {
+        display: block;
+        font-size: 12px;
+        color: var(--text-secondary);
+        margin-top: 4px;
+      }
+
+      /* ── Theme grid (responsive multi-column) ── */
+      .feature-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 24px;
+        margin-top: 16px;
+      }
+
+      .feature-grid .feature {
+        margin-bottom: 0;
+      }
+
+      /* Wide cards span both columns when present */
+      .feature-grid .feature.feature-wide {
+        grid-column: 1 / -1;
+      }
+
+      /* Sub-section heading inside a release */
+      .release-subheading {
+        font-family: var(--mono);
+        font-size: 18px;
+        font-weight: 700;
+        color: var(--text);
+        margin: 40px 0 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border);
+        letter-spacing: 0.02em;
+      }
+
+      .release-subheading-desc {
+        color: var(--text-secondary);
+        font-size: 14px;
+        margin: -8px 0 16px;
+      }
+
+      /* Compact card variant (no terminal, used in 2-col grid) */
+      .feature-compact {
+        padding: 24px;
+      }
+
+      .feature-compact h2 {
+        font-size: 17px;
+      }
+
+      .feature-compact p {
+        font-size: 14px;
+      }
+
+      .feature-compact ul li {
+        font-size: 14px;
+      }
+
       /* ── Responsive ── */
       @media (max-width: 640px) {
         .feature {
           padding: 24px 20px;
+        }
+
+        .major-release {
+          padding: 32px 20px;
+        }
+
+        .release-stats {
+          gap: 8px;
+        }
+
+        .release-stat {
+          padding: 10px 14px;
+          min-width: 90px;
+        }
+
+        .release-stat .stat-value {
+          font-size: 18px;
         }
 
         .menu-toggle {
@@ -531,6 +721,580 @@
       <div class="container">
         <h1>Release Notes</h1>
         <p>All Bernard releases, newest first.</p>
+      </div>
+    </section>
+
+    <!-- v0.9.0 -->
+    <section class="version-section" id="v0.9.0">
+      <div class="container">
+        <div class="major-release">
+          <div class="major-release-badge">Major release</div>
+          <h2 class="version-heading">
+            v0.9.0
+            <span class="version-date">2026-05-07</span>
+            <span class="version-tagline">Bernard learns to look things up.</span>
+          </h2>
+          <p class="major-release-intro">
+            The largest update since launch. v0.9.0 reshapes how Bernard handles ambiguity:
+            references resolve against memory before each turn, unknown entities trigger a
+            read-only tool lookup, and prompts get rewritten for the active model family. A
+            new coordinator (ReAct) mode adds iterative reasoning with verifiable plans, the
+            UI moves to arrow-key menus, and a tool augmentation layer learns from every
+            error your tools throw.
+          </p>
+          <div class="release-stats">
+            <div class="release-stat">
+              <span class="stat-value">16</span>
+              <span class="stat-label">PRs merged</span>
+            </div>
+            <div class="release-stat">
+              <span class="stat-value">14</span>
+              <span class="stat-label">user-facing features</span>
+            </div>
+            <div class="release-stat">
+              <span class="stat-value">7</span>
+              <span class="stat-label">new env vars</span>
+            </div>
+            <div class="release-stat">
+              <span class="stat-value">5</span>
+              <span class="stat-label">bundled specialists</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-grid">
+        <!-- Theme: Smarter conversations -->
+        <div class="feature feature-wide">
+          <div class="feature-header">
+            <div class="feature-icon">
+              <!-- message-square icon -->
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="fill: none; stroke: var(--accent)"
+              >
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+              </svg>
+            </div>
+            <h2>Smarter conversations <span class="tag">new</span></h2>
+          </div>
+          <p>
+            Bernard now understands references the same way a human collaborator does. Before each
+            turn, a reference resolver scans your message for named entities ("my brother", "the
+            staging cluster") and looks them up in persistent memory. If the answer is missing,
+            Bernard tries one read-only tool (e.g.&nbsp;a Google Contacts MCP) before asking you,
+            then offers a Save / Edit / Skip menu so the answer sticks. A model-specific prompt
+            rewriter then reshapes the message for the active model family, and a context-gathering
+            protocol keeps the agent from inventing numbers it could have just looked up.
+          </p>
+          <div class="terminal">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <span class="terminal-title">bernard</span>
+            </div>
+            <div class="terminal-body">
+              <span class="prompt">bernard&gt;</span> email my brother about the trip<br />
+              <span class="muted">// resolver: "my brother" not in memory &mdash; trying lookup</span><br />
+              &nbsp;&nbsp;&#x25B6; google_contacts__search { query: "brother" }<br />
+              &nbsp;&nbsp;&#x2514;&#x2500; <span class="success">found</span>: Daniel Pereira
+              &lt;daniel@example.com&gt;<br />
+              <br />
+              <span class="muted">? Save this for next time?</span><br />
+              &nbsp;&nbsp;&#x276F; <span class="success">Save</span>
+              &nbsp;&nbsp;Edit&nbsp;&nbsp;Skip<br />
+              <br />
+              &nbsp;&nbsp;&#x25B6; gmail__send_email { to: "daniel@example.com", &hellip; }<br />
+              &nbsp;&nbsp;<span class="success">&#x2713;</span> sent
+            </div>
+          </div>
+          <ul>
+            <li>Reference resolver with four outcomes: resolved, ambiguous, unknown, no-op (#128)</li>
+            <li>Reference tool-lookup pass with read-only allowlist + 5&thinsp;s timeout (#138)</li>
+            <li>
+              Model-specific prompt rewriter using <code>ModelProfile.rewriterHint</code>, fail-open
+              (#125, #131)
+            </li>
+            <li>Context-gathering protocol baked into the base system prompt (#126)</li>
+          </ul>
+        </div>
+
+        <!-- Theme: Better reasoning -->
+        <div class="feature feature-wide">
+          <div class="feature-header">
+            <div class="feature-icon">
+              <!-- brain icon -->
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="fill: none; stroke: var(--accent)"
+              >
+                <path
+                  d="M12 5a3 3 0 1 0-5.997.142 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
+                ></path>
+                <path
+                  d="M12 5a3 3 0 1 1 5.997.142 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
+                ></path>
+              </svg>
+            </div>
+            <h2>Better reasoning <span class="tag">new</span></h2>
+          </div>
+          <p>
+            Coordinator (ReAct) mode turns Bernard into an iterative thinker. With
+            <code>BERNARD_REACT_MODE=true</code>, every turn runs a think&nbsp;&rarr;&nbsp;act&nbsp;&rarr;&nbsp;evaluate&nbsp;&rarr;&nbsp;decide
+            loop with new <code>plan</code>, <code>think</code>, and <code>evaluate</code> tools.
+            The step budget triples (capped at 150) so multi-step plans actually finish, and a
+            post-run verifier re-checks the plan if any step is still unresolved. Turn it on for
+            hard tasks; leave it off for chat &mdash; you can flip the toggle live in
+            <code>/agent-options</code>.
+          </p>
+          <div class="terminal">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <span class="terminal-title">bernard</span>
+            </div>
+            <div class="terminal-body">
+              <span class="prompt">bernard&gt;</span> /agent-options<br />
+              &nbsp;&nbsp;ReAct (coordinator) mode&nbsp;&nbsp;<span class="success">[on]</span><br />
+              <br />
+              <span class="prompt">bernard&gt;</span> ship a release: build, test, tag, push<br />
+              &nbsp;&nbsp;&#x25B6; plan: 4 steps drafted<br />
+              &nbsp;&nbsp;&#x25B6; think: tests must pass before tagging<br />
+              &nbsp;&nbsp;&#x25B6; shell: npm test &mdash; <span class="success">2074 passed</span><br />
+              &nbsp;&nbsp;&#x25B6; evaluate: step 1/4 done, advancing<br />
+              &nbsp;&nbsp;&hellip; (think &rarr; act &rarr; evaluate, repeated)<br />
+              &nbsp;&nbsp;<span class="success">&#x2713;</span> all 4 steps verified
+            </div>
+          </div>
+          <ul>
+            <li>
+              Coordinator / ReAct loop with <code>plan</code>, <code>think</code>,
+              <code>evaluate</code> tools (#117)
+            </li>
+            <li>
+              Per-turn step budget grows to <code>min(BERNARD_MAX_STEPS &times; 3, 150)</code> when
+              ReAct is on
+            </li>
+            <li>Post-run activity logs and plan verification with up to 2 enforcement re-prompts (#137)</li>
+          </ul>
+        </div>
+
+        <!-- Theme: New UI surface -->
+        <div class="feature feature-wide">
+          <div class="feature-header">
+            <div class="feature-icon">
+              <!-- monitor icon -->
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="fill: none; stroke: var(--accent)"
+              >
+                <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+                <line x1="8" y1="21" x2="16" y2="21"></line>
+                <line x1="12" y1="17" x2="12" y2="21"></line>
+              </svg>
+            </div>
+            <h2>New UI surface <span class="tag">new</span></h2>
+          </div>
+          <p>
+            Menus are now arrow-key driven by default. Bernard pins the menu region with
+            <code>setPinnedRegion</code>, you move with arrows or digits 1&ndash;9, and Enter
+            commits. Non-TTY environments and <code>BERNARD_PLAIN_MENU=1</code> still get the
+            classic numbered prompt as a fallback. <code>/image &lt;path&gt; [prompt]</code>
+            attaches an image to the next turn, and a <code>/options tool-details</code> toggle
+            collapses the per-call tool noise into compact one-liners.
+          </p>
+          <div class="terminal">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <span class="terminal-title">bernard</span>
+            </div>
+            <div class="terminal-body">
+              <span class="prompt">bernard&gt;</span> /image ./screenshot.png describe this UI<br />
+              <span class="muted">// attached: screenshot.png (412 KB)</span><br />
+              &nbsp;&nbsp;&#x25B6; reading image &hellip;<br />
+              &nbsp;&nbsp;&#x2514;&#x2500; A dark dashboard with three tabs: Memory, Cron, MCP. The
+              Memory tab&hellip;<br />
+              <br />
+              <span class="prompt">bernard&gt;</span> /theme<br />
+              &nbsp;&nbsp;<span class="muted">? Pick a theme &mdash; &uarr;/&darr; Enter</span><br />
+              &nbsp;&nbsp;&#x276F; <span class="success">bernard</span><br />
+              &nbsp;&nbsp;&nbsp;&nbsp;ocean<br />
+              &nbsp;&nbsp;&nbsp;&nbsp;forest<br />
+              &nbsp;&nbsp;&nbsp;&nbsp;synthwave
+            </div>
+          </div>
+          <ul>
+            <li>Arrow-key menu component with <code>BERNARD_PLAIN_MENU</code> fallback (#113, #132)</li>
+            <li>Image attachment via <code>/image</code> on vision-capable models (#112)</li>
+            <li>
+              <code>/options tool-details</code> compact / verbose toggle &mdash;
+              <code>BERNARD_TOOL_DETAILS</code> (#119)
+            </li>
+          </ul>
+        </div>
+
+        <!-- Theme: Operators & infra -->
+        <div class="feature feature-wide">
+          <div class="feature-header">
+            <div class="feature-icon">
+              <!-- server icon -->
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="fill: none; stroke: var(--accent)"
+              >
+                <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+                <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+                <line x1="6" y1="6" x2="6.01" y2="6"></line>
+                <line x1="6" y1="18" x2="6.01" y2="18"></line>
+              </svg>
+            </div>
+            <h2>Operators &amp; infra <span class="tag">new</span></h2>
+          </div>
+          <p>
+            A new tool augmentation layer wraps every tool's <code>execute</code> to observe errors
+            and patch the system prompt with concrete bad-example fixes &mdash; no hallucination,
+            only real observed failures. Shell commands are split into sub-categories
+            (<code>shell.git</code>, <code>shell.gh</code>, <code>shell.docker</code>,
+            <code>shell.npm</code>, <code>shell.fs</code>, <code>shell.http</code>) so guidance
+            stays scoped. Cron jobs gained persistent notes: the daemon injects
+            <code>cron_notes_read</code> / <code>cron_notes_write</code> scoped to the current job
+            so long-running schedules don't redo work after restarts.
+          </p>
+          <div class="terminal">
+            <div class="terminal-bar">
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <div class="terminal-dot"></div>
+              <span class="terminal-title">bernard</span>
+            </div>
+            <div class="terminal-body">
+              <span class="muted">// In a cron job, Bernard reads notes from the previous run:</span><br />
+              &nbsp;&nbsp;&#x25B6; cron_notes_read &mdash; 3 entries<br />
+              &nbsp;&nbsp;&nbsp;&nbsp;1. last sync cursor: 2026-05-07T03:14Z<br />
+              &nbsp;&nbsp;&nbsp;&nbsp;2. skip account #482 &mdash; flagged for review<br />
+              &nbsp;&nbsp;&nbsp;&nbsp;3. retry budget reset to 0<br />
+              &nbsp;&nbsp;&#x25B6; sync_accounts { since: "2026-05-07T03:14Z" }<br />
+              &nbsp;&nbsp;&#x25B6; cron_notes_write { entry: "synced 12 accounts, cursor &rarr; &hellip;" }<br />
+              &nbsp;&nbsp;<span class="success">&#x2713;</span> run finished &mdash; notes saved
+            </div>
+          </div>
+          <ul>
+            <li>
+              Tool augmentation layer with auto-learned bad-example fixes &mdash; tool-wrapper
+              specialists (<code>shell-wrapper</code>, <code>file-wrapper</code>,
+              <code>web-wrapper</code>), correction agent, and specialist creator (#111)
+            </li>
+            <li>
+              Cron persistent notes: per-job JSON store, 100-entry cap, atomic writes, and a
+              <code>## Notes written during this run</code> section in <code>cron_logs_get</code> (#130)
+            </li>
+          </ul>
+        </div>
+
+        <!-- Reliability & polish -->
+        <div class="feature feature-wide">
+          <div class="feature-header">
+            <div class="feature-icon">
+              <!-- check-circle icon -->
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="fill: none; stroke: var(--accent)"
+              >
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+                <polyline points="22 4 12 14.01 9 11.01"></polyline>
+              </svg>
+            </div>
+            <h2>Reliability &amp; polish <span class="tag">fix</span></h2>
+          </div>
+          <ul>
+            <li>Auto-create startup race fixed &mdash; pending candidates are promoted on enable (#135)</li>
+            <li>Critic and ReAct toggles now have round-trip test coverage (#129)</li>
+            <li>
+              MCP-tool schema extraction handles both <code>jsonSchema</code> and the
+              <code>_jsonSchema</code> shape produced by <code>@ai-sdk/ui-utils</code>
+            </li>
+            <li>
+              Reference-lookup timeout enforced via <code>Promise.race</code> against a real timer
+              &mdash; resilient to tools that ignore <code>abortSignal</code>
+            </li>
+          </ul>
+        </div>
+        </div>
+        <!-- /feature-grid (themes) -->
+
+        <h3 class="release-subheading">Also in this release</h3>
+        <p class="release-subheading-desc">
+          Smaller-but-load-bearing pieces that ship with v0.9.0 &mdash; many of them power the
+          headline themes above.
+        </p>
+
+        <div class="feature-grid">
+          <!-- Bundled specialists -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="8.5" cy="7" r="4"></circle>
+                  <path d="M20 8v6"></path>
+                  <path d="M23 11h-6"></path>
+                </svg>
+              </div>
+              <h2>Bundled specialists</h2>
+            </div>
+            <p>
+              Five tool-wrapper specialists ship out of the box and seed on first run:
+              <code>shell-wrapper</code>, <code>file-wrapper</code>, <code>web-wrapper</code>,
+              <code>correction-agent</code>, and <code>specialist-creator</code>. A
+              <code>.seeded-v1</code> marker prevents re-seeding so user edits stick.
+            </p>
+          </div>
+
+          <!-- tool_wrapper_run -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline>
+                  <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path>
+                </svg>
+              </div>
+              <h2><code>tool_wrapper_run</code> dispatch</h2>
+            </div>
+            <p>
+              The main agent talks to specialists through one strict-typed dispatch tool.
+              Each call is isolated to its <code>targetTools</code> &mdash; the
+              <code>shell-wrapper</code> can't accidentally browse the web. Output is
+              guaranteed JSON: <code>{status, result, error?, reasoning?}</code>.
+            </p>
+          </div>
+
+          <!-- web_search provider chain -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <circle cx="11" cy="11" r="8"></circle>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
+              </div>
+              <h2><code>web_search</code> with provider chain</h2>
+            </div>
+            <p>
+              A new built-in <code>web_search</code> tool tries Brave first
+              (<code>BRAVE_API_KEY</code>), falls back to Tavily
+              (<code>TAVILY_API_KEY</code>), and finally to a DuckDuckGo scrape so search
+              keeps working without keys. Returns <code>[{title, url, snippet}]</code>.
+            </p>
+          </div>
+
+          <!-- Correction loop -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <polyline points="23 4 23 10 17 10"></polyline>
+                  <polyline points="1 20 1 14 7 14"></polyline>
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
+                  <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
+                </svg>
+              </div>
+              <h2>Correction loop with validation</h2>
+            </div>
+            <p>
+              When a tool-wrapper returns <code>status: 'error'</code>, the args land in a
+              candidate queue. At REPL shutdown the <code>correction-agent</code> proposes a
+              fix and <em>actually executes</em> it via <code>tool_wrapper_run</code>. Only
+              validated fixes get appended to the specialist's good/bad examples (capped at
+              10 each).
+            </p>
+          </div>
+
+          <!-- Reasoning logs -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                  <polyline points="14 2 14 8 20 8"></polyline>
+                  <line x1="16" y1="13" x2="8" y2="13"></line>
+                  <line x1="16" y1="17" x2="8" y2="17"></line>
+                  <polyline points="10 9 9 9 8 9"></polyline>
+                </svg>
+              </div>
+              <h2>Reasoning logs</h2>
+            </div>
+            <p>
+              Every tool-wrapper run appends one JSONL entry to
+              <code>logs/tool-wrappers.jsonl</code>. Easy to <code>jq</code>, easy to grep,
+              easy to ship to a log aggregator. Pairs naturally with the new post-run
+              activity logs to give you a full audit trail of what Bernard actually did.
+            </p>
+          </div>
+
+          <!-- OS-aware prompts -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+                  <line x1="8" y1="21" x2="16" y2="21"></line>
+                  <line x1="12" y1="17" x2="12" y2="21"></line>
+                </svg>
+              </div>
+              <h2>OS-aware tool prompts</h2>
+            </div>
+            <p>
+              <code>osPromptBlock()</code> detects the host OS and injects shell hints
+              (Linux, macOS, Windows) into every tool-wrapper system prompt &mdash; so the
+              <code>shell-wrapper</code> doesn't suggest <code>brew</code> on Ubuntu or
+              GNU-only flags on macOS.
+            </p>
+          </div>
+
+          <!-- XDG layout -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                </svg>
+              </div>
+              <h2>XDG paths everywhere</h2>
+            </div>
+            <p>
+              All file paths now follow the XDG Base Directory Specification, centralized in
+              <code>src/paths.ts</code>. Set <code>BERNARD_HOME</code> for the legacy flat
+              layout. Existing <code>~/.bernard/</code> installs auto-migrate on first run
+              and leave a <code>MIGRATED</code> marker behind.
+            </p>
+          </div>
+
+          <!-- Subagent result cap -->
+          <div class="feature feature-compact">
+            <div class="feature-header">
+              <div class="feature-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  style="fill: none; stroke: var(--accent)"
+                >
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                  <line x1="9" y1="10" x2="15" y2="10"></line>
+                </svg>
+              </div>
+              <h2>Sub-agent context guard</h2>
+            </div>
+            <p>
+              <code>BERNARD_SUBAGENT_RESULT_MAX_CHARS</code> (default 4000) caps how much of
+              a sub-agent or specialist's output gets fed back into the parent context. The
+              user still sees the full output in the terminal &mdash; only the parent's
+              memory budget gets protected.
+            </p>
+          </div>
+        </div>
+        <!-- /feature-grid (Also in this release) -->
       </div>
     </section>
 
@@ -1567,7 +2331,7 @@
             <li>Helps identify recurring patterns across conversations</li>
             <li>All four domain extractors run in parallel &mdash; no extra latency</li>
             <li>
-              Search returns up to 5 results per domain (20 total max), preventing any single domain
+              Search returns up to 5 results per domain (15 total max), preventing any single domain
               from crowding out others
             </li>
           </ul>
@@ -1600,6 +2364,27 @@
               &nbsp;&nbsp;&nbsp;&nbsp;conversations&nbsp;&nbsp;&nbsp;&nbsp;22 facts
             </div>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="version-section" id="pre-v0.6.0">
+      <div class="container">
+        <div class="feature" style="background: transparent; border-style: dashed">
+          <p>
+            <span class="muted" style="color: var(--text-secondary)"
+              >Earlier releases &mdash; <code>Routines</code>, the multi-provider switch, and the
+              first sub-agent loop &mdash; predate this changelog format and aren't reproduced here.
+              See the
+              <a
+                href="https://github.com/phillt/bernard/commits/master"
+                target="_blank"
+                rel="noopener noreferrer"
+                >git history</a
+              >
+              for anything before v0.6.0.</span
+            >
+          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Adds a major-release v0.9.0 card to `releases.html` with a pulsing badge, tagline, intro, and stat strip; reorganizes the release content into a responsive multi-column `feature-grid` (4 themes + reliability) and a second compact-card grid for the eight features the original draft missed.
- Brings `manual.html` up to date with v0.9.0: documents the reference resolver, tool-lookup, prompt rewriter, coordinator (ReAct) mode, image attachment, tool augmentation layer, and cron notes; adds 9 missing env vars and 2 missing options-table rows; fixes the duplicate `/options` row, the stale "5-step" `/task` budget, the legacy `~/.bernard/` paths, and the leftover `/critic` / `/debug` rows.
- Refreshes `index.html`: every version string and GitHub release link bumps to 0.9.0, stale model slugs (`gpt-4o` → `gpt-5.2`, `grok-3` → `grok-4-fast`) are corrected, Quick Start now names the actual env vars, and four new animated feature tabs land for reference resolution, coordinator mode, specialists & auto-dispatch, and image attachment.
- Adds a "Current as of Bernard v0.9.0" stamp to `domain-specific-memory.md`.
- Fixes the 20 → 15 retrieval-cap drift in the historical v0.6.0 release card and adds a pre-v0.6.0 history footnote.

**Out of scope:** `package.json` version bump, git tag, `npm publish`.

## Test plan

- [ ] Open `docs/index.html` in a browser; confirm the hero badge reads `v0.9.0`, the GitHub release link points at `/releases/tag/0.9.0`, and every feature tab plays cleanly (especially the four new ones).
- [ ] Open `docs/manual.html`; confirm the TOC links resolve, no duplicate rows in the slash-command or options tables, and every new section has a working anchor.
- [ ] Open `docs/releases.html`; confirm the v0.9.0 major-release card renders (badge pulse animation, gradient bg, stats), the four theme cards span full width, and the "Also in this release" sub-section renders as a 2+ column grid that collapses to a single column under ~672px.
- [ ] Resize each page down to mobile width; confirm padding/font overrides at the 640px breakpoint kick in cleanly.
- [ ] Render `docs/domain-specific-memory.md` via GitHub's markdown preview to confirm the version stamp shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)