### PR TITLE
Add custom providers for user-defined LLM endpoints (#149)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,33 @@ bernard -p openai -m gpt-4o  # Use specific provider/model
 - **src/reference-resolver.ts** — Pre-turn LLM pass that resolves user-named entities (e.g. "my daughter") against persistent memory; returns `resolved`, `ambiguous` (menu), `unknown` (prompts user), or `noop`. Invoked from `src/repl.ts` before `agent.processInput` and rendered as a `## Resolved References` block in the system prompt (agent-visible, user-hidden).
 - **src/reference-tool-lookup.ts** — Pre-fallback module that runs only when the resolver returns `unknown`. Picks one read-only allowlisted lookup tool (MCP `*_search`/`*_list`/`*_read`/etc., plus `web_search`/`web_read`) via an LLM call, executes it with a 5 s hard timeout enforced via `Promise.race` (so even MCP tools that ignore `abortSignal` can't stall the REPL), and interprets the result into `{none|found|ambiguous}`. The `select` and `interpret` LLM calls respect the parent abort signal (Esc cancels) but are otherwise bounded by the AI SDK's API timeout. On `found`, the REPL shows a Save/Edit/Skip menu before persisting to memory. Fails open at every stage. Gated by `config.referenceLookup` (default on).
 - **src/prompt-rewriter.ts** — Pre-turn LLM pass that rewrites the user's message for the active model family (see `ModelProfile.rewriterHint` in `src/providers/profiles.ts`). Runs after reference-resolution so resolved entities can be inlined. Temperature 0, fail-open to the original prompt, gated by `config.promptRewriter` (default on; toggle via `/agent-options` or `BERNARD_PROMPT_REWRITER=false`).
-- **src/providers/** — `getModel()` factory returning AI SDK `LanguageModel`
+- **src/providers/** — `getModel()` factory returning AI SDK `LanguageModel`. `getModelForConfig(config, provider, model)` wraps it to consult `config.customProviders` and route through `createOpenAI` / `createAnthropic` / `createXai` with `{ baseURL, apiKey }` when the active provider is user-defined.
+- **src/custom-providers.ts** — `CustomProviderStore`: single-file JSON store at `~/.config/bernard/custom-providers.json`. Each entry binds a user-chosen `name` to one of the three installed SDKs (`openai` / `anthropic` / `xai`), a `baseURL`, a `defaultModel`, and a remembered `models[]` list that grows as the user types new names in `/model`. Reserved names: `anthropic`, `openai`, `xai`.
 - **src/tools/** — Tool registry; each tool is a separate file using `tool()` from `ai`
+
+## Custom Providers
+
+Users can register named **custom providers** that wrap one of the installed SDKs (`openai`, `anthropic`, `xai`) and point it at a non-default endpoint — Ollama, LM Studio, OpenRouter, internal proxies, etc. Multiple custom providers can coexist with the built-ins.
+
+```bash
+# CLI:
+bernard add-provider ollama --sdk openai --base-url http://localhost:11434/v1 --model llama3.2 [--key <api-key>]
+bernard remove-provider ollama
+bernard providers                # lists built-ins and custom side-by-side
+
+# REPL:
+/provider                        # menu now ends with "+ Add custom provider…" (interactive wizard)
+/model                           # for a custom provider, menu ends with "+ Type a new model name…"
+```
+
+Keys for custom providers are stored in `keys.json` (same path as built-ins) and never injected into `process.env`. Built-in providers are unaffected.
 
 ## Key Patterns
 
 - **Vercel AI SDK** (`ai` package) provides unified tool calling across Anthropic/OpenAI/xAI
-- Adding a provider: one import + one case in `src/providers/index.ts`
+- Adding a built-in provider: one import + one case in `src/providers/index.ts`. To wrap an existing SDK at a different endpoint, use **Custom Providers** (`bernard add-provider`) instead — no code change.
 - Adding a tool: create `src/tools/newtool.ts`, register in `src/tools/index.ts`
+- All `generateText` call sites use `getModelForConfig(config, provider, model)` + `getProviderOptionsForConfig(config, provider)` rather than calling `getModel`/`getProviderOptions` directly, so custom-provider endpoints are routed transparently.
 - Config loads `.env` from cwd first, then `$XDG_CONFIG_HOME/bernard/.env`, then legacy `~/.bernard/.env`
 - **src/paths.ts** centralizes all file paths using XDG Base Directory Specification
 - CommonJS (no `"type": "module"` in package.json) for chalk v4 compatibility
@@ -64,7 +83,7 @@ Bernard follows the [XDG Base Directory Specification](https://specifications.fr
 
 | Category   | Default Location          | Contents                                                                                                                                                                      |
 | ---------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Config** | `~/.config/bernard/`      | `preferences.json`, `keys.json`, `.env`, `mcp.json`                                                                                                                           |
+| **Config** | `~/.config/bernard/`      | `preferences.json`, `keys.json`, `custom-providers.json`, `.env`, `mcp.json`                                                                                                  |
 | **Data**   | `~/.local/share/bernard/` | `memory/*.md`, `rag/`, `routines/*.json`, `specialists/*.json`, `correction-candidates/*.json`, `tool-profiles/*.json`, `cron/jobs.json`, `cron/alerts/`, `cron/notes/*.json` |
 | **Cache**  | `~/.cache/bernard/`       | `models/` (embeddings), `update-check.json`                                                                                                                                   |
 | **State**  | `~/.local/state/bernard/` | `conversation-history.json`, `logs/*.jsonl`, `cron-daemon.pid`, `cron-daemon.log`                                                                                             |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bernard
 
-A local CLI AI agent that executes terminal commands, manages scheduled tasks, remembers context across sessions, and connects to external tool servers — all through natural language. Supports multiple LLM providers (Anthropic, OpenAI, xAI) via the Vercel AI SDK.
+A local CLI AI agent that executes terminal commands, manages scheduled tasks, remembers context across sessions, and connects to external tool servers — all through natural language. Supports multiple LLM providers (Anthropic, OpenAI, xAI) via the Vercel AI SDK, plus user-registered **custom providers** that point those SDKs at any compatible endpoint (Ollama, LM Studio, OpenRouter, internal proxies, …).
 
 ## Table of Contents
 
@@ -125,6 +125,28 @@ Check which providers have keys configured:
 bernard providers
 ```
 
+### Custom Providers
+
+If you run your own LLM (Ollama, LM Studio, vLLM, ...) or use an OpenAI/Anthropic/xAI-compatible aggregator (OpenRouter, Together, Fireworks, internal proxies), register it as a **custom provider**. You pick a name, pick which of the three installed SDKs to wrap, supply a base URL, and Bernard treats that name like any other provider.
+
+```bash
+# CLI
+bernard add-provider ollama \
+  --sdk openai \
+  --base-url http://localhost:11434/v1 \
+  --model llama3.2 \
+  --key ollama          # any non-empty token; some local servers ignore the value
+bernard add-key ollama <token>   # if you skipped --key above
+bernard providers               # lists built-ins and custom side-by-side
+bernard remove-provider ollama  # removes the entry and its stored key
+```
+
+You can also add one interactively from the REPL: type `/provider`, scroll to **+ Add custom provider…**, and the wizard walks you through SDK, name, base URL, default model, and key. Once added, `/provider` switches to it like any built-in. In `/model`, the menu shows a remembered list of model names plus a `+ Type a new model name…` entry that adds whatever you type for next time.
+
+When the active provider is custom, the welcome banner prints an extra `Endpoint:` line so it's clear the session isn't hitting the SDK's default URL.
+
+Reserved names: `anthropic`, `openai`, `xai` (these are the built-ins). Custom-provider keys are stored in `keys.json` and are **not** read from environment variables.
+
 ### Environment Variables
 
 Bernard loads `.env` from the current directory first, then falls back to `~/.bernard/.env`.
@@ -198,14 +220,17 @@ bernard --alert <id>             # Open with cron alert context
 ### CLI Management Commands
 
 ```bash
-bernard add-key <provider> <key>   # Store an API key securely
-bernard remove-key <provider>      # Remove a stored API key
-bernard providers                  # List providers and key status
-bernard list-options               # Show configurable options
-bernard reset-option <option>      # Reset one option to default
-bernard reset-options              # Reset all options (with confirmation)
-bernard mcp-list                   # List configured MCP servers
-bernard remove-mcp <key>           # Remove an MCP server
+bernard add-key <provider> <key>                                # Store an API key securely
+bernard remove-key <provider>                                   # Remove a stored API key
+bernard providers                                               # List providers (built-in + custom) and key status
+bernard add-provider <name> --sdk <openai|anthropic|xai> \
+  --base-url <url> --model <model> [--key <key>]                # Register a custom provider
+bernard remove-provider <name>                                  # Remove a custom provider and its key
+bernard list-options                                            # Show configurable options
+bernard reset-option <option>                                   # Reset one option to default
+bernard reset-options                                           # Reset all options (with confirmation)
+bernard mcp-list                                                # List configured MCP servers
+bernard remove-mcp <key>                                        # Remove an MCP server
 
 # Cron management
 bernard cron-list                  # List all cron jobs with status

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>Bernard — Local CLI AI Agent</title>
     <meta
       name="description"
-      content="A multi-provider CLI AI agent with tools, memory, sub-agents, and MCP support. Works with Anthropic, OpenAI, and xAI."
+      content="A multi-provider CLI AI agent with tools, memory, sub-agents, and MCP support. Works with Anthropic, OpenAI, xAI, and any custom endpoint that speaks one of those APIs (Ollama, LM Studio, OpenRouter, …)."
     />
 
     <!-- Open Graph -->
@@ -14,7 +14,7 @@
     <meta property="og:title" content="Bernard — Local CLI AI Agent" />
     <meta
       property="og:description"
-      content="A multi-provider CLI AI agent with tools, memory, sub-agents, and MCP support. Works with Anthropic, OpenAI, and xAI."
+      content="A multi-provider CLI AI agent with tools, memory, sub-agents, and MCP support. Works with Anthropic, OpenAI, xAI, and any custom endpoint that speaks one of those APIs (Ollama, LM Studio, OpenRouter, …)."
     />
     <meta property="og:image" content="https://phillt.github.io/bernard/img.png" />
     <meta property="og:url" content="https://phillt.github.io/bernard/" />
@@ -1196,7 +1196,9 @@
         <h2 class="section-title">Your models, your choice</h2>
         <p class="section-desc">
           Bernard uses the Vercel AI SDK for unified access across providers. Switch with a single
-          flag.
+          flag — and point any of the three SDKs at your own endpoint (Ollama, LM Studio,
+          OpenRouter, internal proxy, …) via
+          <code>bernard add-provider</code>.
         </p>
         <div class="providers-grid">
           <a

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -298,8 +298,11 @@
       .content h3 {
         font-size: 18px;
         font-weight: 600;
-        margin-top: 32px;
+        margin-top: 64px;
         margin-bottom: 12px;
+        padding-bottom: 6px;
+        color: var(--text-secondary);
+        border-bottom: 1px solid var(--border);
       }
 
       .content h4 {
@@ -1067,10 +1070,10 @@
           </table>
         </div>
         <p>
-          <strong>Custom providers</strong> (see
-          <a href="#custom-providers">Custom Providers</a>) store their keys via
-          <code>bernard add-key &lt;name&gt; &lt;key&gt;</code> and are <em>not</em> read from
-          environment variables — there is no <code>BERNARD_&lt;NAME&gt;_API_KEY</code> bridge.
+          <strong>Custom providers</strong> (see <a href="#custom-providers">Custom Providers</a>)
+          store their keys via <code>bernard add-key &lt;name&gt; &lt;key&gt;</code> and are
+          <em>not</em> read from environment variables — there is no
+          <code>BERNARD_&lt;NAME&gt;_API_KEY</code> bridge.
         </p>
 
         <h3 id="env-loading">.env File Loading</h3>
@@ -1407,8 +1410,8 @@
                 <td><code>/model</code></td>
                 <td>
                   Interactively switch model for the current provider; for custom providers, the
-                  menu includes a <strong>+ Type a new model name…</strong> entry that is
-                  remembered for next time
+                  menu includes a <strong>+ Type a new model name…</strong> entry that is remembered
+                  for next time
                 </td>
               </tr>
               <tr>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -668,6 +668,7 @@
               <li><a href="#anthropic">Anthropic</a></li>
               <li><a href="#openai">OpenAI</a></li>
               <li><a href="#xai">xAI</a></li>
+              <li><a href="#custom-providers">Custom Providers</a></li>
               <li><a href="#switching-providers">Switching Providers</a></li>
             </ul>
           </li>
@@ -1065,6 +1066,12 @@
             </tbody>
           </table>
         </div>
+        <p>
+          <strong>Custom providers</strong> (see
+          <a href="#custom-providers">Custom Providers</a>) store their keys via
+          <code>bernard add-key &lt;name&gt; &lt;key&gt;</code> and are <em>not</em> read from
+          environment variables — there is no <code>BERNARD_&lt;NAME&gt;_API_KEY</code> bridge.
+        </p>
 
         <h3 id="env-loading">.env File Loading</h3>
         <p>
@@ -1262,6 +1269,54 @@
           <li><code>grok-3-mini</code></li>
         </ul>
 
+        <h3 id="custom-providers">Custom Providers</h3>
+        <p>
+          A <strong>custom provider</strong> is a user-registered named endpoint that wraps one of
+          the three installed SDKs (<code>openai</code>, <code>anthropic</code>, <code>xai</code>)
+          and points it at a non-default base URL — Ollama, LM Studio, vLLM, OpenRouter, Together,
+          Fireworks, internal proxies, or anything else that speaks one of those APIs. You can
+          register as many as you like, and they coexist with the built-ins.
+        </p>
+        <p>Register one from the command line:</p>
+        <pre><code><span class="accent">$</span> bernard add-provider ollama \
+    --sdk openai \
+    --base-url http://localhost:11434/v1 \
+    --model llama3.2 \
+    --key ollama</code></pre>
+        <p>
+          The key is required (some local servers ignore the value but the SDK still sends one). If
+          you skip <code>--key</code>, run <code>bernard add-key ollama &lt;token&gt;</code>
+          afterwards.
+        </p>
+        <p>
+          To register interactively, type <code>/provider</code> in the REPL and choose
+          <strong>+ Add custom provider…</strong>. The wizard asks for SDK, name, base URL, default
+          model, and API key in turn.
+        </p>
+        <p>Other commands:</p>
+        <ul>
+          <li><code>bernard providers</code> &mdash; lists built-ins and custom side-by-side.</li>
+          <li>
+            <code>bernard remove-provider &lt;name&gt;</code> &mdash; deletes the entry and its
+            stored key.
+          </li>
+          <li>
+            <code>/model</code> &mdash; for a custom provider, the menu shows the remembered model
+            list plus a <strong>+ Type a new model name…</strong> entry; whatever you type is added
+            to the list for next time.
+          </li>
+        </ul>
+        <p>
+          When the active provider is custom, the welcome banner prints an extra
+          <code>Endpoint:</code> line so it's obvious the session isn't using the SDK's default URL.
+        </p>
+        <p>
+          Reserved names: <code>anthropic</code>, <code>openai</code>, <code>xai</code> (the
+          built-ins). Custom-provider API keys are stored in <code>keys.json</code> alongside the
+          built-in keys and are <strong>not</strong> read from environment variables — there is no
+          <code>BERNARD_&lt;NAME&gt;_API_KEY</code> bridge.
+        </p>
+
         <h3 id="switching-providers">Switching Providers</h3>
         <p>There are three ways to switch your provider and model:</p>
         <ol>
@@ -1343,11 +1398,18 @@
               </tr>
               <tr>
                 <td><code>/provider</code></td>
-                <td>Interactively switch LLM provider</td>
+                <td>
+                  Interactively switch LLM provider; menu ends with
+                  <strong>+ Add custom provider…</strong> to register a new endpoint
+                </td>
               </tr>
               <tr>
                 <td><code>/model</code></td>
-                <td>Interactively switch model for the current provider</td>
+                <td>
+                  Interactively switch model for the current provider; for custom providers, the
+                  menu includes a <strong>+ Type a new model name…</strong> entry that is
+                  remembered for next time
+                </td>
               </tr>
               <tr>
                 <td><code>/theme</code></td>

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -25,12 +25,14 @@ const fs = await import('node:fs');
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./output.js', () => ({

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,5 @@
 import { generateText, type CoreMessage, type UserContent } from 'ai';
-import { getModel, getModelProfile, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getModelProfile, getProviderOptionsForConfig } from './providers/index.js';
 import { createTools, type ToolOptions } from './tools/index.js';
 import { createSubAgentTool } from './tools/subagent.js';
 import { createTaskTool } from './tools/task.js';
@@ -480,7 +480,11 @@ export class Agent {
     this.planStore.clear();
     clearPinnedRegion('plan');
 
-    const profile = getModelProfile(this.config.provider, this.config.model);
+    const profile = getModelProfile(
+      this.config.provider,
+      this.config.model,
+      this.config.customProviders?.[this.config.provider]?.sdk,
+    );
     // Wrap is outermost so `<user_request>` / `# Request` opens the text at position 0;
     // the timestamp prefix lives inside the wrapper.
     const wrappedInput = profile.wrapUserMessage(timestampUserMessage(userInput));
@@ -667,8 +671,8 @@ export class Agent {
 
       const callGenerateText = (messages?: CoreMessage[]) =>
         generateText({
-          model: getModel(this.config.provider, this.config.model),
-          providerOptions: getProviderOptions(this.config.provider),
+          model: getModelForConfig(this.config, this.config.provider, this.config.model),
+          providerOptions: getProviderOptionsForConfig(this.config, this.config.provider),
           tools: augmentedTools,
           maxSteps: effectiveMaxSteps,
           maxTokens: this.config.maxTokens,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,9 @@
 import { generateText, type CoreMessage, type UserContent } from 'ai';
-import { getModelForConfig, getModelProfile, getProviderOptionsForConfig } from './providers/index.js';
+import {
+  getModelForConfig,
+  getModelProfile,
+  getProviderOptionsForConfig,
+} from './providers/index.js';
 import { createTools, type ToolOptions } from './tools/index.js';
 import { createSubAgentTool } from './tools/subagent.js';
 import { createTaskTool } from './tools/task.js';

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -991,7 +991,7 @@ describe('resolveProviderAndModel', () => {
 
   it('returns ok:false with envVar when no key is present', () => {
     const r = resolveProviderAndModel({ provider: 'xai', config: baseConfig });
-    expect(r).toEqual({ ok: false, provider: 'xai', envVar: 'XAI_API_KEY' });
+    expect(r).toEqual({ ok: false, provider: 'xai', envVar: 'XAI_API_KEY', isCustom: false });
   });
 
   it('uses explicit model override over default-model fallback on cross-provider', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -305,10 +305,7 @@ function isKnownProvider(provider: string): boolean {
  */
 export function saveProviderKey(provider: string, key: string): void {
   if (!isKnownProvider(provider)) {
-    const known = [
-      ...Object.keys(PROVIDER_ENV_VARS),
-      ...Object.keys(loadCustomProviders()),
-    ];
+    const known = [...Object.keys(PROVIDER_ENV_VARS), ...Object.keys(loadCustomProviders())];
     throw new Error(
       `Unknown provider "${provider}". Known: ${known.join(', ') || '(none)'}. ` +
         `Run \`bernard add-provider ${provider} …\` first to register a custom provider.`,
@@ -558,7 +555,9 @@ export function hasProviderKey(config: BernardConfig, provider: string): boolean
  * keys are never read from env, only from `keys.json`).
  */
 export function providerEnvVar(provider: string): string {
-  return PROVIDER_ENV_VARS[provider] ?? `BERNARD_${provider.toUpperCase().replace(/-/g, '_')}_API_KEY`;
+  return (
+    PROVIDER_ENV_VARS[provider] ?? `BERNARD_${provider.toUpperCase().replace(/-/g, '_')}_API_KEY`
+  );
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -567,12 +567,13 @@ export function blankToUndefined(v: string | undefined): string | undefined {
 /**
  * Result of {@link resolveProviderAndModel}. On the failure branch, `provider`
  * is the resolved provider name and `envVar` is the conventional environment
- * variable for it — callers format the error string in their preferred shape
- * (plain text vs JSON-wrapped) using these fields.
+ * variable for it — only meaningful for built-in providers. Custom-provider
+ * keys are stored in `keys.json` and never read from `process.env`, so
+ * callers should hide the env-var hint when `isCustom` is `true`.
  */
 export type ProviderResolution =
   | { ok: true; provider: string; model: string }
-  | { ok: false; provider: string; envVar: string };
+  | { ok: false; provider: string; envVar: string; isCustom: boolean };
 
 /**
  * Resolves the provider and model to use for a sub-agent / specialist /
@@ -607,7 +608,8 @@ export function resolveProviderAndModel(opts: {
       : opts.config.model);
 
   if (!hasProviderKey(opts.config, provider)) {
-    return { ok: false, provider, envVar: providerEnvVar(provider) };
+    const isCustom = Object.hasOwn(opts.config.customProviders ?? {}, provider);
+    return { ok: false, provider, envVar: providerEnvVar(provider), isCustom };
   }
   return { ok: true, provider, model };
 }
@@ -616,9 +618,17 @@ export function resolveProviderAndModel(opts: {
  * Default error message format for a {@link ProviderResolution} failure.
  * Used by the plain-string callers (specialist-run, subagent). Other callers
  * (task: JSON-wrapped, tool-wrapper-run: shorter format) format their own.
+ *
+ * For custom providers, omits the env-var suggestion — those keys are not
+ * read from `process.env`.
  */
-export function defaultProviderErrorMessage(provider: string, envVar: string): string {
-  return `No API key found for provider "${provider}". Run: bernard add-key ${provider} <your-api-key> or set ${envVar}.`;
+export function defaultProviderErrorMessage(
+  provider: string,
+  envVar: string,
+  isCustom = false,
+): string {
+  const envHint = isCustom ? '' : ` or set ${envVar}`;
+  return `No API key found for provider "${provider}". Run: bernard add-key ${provider} <your-api-key>${envHint}.`;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -285,17 +285,6 @@ function loadStoredKeys(): Record<string, string> {
 }
 
 /**
- * Returns true if `provider` is a known built-in or registered custom provider.
- * Used by {@link saveProviderKey} / {@link removeProviderKey} to validate that
- * a key being stored belongs to a provider Bernard knows how to dispatch to.
- */
-function isKnownProvider(provider: string): boolean {
-  if (PROVIDER_ENV_VARS[provider]) return true;
-  const customProviders = loadCustomProviders();
-  return Object.hasOwn(customProviders, provider);
-}
-
-/**
  * Stores an API key for the given provider in the config directory (mode 0600).
  *
  * Accepts both built-in providers and custom providers that have been
@@ -304,12 +293,16 @@ function isKnownProvider(provider: string): boolean {
  * @throws {Error} If `provider` is neither a built-in nor a known custom provider.
  */
 export function saveProviderKey(provider: string, key: string): void {
-  if (!isKnownProvider(provider)) {
-    const known = [...Object.keys(PROVIDER_ENV_VARS), ...Object.keys(loadCustomProviders())];
-    throw new Error(
-      `Unknown provider "${provider}". Known: ${known.join(', ') || '(none)'}. ` +
-        `Run \`bernard add-provider ${provider} …\` first to register a custom provider.`,
-    );
+  const isBuiltin = !!PROVIDER_ENV_VARS[provider];
+  if (!isBuiltin) {
+    const customProviders = loadCustomProviders();
+    if (!Object.hasOwn(customProviders, provider)) {
+      const known = [...Object.keys(PROVIDER_ENV_VARS), ...Object.keys(customProviders)];
+      throw new Error(
+        `Unknown provider "${provider}". Known: ${known.join(', ') || '(none)'}. ` +
+          `Run \`bernard add-provider ${provider} …\` first to register a custom provider.`,
+      );
+    }
   }
   const dir = path.dirname(KEYS_PATH);
   if (!fs.existsSync(dir)) {
@@ -609,7 +602,9 @@ export function resolveProviderAndModel(opts: {
   const explicitModel = blankToUndefined(opts.model) ?? blankToUndefined(opts.specialistModel);
   const model =
     explicitModel ??
-    (provider !== opts.config.provider ? getDefaultModel(provider) : opts.config.model);
+    (provider !== opts.config.provider
+      ? getDefaultModel(provider, opts.config.customProviders)
+      : opts.config.model);
 
   if (!hasProviderKey(opts.config, provider)) {
     return { ok: false, provider, envVar: providerEnvVar(provider) };

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import * as dotenv from 'dotenv';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { PREFS_PATH, KEYS_PATH, ENV_PATH, LEGACY_DIR } from './paths.js';
+import { loadCustomProviders, type CustomProvider } from './custom-providers.js';
 
 /** Resolved runtime configuration for a Bernard session. */
 export interface BernardConfig {
@@ -45,6 +46,14 @@ export interface BernardConfig {
   openaiApiKey?: string;
   /** xAI API key, if available. */
   xaiApiKey?: string;
+  /**
+   * Generic provider -> API key map sourced from `keys.json`. Carries keys
+   * for both built-in and custom providers. The named fields above are kept
+   * as a backwards-compat read view for the three built-in providers.
+   */
+  apiKeys?: Record<string, string>;
+  /** Loaded snapshot of user-defined custom providers from `custom-providers.json`. */
+  customProviders: Record<string, CustomProvider>;
 }
 
 const DEFAULT_PROVIDER = 'anthropic';
@@ -276,14 +285,33 @@ function loadStoredKeys(): Record<string, string> {
 }
 
 /**
+ * Returns true if `provider` is a known built-in or registered custom provider.
+ * Used by {@link saveProviderKey} / {@link removeProviderKey} to validate that
+ * a key being stored belongs to a provider Bernard knows how to dispatch to.
+ */
+function isKnownProvider(provider: string): boolean {
+  if (PROVIDER_ENV_VARS[provider]) return true;
+  const customProviders = loadCustomProviders();
+  return Object.hasOwn(customProviders, provider);
+}
+
+/**
  * Stores an API key for the given provider in the config directory (mode 0600).
  *
- * @throws {Error} If `provider` is not a recognised provider name.
+ * Accepts both built-in providers and custom providers that have been
+ * registered via `bernard add-provider`.
+ *
+ * @throws {Error} If `provider` is neither a built-in nor a known custom provider.
  */
 export function saveProviderKey(provider: string, key: string): void {
-  if (!PROVIDER_ENV_VARS[provider]) {
+  if (!isKnownProvider(provider)) {
+    const known = [
+      ...Object.keys(PROVIDER_ENV_VARS),
+      ...Object.keys(loadCustomProviders()),
+    ];
     throw new Error(
-      `Unknown provider "${provider}". Supported: ${Object.keys(PROVIDER_ENV_VARS).join(', ')}`,
+      `Unknown provider "${provider}". Known: ${known.join(', ') || '(none)'}. ` +
+        `Run \`bernard add-provider ${provider} …\` first to register a custom provider.`,
     );
   }
   const dir = path.dirname(KEYS_PATH);
@@ -301,14 +329,9 @@ export function saveProviderKey(provider: string, key: string): void {
  *
  * Deletes `keys.json` entirely when no keys remain.
  *
- * @throws {Error} If `provider` is unrecognised or has no stored key.
+ * @throws {Error} If `provider` has no stored key.
  */
 export function removeProviderKey(provider: string): void {
-  if (!PROVIDER_ENV_VARS[provider]) {
-    throw new Error(
-      `Unknown provider "${provider}". Supported: ${Object.keys(PROVIDER_ENV_VARS).join(', ')}`,
-    );
-  }
   const existing = loadStoredKeys();
   if (!existing[provider]) {
     throw new Error(`No stored API key found for "${provider}".`);
@@ -389,11 +412,17 @@ export function resetAllOptions(): void {
 }
 
 /**
- * Returns the API key availability status for every known provider.
+ * Returns the API key availability status for every known provider —
+ * built-in providers plus any registered custom providers.
  *
- * Checks both stored keys and environment variables.
+ * Checks both stored keys and environment variables (env vars apply only
+ * to the three built-in providers; custom providers always use `keys.json`).
  */
-export function getProviderKeyStatus(): Array<{ provider: string; hasKey: boolean }> {
+export function getProviderKeyStatus(): Array<{
+  provider: string;
+  hasKey: boolean;
+  custom?: boolean;
+}> {
   const cwdEnv = path.join(process.cwd(), '.env');
   const homeEnv = ENV_PATH;
   const legacyEnv = path.join(LEGACY_DIR, '.env');
@@ -406,11 +435,18 @@ export function getProviderKeyStatus(): Array<{ provider: string; hasKey: boolea
   }
 
   const storedKeys = loadStoredKeys();
+  const customProviders = loadCustomProviders();
 
-  return Object.entries(PROVIDER_ENV_VARS).map(([provider, envVar]) => ({
+  const builtin = Object.entries(PROVIDER_ENV_VARS).map(([provider, envVar]) => ({
     provider,
     hasKey: !!(storedKeys[provider] || process.env[envVar]),
   }));
+  const custom = Object.keys(customProviders).map((provider) => ({
+    provider,
+    hasKey: !!storedKeys[provider],
+    custom: true,
+  }));
+  return [...builtin, ...custom];
 }
 
 /** Known model identifiers for each provider, ordered by preference (first = default). */
@@ -444,34 +480,85 @@ export const PROVIDER_MODELS: Record<string, string[]> = {
   ],
 };
 
-/** Returns the first (preferred) model for a provider, falling back to Anthropic's default. */
-export function getDefaultModel(provider: string): string {
-  return PROVIDER_MODELS[provider]?.[0] ?? PROVIDER_MODELS[DEFAULT_PROVIDER][0];
+/**
+ * Returns the first (preferred) model for a provider.
+ *
+ * For built-ins this is the first entry in `PROVIDER_MODELS`. For custom
+ * providers it is the registered `defaultModel`. Falls back to Anthropic's
+ * built-in default when the provider is unknown.
+ */
+export function getDefaultModel(
+  provider: string,
+  customProviders?: Record<string, CustomProvider>,
+): string {
+  if (PROVIDER_MODELS[provider]) return PROVIDER_MODELS[provider][0];
+  const custom = customProviders ?? loadCustomProviders();
+  if (custom[provider]) return custom[provider].defaultModel;
+  return PROVIDER_MODELS[DEFAULT_PROVIDER][0];
 }
 
-/** Returns the API key for the given provider from config, or undefined if not set. */
+/**
+ * Returns the API key for the given provider from config, or undefined if not set.
+ *
+ * Looks up the generic `apiKeys` map first (which carries keys for both
+ * built-in and custom providers), then falls back to the legacy named fields
+ * (`anthropicApiKey`/`openaiApiKey`/`xaiApiKey`) for backwards compat with
+ * older test fixtures.
+ */
 export function getProviderApiKey(config: BernardConfig, provider: string): string | undefined {
-  const keyMap: Record<string, string | undefined> = {
-    anthropic: config.anthropicApiKey,
-    openai: config.openaiApiKey,
-    xai: config.xaiApiKey,
-  };
-  return Object.hasOwn(keyMap, provider) ? keyMap[provider] : undefined;
+  if (config.apiKeys && Object.hasOwn(config.apiKeys, provider) && config.apiKeys[provider]) {
+    return config.apiKeys[provider];
+  }
+  switch (provider) {
+    case 'anthropic':
+      return config.anthropicApiKey;
+    case 'openai':
+      return config.openaiApiKey;
+    case 'xai':
+      return config.xaiApiKey;
+    default:
+      return undefined;
+  }
 }
 
-/** Returns provider names that have an API key present in the given config. */
+/**
+ * Returns provider names that have an API key present in the given config.
+ * Built-ins precede custom providers in the returned list.
+ */
 export function getAvailableProviders(config: BernardConfig): string[] {
-  return Object.keys(PROVIDER_MODELS).filter((p) => !!getProviderApiKey(config, p));
+  const builtin = Object.keys(PROVIDER_MODELS).filter((p) => !!getProviderApiKey(config, p));
+  const custom = Object.keys(config.customProviders ?? {}).filter(
+    (p) => !!getProviderApiKey(config, p),
+  );
+  return [...builtin, ...custom];
 }
 
-/** Returns true if the given provider name is a known provider in PROVIDER_MODELS. */
-export function isValidProvider(provider: string): boolean {
-  return Object.hasOwn(PROVIDER_MODELS, provider);
+/**
+ * Returns true if `provider` is a known provider — built-in or registered
+ * as a custom provider in the supplied (or freshly loaded) registry.
+ */
+export function isValidProvider(
+  provider: string,
+  customProviders?: Record<string, CustomProvider>,
+): boolean {
+  if (Object.hasOwn(PROVIDER_MODELS, provider)) return true;
+  const custom = customProviders ?? loadCustomProviders();
+  return Object.hasOwn(custom, provider);
 }
 
 /** Returns true if the given config has an API key for the specified provider. */
 export function hasProviderKey(config: BernardConfig, provider: string): boolean {
   return !!getProviderApiKey(config, provider);
+}
+
+/**
+ * Returns the conventional env-var name for an API key for the given provider.
+ * Built-ins return the canonical `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY`;
+ * custom providers return `BERNARD_<NAME>_API_KEY` (informational only — custom
+ * keys are never read from env, only from `keys.json`).
+ */
+export function providerEnvVar(provider: string): string {
+  return PROVIDER_ENV_VARS[provider] ?? `BERNARD_${provider.toUpperCase().replace(/-/g, '_')}_API_KEY`;
 }
 
 /**
@@ -526,8 +613,7 @@ export function resolveProviderAndModel(opts: {
     (provider !== opts.config.provider ? getDefaultModel(provider) : opts.config.model);
 
   if (!hasProviderKey(opts.config, provider)) {
-    const envVar = PROVIDER_ENV_VARS[provider] ?? `${provider.toUpperCase()}_API_KEY`;
-    return { ok: false, provider, envVar };
+    return { ok: false, provider, envVar: providerEnvVar(provider) };
   }
   return { ok: true, provider, model };
 }
@@ -563,33 +649,45 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     dotenv.config({ path: legacyEnv });
   }
 
-  // Stored keys override .env — user explicitly ran `add-key`
+  // Stored keys override .env — user explicitly ran `add-key`.
+  // Built-in providers also get their key bridged into `process.env` so the
+  // AI SDK module-level singletons pick it up. Custom-provider keys live only
+  // in `config.apiKeys` and are read directly when constructing the model.
   const storedKeys = loadStoredKeys();
   for (const [provider, key] of Object.entries(storedKeys)) {
     const envVar = PROVIDER_ENV_VARS[provider];
     if (envVar && key) process.env[envVar] = key;
   }
 
+  const customProviders = loadCustomProviders();
   const prefs = loadPreferences();
   const explicitProvider = overrides?.provider || prefs.provider || process.env.BERNARD_PROVIDER;
   let provider = explicitProvider || DEFAULT_PROVIDER;
   let model =
-    overrides?.model || prefs.model || process.env.BERNARD_MODEL || getDefaultModel(provider);
+    overrides?.model ||
+    prefs.model ||
+    process.env.BERNARD_MODEL ||
+    getDefaultModel(provider, customProviders);
 
   // When provider was not explicitly chosen and the default has no key,
-  // auto-detect the first provider that does have a key available.
+  // auto-detect the first provider (built-in or custom) that does have one.
   if (!explicitProvider) {
-    const keyMap: Record<string, string | undefined> = {
+    const builtinKeys: Record<string, string | undefined> = {
       anthropic: process.env.ANTHROPIC_API_KEY,
       openai: process.env.OPENAI_API_KEY,
       xai: process.env.XAI_API_KEY,
     };
-    if (!keyMap[provider]) {
-      const available = Object.keys(PROVIDER_ENV_VARS).find((p) => !!keyMap[p]);
+    const hasKey = (p: string): boolean => {
+      if (builtinKeys[p]) return true;
+      return !!storedKeys[p];
+    };
+    if (!hasKey(provider)) {
+      const available =
+        Object.keys(PROVIDER_ENV_VARS).find(hasKey) ?? Object.keys(customProviders).find(hasKey);
       if (available) {
         provider = available;
         if (!overrides?.model && !prefs.model && !process.env.BERNARD_MODEL) {
-          model = getDefaultModel(provider);
+          model = getDefaultModel(provider, customProviders);
         }
       }
     }
@@ -681,6 +779,8 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
     openaiApiKey: process.env.OPENAI_API_KEY,
     xaiApiKey: process.env.XAI_API_KEY,
+    apiKeys: { ...storedKeys },
+    customProviders,
   };
 
   validateConfig(config);
@@ -690,11 +790,11 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
 function validateConfig(config: BernardConfig): void {
   const key = getProviderApiKey(config, config.provider);
   if (!key) {
-    const envVar = PROVIDER_ENV_VARS[config.provider];
-    throw new Error(
-      `No API key found for provider "${config.provider}". ` +
-        `Run: bernard add-key ${config.provider} <your-api-key>\n` +
-        `Or set ${envVar} in your .env file or environment.`,
-    );
+    const envVar = providerEnvVar(config.provider);
+    const isCustom = Object.hasOwn(config.customProviders ?? {}, config.provider);
+    const hint = isCustom
+      ? `Run: bernard add-key ${config.provider} <your-api-key>`
+      : `Run: bernard add-key ${config.provider} <your-api-key>\nOr set ${envVar} in your .env file or environment.`;
+    throw new Error(`No API key found for provider "${config.provider}". ${hint}`);
   }
 }

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -21,12 +21,14 @@ import type { RAGStore } from './rag.js';
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./logger.js', () => ({

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { generateText, type CoreMessage } from 'ai';
-import { getModel, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
 import type { RAGStore } from './rag.js';
@@ -163,8 +163,8 @@ export async function extractDomainFacts(
       const domain = DOMAIN_REGISTRY[domainId];
 
       const result = await generateText({
-        model: getModel(config.provider, config.model),
-        providerOptions: getProviderOptions(config.provider),
+        model: getModelForConfig(config, config.provider, config.model),
+        providerOptions: getProviderOptionsForConfig(config, config.provider),
         maxTokens: 2048,
         system: domain.extractionPrompt,
         messages: [
@@ -257,8 +257,8 @@ export async function compressHistory(
   try {
     // Run summarization and domain-specific fact extraction in parallel
     const summarizePromise = generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       maxTokens: 2048,
       system: SUMMARIZATION_PROMPT,
       messages: [{ role: 'user', content: `Summarize this conversation:\n\n${serialized}` }],

--- a/src/critic.test.ts
+++ b/src/critic.test.ts
@@ -17,12 +17,14 @@ const fs = await import('node:fs');
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./output.js', () => ({

--- a/src/critic.ts
+++ b/src/critic.ts
@@ -1,5 +1,5 @@
 import { generateText } from 'ai';
-import { getModel, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import {
   printCriticStart,
   printCriticVerdict,
@@ -128,8 +128,8 @@ ${truncatedLog
   .join('\n\n')}`;
 
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       system: CRITIC_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: criticMessage }],
       maxSteps: 1,

--- a/src/cron/runner.test.ts
+++ b/src/cron/runner.test.ts
@@ -74,7 +74,9 @@ vi.mock('../mcp.js', () => ({
 
 vi.mock('../providers/index.js', () => ({
   getModel: vi.fn().mockReturnValue('mock-model'),
+  getModelForConfig: vi.fn().mockReturnValue('mock-model'),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('../config.js', () => ({

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -2,7 +2,7 @@ import * as crypto from 'node:crypto';
 import { generateText } from 'ai';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { getModel, getProviderOptions } from '../providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { loadConfig } from '../config.js';
 import { MemoryStore } from '../memory.js';
 import { RAGStore } from '../rag.js';
@@ -262,8 +262,8 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
     };
 
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       tools,
       maxSteps: config.maxSteps,
       maxTokens: config.maxTokens,
@@ -281,8 +281,8 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
         initialResult: result,
         regenerate: async (extraMessages) => {
           return generateText({
-            model: getModel(config.provider, config.model),
-            providerOptions: getProviderOptions(config.provider),
+            model: getModelForConfig(config, config.provider, config.model),
+            providerOptions: getProviderOptionsForConfig(config, config.provider),
             tools,
             maxSteps: 20,
             maxTokens: config.maxTokens,

--- a/src/custom-providers.test.ts
+++ b/src/custom-providers.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+async function loadModule() {
+  vi.resetModules();
+  return import('./custom-providers.js');
+}
+
+describe('custom-providers store', () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-custom-providers-'));
+    origHome = process.env.BERNARD_HOME;
+    process.env.BERNARD_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.BERNARD_HOME;
+    else process.env.BERNARD_HOME = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('validateProviderName', () => {
+    it('accepts valid lowercase names', async () => {
+      const m = await loadModule();
+      expect(m.validateProviderName('ollama')).toBeNull();
+      expect(m.validateProviderName('lm-studio')).toBeNull();
+      expect(m.validateProviderName('local_proxy')).toBeNull();
+      expect(m.validateProviderName('a1')).toBeNull();
+    });
+
+    it('rejects empty / malformed names', async () => {
+      const m = await loadModule();
+      expect(m.validateProviderName('')).toMatch(/empty/i);
+      expect(m.validateProviderName('Ollama')).toMatch(/lowercase/i);
+      expect(m.validateProviderName('1ollama')).toMatch(/lowercase letter/i);
+      expect(m.validateProviderName('ollama!')).toMatch(/lowercase/i);
+      expect(m.validateProviderName('a'.repeat(33))).toMatch(/32 characters/i);
+    });
+
+    it('rejects reserved built-in names', async () => {
+      const m = await loadModule();
+      expect(m.validateProviderName('anthropic')).toMatch(/built-in/i);
+      expect(m.validateProviderName('openai')).toMatch(/built-in/i);
+      expect(m.validateProviderName('xai')).toMatch(/built-in/i);
+    });
+  });
+
+  describe('validateBaseURL', () => {
+    it('accepts http and https URLs', async () => {
+      const m = await loadModule();
+      expect(m.validateBaseURL('http://localhost:11434/v1')).toBeNull();
+      expect(m.validateBaseURL('https://api.openrouter.ai/v1')).toBeNull();
+    });
+
+    it('rejects empty / invalid / non-http URLs', async () => {
+      const m = await loadModule();
+      expect(m.validateBaseURL('')).toMatch(/empty/i);
+      expect(m.validateBaseURL('not a url')).toMatch(/valid URL/i);
+      expect(m.validateBaseURL('ftp://example.com')).toMatch(/http or https/i);
+    });
+  });
+
+  describe('saveCustomProvider', () => {
+    it('writes a new entry with defaultModel first in models[]', async () => {
+      const m = await loadModule();
+      const entry = m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'llama3.2',
+      });
+      expect(entry.models).toEqual(['llama3.2']);
+      expect(entry.createdAt).toBeTruthy();
+      expect(entry.updatedAt).toBeTruthy();
+
+      const loaded = m.loadCustomProviders();
+      expect(loaded.ollama.defaultModel).toBe('llama3.2');
+      expect(loaded.ollama.sdk).toBe('openai');
+      expect(loaded.ollama.baseURL).toBe('http://localhost:11434/v1');
+    });
+
+    it('throws on invalid name / sdk / baseURL', async () => {
+      const m = await loadModule();
+      expect(() =>
+        m.saveCustomProvider({
+          name: 'BadName',
+          sdk: 'openai',
+          baseURL: 'http://x',
+          defaultModel: 'm',
+        }),
+      ).toThrow();
+      expect(() =>
+        m.saveCustomProvider({
+          name: 'good',
+          // @ts-expect-error - intentional bad sdk
+          sdk: 'gemini',
+          baseURL: 'http://x',
+          defaultModel: 'm',
+        }),
+      ).toThrow();
+      expect(() =>
+        m.saveCustomProvider({
+          name: 'good',
+          sdk: 'openai',
+          baseURL: 'not-a-url',
+          defaultModel: 'm',
+        }),
+      ).toThrow();
+      expect(() =>
+        m.saveCustomProvider({
+          name: 'good',
+          sdk: 'openai',
+          baseURL: 'http://x',
+          defaultModel: '   ',
+        }),
+      ).toThrow();
+    });
+
+    it('preserves createdAt when updating an existing entry', async () => {
+      const m = await loadModule();
+      const first = m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'llama3.2',
+      });
+      // Force a perceivable wall-clock gap so updatedAt differs.
+      await new Promise((r) => setTimeout(r, 5));
+      const second = m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'mistral',
+      });
+      expect(second.createdAt).toBe(first.createdAt);
+      expect(second.updatedAt).not.toBe(first.updatedAt);
+      expect(second.defaultModel).toBe('mistral');
+    });
+  });
+
+  describe('removeCustomProvider', () => {
+    it('removes an entry and deletes file when empty', async () => {
+      const m = await loadModule();
+      m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'llama3.2',
+      });
+      m.removeCustomProvider('ollama');
+      expect(m.loadCustomProviders()).toEqual({});
+    });
+
+    it('throws when the entry does not exist', async () => {
+      const m = await loadModule();
+      expect(() => m.removeCustomProvider('missing')).toThrow();
+    });
+  });
+
+  describe('rememberCustomModel', () => {
+    it('appends a new model and keeps default first', async () => {
+      const m = await loadModule();
+      m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'llama3.2',
+      });
+      m.rememberCustomModel('ollama', 'mistral');
+      m.rememberCustomModel('ollama', 'qwen2.5-coder');
+      const loaded = m.loadCustomProviders();
+      expect(loaded.ollama.models[0]).toBe('llama3.2');
+      expect(loaded.ollama.models).toContain('mistral');
+      expect(loaded.ollama.models).toContain('qwen2.5-coder');
+    });
+
+    it('is idempotent for duplicate models', async () => {
+      const m = await loadModule();
+      m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'llama3.2',
+      });
+      m.rememberCustomModel('ollama', 'llama3.2');
+      m.rememberCustomModel('ollama', 'mistral');
+      m.rememberCustomModel('ollama', 'mistral');
+      const loaded = m.loadCustomProviders();
+      expect(loaded.ollama.models).toEqual(['llama3.2', 'mistral']);
+    });
+
+    it('no-ops for unknown providers', async () => {
+      const m = await loadModule();
+      // Should not throw.
+      m.rememberCustomModel('does-not-exist', 'mistral');
+      expect(m.loadCustomProviders()).toEqual({});
+    });
+  });
+
+  describe('loadCustomProviders', () => {
+    it('returns empty map when file does not exist', async () => {
+      const m = await loadModule();
+      expect(m.loadCustomProviders()).toEqual({});
+    });
+
+    it('returns empty map on corrupted JSON', async () => {
+      const m = await loadModule();
+      m.saveCustomProvider({
+        name: 'ollama',
+        sdk: 'openai',
+        baseURL: 'http://localhost:11434/v1',
+        defaultModel: 'llama3.2',
+      });
+      const { CUSTOM_PROVIDERS_PATH } = await import('./paths.js');
+      fs.writeFileSync(CUSTOM_PROVIDERS_PATH, '{ corrupted');
+      expect(m.loadCustomProviders()).toEqual({});
+    });
+
+    it('skips entries with invalid sdk values', async () => {
+      const m = await loadModule();
+      const { CUSTOM_PROVIDERS_PATH } = await import('./paths.js');
+      const dir = path.dirname(CUSTOM_PROVIDERS_PATH);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        CUSTOM_PROVIDERS_PATH,
+        JSON.stringify({
+          providers: {
+            good: {
+              name: 'good',
+              sdk: 'openai',
+              baseURL: 'http://x.test',
+              defaultModel: 'm',
+              models: ['m'],
+              createdAt: '2024-01-01T00:00:00.000Z',
+              updatedAt: '2024-01-01T00:00:00.000Z',
+            },
+            bad: {
+              name: 'bad',
+              sdk: 'gemini',
+              baseURL: 'http://y.test',
+              defaultModel: 'm',
+            },
+          },
+        }),
+      );
+      const loaded = m.loadCustomProviders();
+      expect(loaded.good).toBeDefined();
+      expect(loaded.bad).toBeUndefined();
+    });
+  });
+});

--- a/src/custom-providers.ts
+++ b/src/custom-providers.ts
@@ -1,0 +1,238 @@
+/**
+ * @module custom-providers
+ *
+ * Disk-backed registry of user-defined custom providers — named endpoints
+ * that wrap one of the installed AI SDKs (`@ai-sdk/openai`,
+ * `@ai-sdk/anthropic`, `@ai-sdk/xai`) with a custom `baseURL` and API key.
+ *
+ * Lets the user route Bernard at OpenAI/Anthropic/xAI-compatible servers
+ * (Ollama, LM Studio, vLLM, OpenRouter, Together, internal proxies, ...)
+ * and have several such endpoints configured at once alongside the
+ * built-in providers.
+ *
+ * Storage: `~/.config/bernard/custom-providers.json`
+ * Shape:   `{ providers: Record<name, CustomProvider> }` with file mode 0600.
+ *
+ * API keys are NOT stored here; they live in `keys.json` keyed by the
+ * provider name (the same file the built-in providers use).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { CUSTOM_PROVIDERS_PATH } from './paths.js';
+import type { SupportedSdk } from './providers/types.js';
+
+/** Names reserved by built-in providers — cannot be used for custom entries. */
+export const RESERVED_PROVIDER_NAMES: ReadonlySet<string> = new Set([
+  'anthropic',
+  'openai',
+  'xai',
+]);
+
+/** Allowed SDK choices for a custom provider. */
+export const SUPPORTED_SDKS: ReadonlyArray<SupportedSdk> = ['openai', 'anthropic', 'xai'];
+
+/** Max remembered models per custom provider (oldest entries drop when full). */
+const MODELS_CAP = 20;
+
+const NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const NAME_MAX_LENGTH = 32;
+
+/** A single registered custom provider. */
+export interface CustomProvider {
+  /** Provider name — used as the `--provider` value. Lowercase, [a-z0-9_-]+. */
+  name: string;
+  /** Which installed AI-SDK package to wrap. */
+  sdk: SupportedSdk;
+  /** Base URL for the provider endpoint, e.g. `http://localhost:11434/v1`. */
+  baseURL: string;
+  /** Default model — first one offered in the /model menu, used when switching. */
+  defaultModel: string;
+  /** Known models for this provider. `defaultModel` is always first. Grows as user types new model names. */
+  models: string[];
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 last-update timestamp. */
+  updatedAt: string;
+}
+
+interface CustomProvidersFile {
+  providers: Record<string, CustomProvider>;
+}
+
+/**
+ * Validates a custom provider name.
+ * @returns An error message if invalid, or `null` if valid.
+ */
+export function validateProviderName(name: string): string | null {
+  if (!name) return 'Provider name cannot be empty.';
+  if (name.length > NAME_MAX_LENGTH)
+    return `Provider name must be ${NAME_MAX_LENGTH} characters or fewer.`;
+  if (!NAME_PATTERN.test(name))
+    return 'Provider name must start with a lowercase letter and contain only lowercase letters, digits, hyphens, and underscores.';
+  if (RESERVED_PROVIDER_NAMES.has(name))
+    return `"${name}" is a built-in provider name; pick a different name for the custom entry.`;
+  return null;
+}
+
+/**
+ * Validates a base URL — must parse, and use http/https.
+ * @returns An error message if invalid, or `null` if valid.
+ */
+export function validateBaseURL(url: string): string | null {
+  if (!url || !url.trim()) return 'Base URL cannot be empty.';
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Base URL is not a valid URL.';
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+    return 'Base URL must use http or https.';
+  return null;
+}
+
+/** Reads the custom-providers file. Fails open to an empty map on any error. */
+export function loadCustomProviders(): Record<string, CustomProvider> {
+  try {
+    const raw = fs.readFileSync(CUSTOM_PROVIDERS_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<CustomProvidersFile>;
+    if (parsed && typeof parsed === 'object' && parsed.providers && typeof parsed.providers === 'object') {
+      const out: Record<string, CustomProvider> = {};
+      for (const [name, entry] of Object.entries(parsed.providers)) {
+        if (!entry || typeof entry !== 'object') continue;
+        const e = entry as Partial<CustomProvider>;
+        if (
+          typeof e.name === 'string' &&
+          typeof e.sdk === 'string' &&
+          SUPPORTED_SDKS.includes(e.sdk as SupportedSdk) &&
+          typeof e.baseURL === 'string' &&
+          typeof e.defaultModel === 'string'
+        ) {
+          const models = Array.isArray(e.models)
+            ? e.models.filter((m): m is string => typeof m === 'string' && m.length > 0)
+            : [e.defaultModel];
+          if (!models.includes(e.defaultModel)) models.unshift(e.defaultModel);
+          out[name] = {
+            name: e.name,
+            sdk: e.sdk as SupportedSdk,
+            baseURL: e.baseURL,
+            defaultModel: e.defaultModel,
+            models,
+            createdAt: typeof e.createdAt === 'string' ? e.createdAt : new Date().toISOString(),
+            updatedAt: typeof e.updatedAt === 'string' ? e.updatedAt : new Date().toISOString(),
+          };
+        }
+      }
+      return out;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function writeFile(providers: Record<string, CustomProvider>): void {
+  const dir = path.dirname(CUSTOM_PROVIDERS_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const payload: CustomProvidersFile = { providers };
+  fs.writeFileSync(CUSTOM_PROVIDERS_PATH, JSON.stringify(payload, null, 2) + '\n');
+  fs.chmodSync(CUSTOM_PROVIDERS_PATH, 0o600);
+}
+
+/**
+ * Inserts or updates a custom provider. Validates name / sdk / baseURL /
+ * defaultModel and ensures `defaultModel` is the first entry in `models`.
+ *
+ * @throws {Error} If any field fails validation.
+ */
+export function saveCustomProvider(input: {
+  name: string;
+  sdk: SupportedSdk;
+  baseURL: string;
+  defaultModel: string;
+  models?: string[];
+}): CustomProvider {
+  const nameErr = validateProviderName(input.name);
+  if (nameErr) throw new Error(nameErr);
+
+  if (!SUPPORTED_SDKS.includes(input.sdk)) {
+    throw new Error(`Unsupported SDK "${input.sdk}". Supported: ${SUPPORTED_SDKS.join(', ')}.`);
+  }
+
+  const urlErr = validateBaseURL(input.baseURL);
+  if (urlErr) throw new Error(urlErr);
+
+  const defaultModel = input.defaultModel.trim();
+  if (!defaultModel) throw new Error('Default model cannot be empty.');
+
+  const existing = loadCustomProviders();
+  const now = new Date().toISOString();
+  const seedModels = input.models?.filter((m) => m && m.trim().length > 0) ?? [];
+  const models = [defaultModel, ...seedModels.filter((m) => m !== defaultModel)];
+
+  const entry: CustomProvider = {
+    name: input.name,
+    sdk: input.sdk,
+    baseURL: input.baseURL,
+    defaultModel,
+    models: models.slice(0, MODELS_CAP),
+    createdAt: existing[input.name]?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  existing[input.name] = entry;
+  writeFile(existing);
+  return entry;
+}
+
+/**
+ * Deletes a custom provider entry. Does NOT delete the matching key in
+ * `keys.json` — callers (CLI / REPL) handle key cleanup explicitly.
+ *
+ * @throws {Error} If no custom provider with that name exists.
+ */
+export function removeCustomProvider(name: string): void {
+  const existing = loadCustomProviders();
+  if (!existing[name]) {
+    throw new Error(`No custom provider named "${name}".`);
+  }
+  delete existing[name];
+  if (Object.keys(existing).length === 0) {
+    if (fs.existsSync(CUSTOM_PROVIDERS_PATH)) {
+      fs.unlinkSync(CUSTOM_PROVIDERS_PATH);
+    }
+  } else {
+    writeFile(existing);
+  }
+}
+
+/**
+ * Adds `model` to the remembered list for a custom provider if not already
+ * present. The default model always stays at position 0. No-op when the
+ * provider is unknown.
+ */
+export function rememberCustomModel(name: string, model: string): void {
+  const trimmed = model.trim();
+  if (!trimmed) return;
+  const existing = loadCustomProviders();
+  const entry = existing[name];
+  if (!entry) return;
+  if (entry.models.includes(trimmed)) return;
+
+  const next = [...entry.models, trimmed].slice(-MODELS_CAP);
+  // Default model always first.
+  const reordered = [entry.defaultModel, ...next.filter((m) => m !== entry.defaultModel)];
+  existing[name] = { ...entry, models: reordered, updatedAt: new Date().toISOString() };
+  writeFile(existing);
+}
+
+/** Returns true if `name` matches an existing custom provider entry. */
+export function isCustomProvider(
+  name: string,
+  customProviders: Record<string, CustomProvider> = loadCustomProviders(),
+): boolean {
+  return Object.hasOwn(customProviders, name);
+}

--- a/src/custom-providers.ts
+++ b/src/custom-providers.ts
@@ -23,11 +23,7 @@ import { CUSTOM_PROVIDERS_PATH } from './paths.js';
 import type { SupportedSdk } from './providers/types.js';
 
 /** Names reserved by built-in providers — cannot be used for custom entries. */
-export const RESERVED_PROVIDER_NAMES: ReadonlySet<string> = new Set([
-  'anthropic',
-  'openai',
-  'xai',
-]);
+export const RESERVED_PROVIDER_NAMES: ReadonlySet<string> = new Set(['anthropic', 'openai', 'xai']);
 
 /** Allowed SDK choices for a custom provider. */
 export const SUPPORTED_SDKS: ReadonlyArray<SupportedSdk> = ['openai', 'anthropic', 'xai'];
@@ -97,7 +93,12 @@ export function loadCustomProviders(): Record<string, CustomProvider> {
   try {
     const raw = fs.readFileSync(CUSTOM_PROVIDERS_PATH, 'utf-8');
     const parsed = JSON.parse(raw) as Partial<CustomProvidersFile>;
-    if (parsed && typeof parsed === 'object' && parsed.providers && typeof parsed.providers === 'object') {
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.providers &&
+      typeof parsed.providers === 'object'
+    ) {
       const out: Record<string, CustomProvider> = {};
       for (const [name, entry] of Object.entries(parsed.providers)) {
         if (!entry || typeof entry !== 'object') continue;

--- a/src/custom-providers.ts
+++ b/src/custom-providers.ts
@@ -20,6 +20,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { CUSTOM_PROVIDERS_PATH } from './paths.js';
+import { atomicWriteFileSync } from './fs-utils.js';
 import type { SupportedSdk } from './providers/types.js';
 
 /** Names reserved by built-in providers — cannot be used for custom entries. */
@@ -134,12 +135,9 @@ export function loadCustomProviders(): Record<string, CustomProvider> {
 }
 
 function writeFile(providers: Record<string, CustomProvider>): void {
-  const dir = path.dirname(CUSTOM_PROVIDERS_PATH);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(path.dirname(CUSTOM_PROVIDERS_PATH), { recursive: true });
   const payload: CustomProvidersFile = { providers };
-  fs.writeFileSync(CUSTOM_PROVIDERS_PATH, JSON.stringify(payload, null, 2) + '\n');
+  atomicWriteFileSync(CUSTOM_PROVIDERS_PATH, JSON.stringify(payload, null, 2) + '\n');
   fs.chmodSync(CUSTOM_PROVIDERS_PATH, 0o600);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,9 @@ program
       printInfo('\nTo add a key: bernard add-key <provider> <key>');
     }
     if (customStatuses.length === 0) {
-      printInfo('To add a custom provider: bernard add-provider <name> --sdk <openai|anthropic|xai> --base-url <url> --model <model>');
+      printInfo(
+        'To add a custom provider: bernard add-provider <name> --sdk <openai|anthropic|xai> --base-url <url> --model <model>',
+      );
     }
   });
 
@@ -179,37 +181,32 @@ program
   .requiredOption('--base-url <url>', 'Base URL for the API endpoint')
   .requiredOption('--model <model>', 'Default model name to use')
   .option('--key <key>', 'API key (can also be added later via add-key)')
-  .action(
-    (
-      name: string,
-      opts: { sdk: string; baseUrl: string; model: string; key?: string },
-    ) => {
-      try {
-        const sdk = opts.sdk.toLowerCase();
-        if (!SUPPORTED_SDKS.includes(sdk as SupportedSdk)) {
-          printError(`Unsupported SDK "${opts.sdk}". Supported: ${SUPPORTED_SDKS.join(', ')}.`);
-          process.exit(1);
-        }
-        const entry = saveCustomProvider({
-          name,
-          sdk: sdk as SupportedSdk,
-          baseURL: opts.baseUrl,
-          defaultModel: opts.model,
-        });
-        printInfo(`Custom provider "${entry.name}" saved (sdk=${entry.sdk}, url=${entry.baseURL}).`);
-        if (opts.key) {
-          saveProviderKey(name, opts.key);
-          printInfo(`API key for "${name}" saved.`);
-        } else {
-          printInfo(`Next: bernard add-key ${name} <your-api-key>`);
-        }
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        printError(message);
+  .action((name: string, opts: { sdk: string; baseUrl: string; model: string; key?: string }) => {
+    try {
+      const sdk = opts.sdk.toLowerCase();
+      if (!SUPPORTED_SDKS.includes(sdk as SupportedSdk)) {
+        printError(`Unsupported SDK "${opts.sdk}". Supported: ${SUPPORTED_SDKS.join(', ')}.`);
         process.exit(1);
       }
-    },
-  );
+      const entry = saveCustomProvider({
+        name,
+        sdk: sdk as SupportedSdk,
+        baseURL: opts.baseUrl,
+        defaultModel: opts.model,
+      });
+      printInfo(`Custom provider "${entry.name}" saved (sdk=${entry.sdk}, url=${entry.baseURL}).`);
+      if (opts.key) {
+        saveProviderKey(name, opts.key);
+        printInfo(`API key for "${name}" saved.`);
+      } else {
+        printInfo(`Next: bernard add-key ${name} <your-api-key>`);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      printError(message);
+      process.exit(1);
+    }
+  });
 
 program
   .command('remove-provider <name>')

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,15 @@ import {
   resetOption,
   resetAllOptions,
   getDefaultModel,
+  providerEnvVar,
 } from './config.js';
+import {
+  loadCustomProviders,
+  saveCustomProvider,
+  removeCustomProvider,
+  SUPPORTED_SDKS,
+} from './custom-providers.js';
+import type { SupportedSdk } from './providers/types.js';
 import { startRepl } from './repl.js';
 import { printWelcome, printError, printInfo } from './output.js';
 import { setTheme, DEFAULT_THEME } from './theme.js';
@@ -87,7 +95,12 @@ The user has been notified and this session is open for them to review and act o
         printInfo(`  Time: ${alert.timestamp}\n`);
       }
 
-      printWelcome(config.provider, config.model, getLocalVersion());
+      printWelcome(
+        config.provider,
+        config.model,
+        getLocalVersion(),
+        config.customProviders?.[config.provider]?.baseURL,
+      );
       const prefs = loadPreferences();
       startupUpdateCheck(!!prefs.autoUpdate);
       await startRepl(config, alertContext, !!opts.resume);
@@ -131,14 +144,89 @@ program
   .description('List supported providers and their API key status')
   .action(() => {
     const statuses = getProviderKeyStatus();
-    printInfo('Providers:');
-    for (const { provider, hasKey } of statuses) {
-      const envVar = PROVIDER_ENV_VARS[provider];
+    const customProviders = loadCustomProviders();
+    const builtinStatuses = statuses.filter((s) => !customProviders[s.provider]);
+    const customStatuses = statuses.filter((s) => customProviders[s.provider]);
+
+    printInfo('Built-in providers:');
+    for (const { provider, hasKey } of builtinStatuses) {
+      const envVar = PROVIDER_ENV_VARS[provider] ?? providerEnvVar(provider);
       const status = hasKey ? '\u2713' : '\u2717';
       printInfo(`  ${status} ${provider} (${envVar})`);
     }
+
+    if (customStatuses.length > 0) {
+      printInfo('\nCustom providers:');
+      for (const { provider, hasKey } of customStatuses) {
+        const entry = customProviders[provider];
+        const status = hasKey ? '\u2713' : '\u2717';
+        printInfo(`  ${status} ${provider} \u2014 sdk=${entry.sdk} url=${entry.baseURL}`);
+      }
+    }
+
     if (statuses.some((s) => !s.hasKey)) {
       printInfo('\nTo add a key: bernard add-key <provider> <key>');
+    }
+    if (customStatuses.length === 0) {
+      printInfo('To add a custom provider: bernard add-provider <name> --sdk <openai|anthropic|xai> --base-url <url> --model <model>');
+    }
+  });
+
+program
+  .command('add-provider <name>')
+  .description('Register a custom provider (OpenAI/Anthropic/xAI-compatible endpoint)')
+  .requiredOption('--sdk <sdk>', 'Which SDK to use: openai, anthropic, or xai')
+  .requiredOption('--base-url <url>', 'Base URL for the API endpoint')
+  .requiredOption('--model <model>', 'Default model name to use')
+  .option('--key <key>', 'API key (can also be added later via add-key)')
+  .action(
+    (
+      name: string,
+      opts: { sdk: string; baseUrl: string; model: string; key?: string },
+    ) => {
+      try {
+        const sdk = opts.sdk.toLowerCase();
+        if (!SUPPORTED_SDKS.includes(sdk as SupportedSdk)) {
+          printError(`Unsupported SDK "${opts.sdk}". Supported: ${SUPPORTED_SDKS.join(', ')}.`);
+          process.exit(1);
+        }
+        const entry = saveCustomProvider({
+          name,
+          sdk: sdk as SupportedSdk,
+          baseURL: opts.baseUrl,
+          defaultModel: opts.model,
+        });
+        printInfo(`Custom provider "${entry.name}" saved (sdk=${entry.sdk}, url=${entry.baseURL}).`);
+        if (opts.key) {
+          saveProviderKey(name, opts.key);
+          printInfo(`API key for "${name}" saved.`);
+        } else {
+          printInfo(`Next: bernard add-key ${name} <your-api-key>`);
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        printError(message);
+        process.exit(1);
+      }
+    },
+  );
+
+program
+  .command('remove-provider <name>')
+  .description('Remove a custom provider and its stored API key')
+  .action((name: string) => {
+    try {
+      removeCustomProvider(name);
+      try {
+        removeProviderKey(name);
+      } catch {
+        // No key stored for this provider \u2014 fine.
+      }
+      printInfo(`Custom provider "${name}" removed.`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      printError(message);
+      process.exit(1);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ import {
   loadCustomProviders,
   saveCustomProvider,
   removeCustomProvider,
-  SUPPORTED_SDKS,
 } from './custom-providers.js';
 import type { SupportedSdk } from './providers/types.js';
 import { startRepl } from './repl.js';
@@ -183,14 +182,9 @@ program
   .option('--key <key>', 'API key (can also be added later via add-key)')
   .action((name: string, opts: { sdk: string; baseUrl: string; model: string; key?: string }) => {
     try {
-      const sdk = opts.sdk.toLowerCase();
-      if (!SUPPORTED_SDKS.includes(sdk as SupportedSdk)) {
-        printError(`Unsupported SDK "${opts.sdk}". Supported: ${SUPPORTED_SDKS.join(', ')}.`);
-        process.exit(1);
-      }
       const entry = saveCustomProvider({
         name,
-        sdk: sdk as SupportedSdk,
+        sdk: opts.sdk.toLowerCase() as SupportedSdk,
         baseURL: opts.baseUrl,
         defaultModel: opts.model,
       });

--- a/src/output.ts
+++ b/src/output.ts
@@ -237,10 +237,18 @@ export function stopSpinner(): void {
 }
 
 /** Prints the branded welcome banner with provider, model, and optional version info. */
-export function printWelcome(provider: string, model: string, version?: string): void {
+export function printWelcome(
+  provider: string,
+  model: string,
+  version?: string,
+  baseURL?: string,
+): void {
   const ver = version ? getTheme().muted(` v${version}`) : '';
   console.log(getTheme().accentBold('\n  Bernard') + ver + getTheme().muted(' — AI CLI Assistant'));
   console.log(getTheme().muted(`  Provider: ${provider} | Model: ${model}`));
+  if (baseURL) {
+    console.log(getTheme().muted(`  Endpoint: ${baseURL}`));
+  }
   if (process.env.BERNARD_DEBUG === 'true' || process.env.BERNARD_DEBUG === '1') {
     console.log(getTheme().warning('  DEBUG mode enabled — logging to .logs/'));
   }

--- a/src/pac.test.ts
+++ b/src/pac.test.ts
@@ -13,12 +13,14 @@ vi.mock('node:fs', () => ({
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./output.js', () => ({

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -29,6 +29,7 @@ export const PREFS_PATH = path.join(CONFIG_DIR, 'preferences.json');
 export const KEYS_PATH = path.join(CONFIG_DIR, 'keys.json');
 export const ENV_PATH = path.join(CONFIG_DIR, '.env');
 export const MCP_CONFIG_PATH = path.join(CONFIG_DIR, 'mcp.json');
+export const CUSTOM_PROVIDERS_PATH = path.join(CONFIG_DIR, 'custom-providers.json');
 
 // Data
 export const MEMORY_DIR = path.join(DATA_DIR, 'memory');

--- a/src/prompt-rewriter.test.ts
+++ b/src/prompt-rewriter.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./logger.js', () => ({

--- a/src/prompt-rewriter.ts
+++ b/src/prompt-rewriter.ts
@@ -1,5 +1,5 @@
 import { generateText } from 'ai';
-import { getModel, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import type { ModelProfile } from './providers/profiles.js';
 import type { ResolvedEntry } from './reference-resolver.js';
 import type { BernardConfig } from './config.js';
@@ -143,8 +143,8 @@ export async function rewritePrompt(
 
   try {
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       system: buildSystemPrompt(profile),
       messages: [{ role: 'user', content: buildUserMessage(input, resolvedEntries) }],
       maxSteps: 1,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -20,12 +20,34 @@ export interface CustomProviderInvocation {
   apiKey: string;
 }
 
+// Memoize SDK factories so repeated `getModel` calls for the same custom
+// provider don't reconstruct the factory on every agent turn / sub-agent
+// dispatch. Built-in providers already use module-level singletons.
+type CustomFactory = ReturnType<typeof createOpenAI | typeof createAnthropic | typeof createXai>;
+const customFactoryCache = new Map<string, CustomFactory>();
+
+function getCustomFactory(custom: CustomProviderInvocation): CustomFactory {
+  const cacheKey = `${custom.sdk}|${custom.baseURL}|${custom.apiKey}`;
+  const cached = customFactoryCache.get(cacheKey);
+  if (cached) return cached;
+  const opts = { baseURL: custom.baseURL, apiKey: custom.apiKey };
+  const factory =
+    custom.sdk === 'openai'
+      ? createOpenAI(opts)
+      : custom.sdk === 'anthropic'
+        ? createAnthropic(opts)
+        : createXai(opts);
+  customFactoryCache.set(cacheKey, factory);
+  return factory;
+}
+
 /**
  * Return an AI SDK `LanguageModel` instance for the given provider and model name.
  *
  * For built-in providers (`anthropic`, `openai`, `xai`) the module-level singletons
  * are used, which read API keys from environment variables. For custom providers
- * the matching `createXxx({ baseURL, apiKey })` factory is invoked instead.
+ * the matching `createXxx({ baseURL, apiKey })` factory is invoked instead (cached
+ * by `(sdk, baseURL, apiKey)` so repeated calls are cheap).
  *
  * @param provider - Provider identifier (built-in or custom registry name).
  * @param model - Provider-specific model identifier.
@@ -39,16 +61,9 @@ export function getModel(
   custom?: CustomProviderInvocation,
 ): LanguageModel {
   if (custom) {
-    switch (custom.sdk) {
-      case 'openai': {
-        const factory = createOpenAI({ baseURL: custom.baseURL, apiKey: custom.apiKey });
-        return factory.responses(model);
-      }
-      case 'anthropic':
-        return createAnthropic({ baseURL: custom.baseURL, apiKey: custom.apiKey })(model);
-      case 'xai':
-        return createXai({ baseURL: custom.baseURL, apiKey: custom.apiKey })(model);
-    }
+    const factory = getCustomFactory(custom);
+    if (custom.sdk === 'openai') return (factory as ReturnType<typeof createOpenAI>).responses(model);
+    return (factory as ReturnType<typeof createAnthropic> | ReturnType<typeof createXai>)(model);
   }
   switch (provider) {
     case 'anthropic':

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -62,7 +62,8 @@ export function getModel(
 ): LanguageModel {
   if (custom) {
     const factory = getCustomFactory(custom);
-    if (custom.sdk === 'openai') return (factory as ReturnType<typeof createOpenAI>).responses(model);
+    if (custom.sdk === 'openai')
+      return (factory as ReturnType<typeof createOpenAI>).responses(model);
     return (factory as ReturnType<typeof createAnthropic> | ReturnType<typeof createXai>)(model);
   }
   switch (provider) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,19 +1,55 @@
-import { anthropic } from '@ai-sdk/anthropic';
-import { openai } from '@ai-sdk/openai';
-import { xai } from '@ai-sdk/xai';
+import { anthropic, createAnthropic } from '@ai-sdk/anthropic';
+import { openai, createOpenAI } from '@ai-sdk/openai';
+import { xai, createXai } from '@ai-sdk/xai';
 import type { LanguageModel } from 'ai';
+import type { SupportedSdk } from './types.js';
+import type { BernardConfig } from '../config.js';
+import { getProviderApiKey } from '../config.js';
 
 export { getModelProfile } from './profiles.js';
 export type { ModelProfile } from './profiles.js';
+export type { SupportedSdk } from './types.js';
+
+/** Custom-provider params for `getModel()` — set when the active provider is user-defined. */
+export interface CustomProviderInvocation {
+  /** Which installed AI-SDK to wrap. */
+  sdk: SupportedSdk;
+  /** Endpoint base URL, e.g. `http://localhost:11434/v1`. */
+  baseURL: string;
+  /** API key (some local servers accept any non-empty token). */
+  apiKey: string;
+}
 
 /**
  * Return an AI SDK `LanguageModel` instance for the given provider and model name.
- * @param provider - One of `"anthropic"`, `"openai"`, or `"xai"`.
- * @param model - Provider-specific model identifier (e.g. `"claude-sonnet-4-20250514"`).
+ *
+ * For built-in providers (`anthropic`, `openai`, `xai`) the module-level singletons
+ * are used, which read API keys from environment variables. For custom providers
+ * the matching `createXxx({ baseURL, apiKey })` factory is invoked instead.
+ *
+ * @param provider - Provider identifier (built-in or custom registry name).
+ * @param model - Provider-specific model identifier.
+ * @param custom - When set, build the model via the SDK factory with these options.
  * @returns A ready-to-use `LanguageModel` backed by the requested provider.
- * @throws {Error} If the provider string is not recognized.
+ * @throws {Error} If the provider string is not recognized and no `custom` info is supplied.
  */
-export function getModel(provider: string, model: string): LanguageModel {
+export function getModel(
+  provider: string,
+  model: string,
+  custom?: CustomProviderInvocation,
+): LanguageModel {
+  if (custom) {
+    switch (custom.sdk) {
+      case 'openai': {
+        const factory = createOpenAI({ baseURL: custom.baseURL, apiKey: custom.apiKey });
+        return factory.responses(model);
+      }
+      case 'anthropic':
+        return createAnthropic({ baseURL: custom.baseURL, apiKey: custom.apiKey })(model);
+      case 'xai':
+        return createXai({ baseURL: custom.baseURL, apiKey: custom.apiKey })(model);
+    }
+  }
   switch (provider) {
     case 'anthropic':
       return anthropic(model);
@@ -26,6 +62,31 @@ export function getModel(provider: string, model: string): LanguageModel {
   }
 }
 
+/**
+ * Resolves a `LanguageModel` for the given `provider`/`model`, automatically
+ * routing through the custom-provider registry when `provider` is user-defined.
+ *
+ * This is the call-site helper — every place in the codebase that used to call
+ * `getModel(provider, model)` should now call `getModelForConfig(config, provider, model)`
+ * so custom providers transparently take effect.
+ */
+export function getModelForConfig(
+  config: BernardConfig,
+  provider: string,
+  model: string,
+): LanguageModel {
+  const custom = config.customProviders?.[provider];
+  if (custom) {
+    const apiKey = getProviderApiKey(config, provider) ?? '';
+    return getModel(provider, model, {
+      sdk: custom.sdk,
+      baseURL: custom.baseURL,
+      apiKey,
+    });
+  }
+  return getModel(provider, model);
+}
+
 // Disable OpenAI strict-schemas: MCP tools commonly emit JSON Schema features
 // (`oneOf` partial-constraint branches, untyped `items: {}`, etc.) that strict
 // mode rejects at preflight, killing the user's turn.
@@ -33,8 +94,30 @@ const OPENAI_PROVIDER_OPTIONS = Object.freeze({
   openai: Object.freeze({ strictSchemas: false as const }),
 });
 
+/**
+ * Returns provider-specific generation options for the AI SDK.
+ *
+ * The optional `sdk` argument lets callers pass the underlying SDK family
+ * of a custom provider (its factory is OpenAI-shaped even if the name is e.g.
+ * "ollama") so the OpenAI strictSchemas escape hatch is also applied there.
+ */
 export function getProviderOptions(
   provider: string,
+  sdk?: SupportedSdk,
 ): { openai: { strictSchemas: false } } | undefined {
-  return provider === 'openai' ? OPENAI_PROVIDER_OPTIONS : undefined;
+  const effective = sdk ?? provider;
+  return effective === 'openai' ? OPENAI_PROVIDER_OPTIONS : undefined;
+}
+
+/**
+ * Helper for the common case of resolving provider options from a `BernardConfig`
+ * by `provider` name — consults the custom-provider registry to pick the right
+ * SDK family.
+ */
+export function getProviderOptionsForConfig(
+  config: BernardConfig,
+  provider: string,
+): { openai: { strictSchemas: false } } | undefined {
+  const custom = config.customProviders?.[provider];
+  return getProviderOptions(provider, custom?.sdk);
 }

--- a/src/providers/profiles.ts
+++ b/src/providers/profiles.ts
@@ -107,21 +107,30 @@ const XAI_STANDARD_PROFILE: ModelProfile = {
  * Matching is first-match-wins and pattern-based so new models in an existing
  * family pick up the right profile automatically. Unknown combinations fall
  * back to a conservative passthrough profile.
+ *
+ * For custom providers (user-defined endpoints that wrap an installed AI-SDK)
+ * pass the wrapped SDK family via `sdk` so the model picks up family-specific
+ * prompt tuning regardless of the registered provider name.
  */
-export function getModelProfile(provider: string, model: string): ModelProfile {
+export function getModelProfile(
+  provider: string,
+  model: string,
+  sdk?: 'anthropic' | 'openai' | 'xai',
+): ModelProfile {
   const m = model.toLowerCase();
+  const family = sdk ?? provider;
 
-  if (provider === 'anthropic') {
+  if (family === 'anthropic') {
     return ANTHROPIC_PROFILE;
   }
 
-  if (provider === 'openai') {
+  if (family === 'openai') {
     // o-series reasoning models: o1, o3, o3-mini, o4-mini, …
     if (/^o\d/.test(m)) return OPENAI_REASONING_PROFILE;
     return OPENAI_STANDARD_PROFILE;
   }
 
-  if (provider === 'xai') {
+  if (family === 'xai') {
     // Explicit non-reasoning variants take precedence over the generic grok-4 rule.
     if (m.includes('non-reasoning')) return XAI_STANDARD_PROFILE;
     if (m.includes('reasoning')) return XAI_REASONING_PROFILE;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,12 +1,16 @@
-/** Supported LLM provider identifiers. Custom providers use arbitrary names — kept as `string`. */
-export type ProviderName = string;
-
 /** The three AI-SDK packages we ship; custom providers must wrap one of these. */
 export type SupportedSdk = 'anthropic' | 'openai' | 'xai';
 
 /** Built-in provider identifiers — fall back to the official endpoints. */
 export const BUILTIN_PROVIDERS = ['anthropic', 'openai', 'xai'] as const;
 export type BuiltinProvider = (typeof BUILTIN_PROVIDERS)[number];
+
+/**
+ * Provider identifier — `'anthropic' | 'openai' | 'xai'` for built-ins, or any
+ * user-chosen name registered as a custom provider. The literal union documents
+ * intent; runtime values are plain strings.
+ */
+export type ProviderName = BuiltinProvider | (string & {});
 
 /** Provider and model pair used to instantiate an AI SDK `LanguageModel`. */
 export interface ProviderConfig {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,5 +1,12 @@
-/** Supported LLM provider identifiers. */
-export type ProviderName = 'anthropic' | 'openai' | 'xai';
+/** Supported LLM provider identifiers. Custom providers use arbitrary names — kept as `string`. */
+export type ProviderName = string;
+
+/** The three AI-SDK packages we ship; custom providers must wrap one of these. */
+export type SupportedSdk = 'anthropic' | 'openai' | 'xai';
+
+/** Built-in provider identifiers — fall back to the official endpoints. */
+export const BUILTIN_PROVIDERS = ['anthropic', 'openai', 'xai'] as const;
+export type BuiltinProvider = (typeof BUILTIN_PROVIDERS)[number];
 
 /** Provider and model pair used to instantiate an AI SDK `LanguageModel`. */
 export interface ProviderConfig {

--- a/src/reference-resolver.test.ts
+++ b/src/reference-resolver.test.ts
@@ -12,12 +12,14 @@ vi.mock('node:fs', () => ({
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./logger.js', () => ({

--- a/src/reference-resolver.ts
+++ b/src/reference-resolver.ts
@@ -1,5 +1,5 @@
 import { generateText, type CoreMessage } from 'ai';
-import { getModel, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import { sanitizeKey, REWRITER_HINTS_KEY, type MemoryStore } from './memory.js';
 import type { RAGStore, RAGSearchResult } from './rag.js';
@@ -304,8 +304,8 @@ export async function resolveReferences(
 
   try {
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       system: RESOLVER_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: userMessage }],
       maxSteps: 1,

--- a/src/reference-tool-lookup.test.ts
+++ b/src/reference-tool-lookup.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./logger.js', () => ({

--- a/src/reference-tool-lookup.ts
+++ b/src/reference-tool-lookup.ts
@@ -1,5 +1,5 @@
 import { generateText } from 'ai';
-import { getModel, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
 
@@ -154,8 +154,8 @@ export async function selectLookupTool(
   if (candidates.length === 0) return null;
   try {
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       system: SELECT_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: buildSelectUserMessage(reference, candidates) }],
       maxSteps: 1,
@@ -277,8 +277,8 @@ export async function interpretLookupResult(
 ): Promise<ReferenceLookupResult> {
   try {
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       system: INTERPRET_SYSTEM_PROMPT,
       messages: [
         {

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -158,12 +158,14 @@ vi.mock('./output.js', () => ({
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 const mockSavePreferences = vi.fn();
@@ -377,7 +379,7 @@ describe('REPL /clear command', () => {
     typeLine('/clear');
 
     await vi.waitFor(() => {
-      expect(mockPrintWelcome).toHaveBeenCalledWith('openai', 'gpt-4o', '0.3.1');
+      expect(mockPrintWelcome).toHaveBeenCalledWith('openai', 'gpt-4o', '0.3.1', undefined);
     });
 
     rlEmitter.emit('close');

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1571,13 +1571,11 @@ export async function startRepl(
             });
           }
         }
+        if (builtinAvailable.length === 0 && customAvailable.length === 0) {
+          printInfo('No providers have API keys configured yet — add one below.');
+        }
         entries.push({ type: 'section', title: '' });
         entries.push({ label: '+ Add custom provider…', value: '__add__' });
-
-        if (entries.length === 1) {
-          // Only the "+ Add custom provider…" entry — nothing else to choose.
-          printError('No providers have API keys configured.');
-        }
 
         const signal = createMenuSignal();
         try {
@@ -1592,9 +1590,13 @@ export async function startRepl(
             if (value === '__add__') {
               const added = await runAddProviderWizard(rl, createMenuSignal, clearMenuSignal);
               if (added) {
-                config.customProviders = { ...customProviders, [added.name]: added };
-                config.provider = added.name;
-                config.model = added.defaultModel;
+                config.customProviders = {
+                  ...customProviders,
+                  [added.entry.name]: added.entry,
+                };
+                config.apiKeys = { ...(config.apiKeys ?? {}), [added.entry.name]: added.apiKey };
+                config.provider = added.entry.name;
+                config.model = added.entry.defaultModel;
                 savePreferences({
                   provider: config.provider,
                   model: config.model,
@@ -1603,7 +1605,9 @@ export async function startRepl(
                   tokenWindow: config.tokenWindow,
                   theme: config.theme,
                 });
-                printInfo(`  Added and switched to ${added.name} (${added.defaultModel})`);
+                printInfo(
+                  `  Added and switched to ${added.entry.name} (${added.entry.defaultModel})`,
+                );
               }
             } else {
               config.provider = value;
@@ -2342,13 +2346,15 @@ Remember: the systemPrompt should read like a persona definition — who this sp
 
 /**
  * Interactive wizard for adding a custom provider from `/provider`.
- * Returns the saved entry on success, `null` on cancel/error.
+ * Returns the saved entry plus the freshly entered API key on success
+ * (so the caller can update the live `config.apiKeys` map without
+ * re-reading from disk), or `null` on cancel/error.
  */
 async function runAddProviderWizard(
   rl: readline.Interface,
   createMenuSignal: () => AbortSignal,
   clearMenuSignal: () => void,
-): Promise<CustomProvider | null> {
+): Promise<{ entry: CustomProvider; apiKey: string } | null> {
   printInfo('\nAdd custom provider — follows the same SDK contract as built-ins.');
 
   // 1. SDK choice
@@ -2432,7 +2438,7 @@ async function runAddProviderWizard(
   try {
     const entry = saveCustomProvider({ name, sdk, baseURL, defaultModel });
     saveProviderKey(name, apiKey);
-    return entry;
+    return { entry, apiKey };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     printError(message);

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -2367,11 +2367,7 @@ async function runAddProviderWizard(
   sig = createMenuSignal();
   let nameResult: ValueResult;
   try {
-    nameResult = await promptValue(
-      rl,
-      { label: 'Provider name (lowercase, e.g. "ollama")' },
-      sig,
-    );
+    nameResult = await promptValue(rl, { label: 'Provider name (lowercase, e.g. "ollama")' }, sig);
   } finally {
     clearMenuSignal();
   }
@@ -2387,11 +2383,7 @@ async function runAddProviderWizard(
   sig = createMenuSignal();
   let urlResult: ValueResult;
   try {
-    urlResult = await promptValue(
-      rl,
-      { label: 'Base URL (e.g. http://localhost:11434/v1)' },
-      sig,
-    );
+    urlResult = await promptValue(rl, { label: 'Base URL (e.g. http://localhost:11434/v1)' }, sig);
   } finally {
     clearMenuSignal();
   }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -52,15 +52,30 @@ import {
   saveOption,
   getProviderKeyStatus,
   normalizeThreshold,
+  saveProviderKey,
   type BernardConfig,
 } from './config.js';
+import {
+  loadCustomProviders,
+  saveCustomProvider,
+  rememberCustomModel,
+  validateProviderName,
+  validateBaseURL,
+  SUPPORTED_SDKS,
+  type CustomProvider,
+} from './custom-providers.js';
+import type { SupportedSdk } from './providers/types.js';
 import { getTheme, setTheme, getThemeKeys, getActiveThemeKey, THEMES } from './theme.js';
 import { interactiveUpdate, getLocalVersion } from './update.js';
 import { CronStore } from './cron/store.js';
 import { isDaemonRunning } from './cron/client.js';
 import { HistoryStore } from './history.js';
 import { generateText } from 'ai';
-import { getModel, getModelProfile, getProviderOptions } from './providers/index.js';
+import {
+  getModelForConfig,
+  getModelProfile,
+  getProviderOptionsForConfig,
+} from './providers/index.js';
 import { rewritePrompt } from './prompt-rewriter.js';
 import {
   serializeMessages,
@@ -670,7 +685,11 @@ export async function startRepl(
   ): Promise<string | null> {
     if (!config.promptRewriter) return null;
     try {
-      const profile = getModelProfile(config.provider, config.model);
+      const profile = getModelProfile(
+        config.provider,
+        config.model,
+        config.customProviders?.[config.provider]?.sdk,
+      );
       const rewriteSignal = createMenuSignal();
       let result;
       startSpinner();
@@ -1117,8 +1136,8 @@ export async function startRepl(
 
       const taskMaxSteps = getTaskMaxSteps(config);
       const result = await generateText({
-        model: getModel(config.provider, config.model),
-        providerOptions: getProviderOptions(config.provider),
+        model: getModelForConfig(config, config.provider, config.model),
+        providerOptions: getProviderOptionsForConfig(config, config.provider),
         tools: baseTools,
         maxSteps: taskMaxSteps,
         maxTokens: config.maxTokens,
@@ -1239,8 +1258,8 @@ export async function startRepl(
 
               const [summaryResult, domainFacts, candidateResult] = await Promise.all([
                 generateText({
-                  model: getModel(config.provider, config.model),
-                  providerOptions: getProviderOptions(config.provider),
+                  model: getModelForConfig(config, config.provider, config.model),
+                  providerOptions: getProviderOptionsForConfig(config, config.provider),
                   maxTokens: 2048,
                   system: SUMMARIZATION_PROMPT,
                   messages: [
@@ -1336,7 +1355,12 @@ export async function startRepl(
         agent.clearHistory();
         historyStore.clear();
         console.clear();
-        printWelcome(config.provider, config.model, getLocalVersion());
+        printWelcome(
+          config.provider,
+          config.model,
+          getLocalVersion(),
+          config.customProviders?.[config.provider]?.baseURL,
+        );
         printInfo('Conversation history and scratch notes cleared.');
         void prompt();
         return;
@@ -1530,12 +1554,31 @@ export async function startRepl(
 
       if (trimmed === '/provider') {
         const available = getAvailableProviders(config);
-        if (available.length === 0) {
-          printError('No providers have API keys configured.');
-          void prompt();
-          return;
+        const customProviders = config.customProviders ?? {};
+        const builtinAvailable = available.filter((p) => !customProviders[p]);
+        const customAvailable = available.filter((p) => customProviders[p]);
+
+        const entries: MenuEntry[] = [];
+        for (const p of builtinAvailable) entries.push({ label: p, value: p });
+        if (customAvailable.length > 0) {
+          entries.push({ type: 'section', title: 'Custom:' });
+          for (const p of customAvailable) {
+            const entry = customProviders[p];
+            entries.push({
+              label: p,
+              annotation: `(${entry.sdk} → ${entry.baseURL})`,
+              value: p,
+            });
+          }
         }
-        const entries: MenuEntry[] = available.map((p) => ({ label: p }));
+        entries.push({ type: 'section', title: '' });
+        entries.push({ label: '+ Add custom provider…', value: '__add__' });
+
+        if (entries.length === 1) {
+          // Only the "+ Add custom provider…" entry — nothing else to choose.
+          printError('No providers have API keys configured.');
+        }
+
         const signal = createMenuSignal();
         try {
           const result = await selectFromMenu(
@@ -1545,17 +1588,36 @@ export async function startRepl(
             signal,
           );
           if (!result.cancelled) {
-            config.provider = available[result.index];
-            config.model = getDefaultModel(config.provider);
-            savePreferences({
-              provider: config.provider,
-              model: config.model,
-              maxTokens: config.maxTokens,
-              shellTimeout: config.shellTimeout,
-              tokenWindow: config.tokenWindow,
-              theme: config.theme,
-            });
-            printInfo(`  Switched to ${config.provider} (${config.model})`);
+            const value = result.item.value as string;
+            if (value === '__add__') {
+              const added = await runAddProviderWizard(rl, createMenuSignal, clearMenuSignal);
+              if (added) {
+                config.customProviders = { ...customProviders, [added.name]: added };
+                config.provider = added.name;
+                config.model = added.defaultModel;
+                savePreferences({
+                  provider: config.provider,
+                  model: config.model,
+                  maxTokens: config.maxTokens,
+                  shellTimeout: config.shellTimeout,
+                  tokenWindow: config.tokenWindow,
+                  theme: config.theme,
+                });
+                printInfo(`  Added and switched to ${added.name} (${added.defaultModel})`);
+              }
+            } else {
+              config.provider = value;
+              config.model = getDefaultModel(config.provider, customProviders);
+              savePreferences({
+                provider: config.provider,
+                model: config.model,
+                maxTokens: config.maxTokens,
+                shellTimeout: config.shellTimeout,
+                tokenWindow: config.tokenWindow,
+                theme: config.theme,
+              });
+              printInfo(`  Switched to ${config.provider} (${config.model})`);
+            }
           }
         } finally {
           clearMenuSignal();
@@ -1566,13 +1628,20 @@ export async function startRepl(
       }
 
       if (trimmed === '/model') {
-        const models = PROVIDER_MODELS[config.provider];
+        const customProviders = config.customProviders ?? {};
+        const customEntry = customProviders[config.provider];
+        const models = customEntry ? customEntry.models : PROVIDER_MODELS[config.provider];
+
         if (!models || models.length === 0) {
           printError(`No models listed for provider "${config.provider}".`);
           void prompt();
           return;
         }
-        const entries: MenuEntry[] = models.map((m) => ({ label: m }));
+        const entries: MenuEntry[] = models.map((m) => ({ label: m, value: m }));
+        if (customEntry) {
+          entries.push({ type: 'section', title: '' });
+          entries.push({ label: '+ Type a new model name…', value: '__free__' });
+        }
         const signal = createMenuSignal();
         try {
           const result = await selectFromMenu(
@@ -1582,16 +1651,39 @@ export async function startRepl(
             signal,
           );
           if (!result.cancelled) {
-            config.model = models[result.index];
-            savePreferences({
-              provider: config.provider,
-              model: config.model,
-              maxTokens: config.maxTokens,
-              shellTimeout: config.shellTimeout,
-              tokenWindow: config.tokenWindow,
-              theme: config.theme,
-            });
-            printInfo(`  Switched to ${config.model}`);
+            const value = result.item.value as string;
+            let chosenModel: string | null = null;
+            if (value === '__free__' && customEntry) {
+              const valueResult = await promptValue(
+                rl,
+                { label: 'Model name' },
+                createMenuSignal(),
+              );
+              clearMenuSignal();
+              if (!valueResult.cancelled) {
+                const newModel = valueResult.raw.trim();
+                if (newModel) {
+                  rememberCustomModel(config.provider, newModel);
+                  // Refresh local copy
+                  config.customProviders = loadCustomProviders();
+                  chosenModel = newModel;
+                }
+              }
+            } else {
+              chosenModel = value;
+            }
+            if (chosenModel) {
+              config.model = chosenModel;
+              savePreferences({
+                provider: config.provider,
+                model: config.model,
+                maxTokens: config.maxTokens,
+                shellTimeout: config.shellTimeout,
+                tokenWindow: config.tokenWindow,
+                theme: config.theme,
+              });
+              printInfo(`  Switched to ${config.model}`);
+            }
           }
         } finally {
           clearMenuSignal();
@@ -2246,4 +2338,112 @@ Remember: the systemPrompt should read like a persona definition — who this sp
   });
 
   void prompt();
+}
+
+/**
+ * Interactive wizard for adding a custom provider from `/provider`.
+ * Returns the saved entry on success, `null` on cancel/error.
+ */
+async function runAddProviderWizard(
+  rl: readline.Interface,
+  createMenuSignal: () => AbortSignal,
+  clearMenuSignal: () => void,
+): Promise<CustomProvider | null> {
+  printInfo('\nAdd custom provider — follows the same SDK contract as built-ins.');
+
+  // 1. SDK choice
+  const sdkEntries: MenuEntry[] = SUPPORTED_SDKS.map((s) => ({ label: s, value: s }));
+  let sdkResult: SelectResult;
+  let sig = createMenuSignal();
+  try {
+    sdkResult = await selectFromMenu(rl, sdkEntries, { title: 'Which SDK to use?' }, sig);
+  } finally {
+    clearMenuSignal();
+  }
+  if (sdkResult.cancelled) return null;
+  const sdk = sdkResult.item.value as SupportedSdk;
+
+  // 2. Name
+  sig = createMenuSignal();
+  let nameResult: ValueResult;
+  try {
+    nameResult = await promptValue(
+      rl,
+      { label: 'Provider name (lowercase, e.g. "ollama")' },
+      sig,
+    );
+  } finally {
+    clearMenuSignal();
+  }
+  if (nameResult.cancelled) return null;
+  const name = nameResult.raw.trim();
+  const nameErr = validateProviderName(name);
+  if (nameErr) {
+    printError(nameErr);
+    return null;
+  }
+
+  // 3. Base URL
+  sig = createMenuSignal();
+  let urlResult: ValueResult;
+  try {
+    urlResult = await promptValue(
+      rl,
+      { label: 'Base URL (e.g. http://localhost:11434/v1)' },
+      sig,
+    );
+  } finally {
+    clearMenuSignal();
+  }
+  if (urlResult.cancelled) return null;
+  const baseURL = urlResult.raw.trim();
+  const urlErr = validateBaseURL(baseURL);
+  if (urlErr) {
+    printError(urlErr);
+    return null;
+  }
+
+  // 4. Default model
+  sig = createMenuSignal();
+  let modelResult: ValueResult;
+  try {
+    modelResult = await promptValue(rl, { label: 'Default model name' }, sig);
+  } finally {
+    clearMenuSignal();
+  }
+  if (modelResult.cancelled) return null;
+  const defaultModel = modelResult.raw.trim();
+  if (!defaultModel) {
+    printError('Default model cannot be empty.');
+    return null;
+  }
+
+  // 5. API key
+  sig = createMenuSignal();
+  let keyResult: ValueResult;
+  try {
+    keyResult = await promptValue(
+      rl,
+      { label: 'API key (any non-empty token; some local servers ignore the value)' },
+      sig,
+    );
+  } finally {
+    clearMenuSignal();
+  }
+  if (keyResult.cancelled) return null;
+  const apiKey = keyResult.raw.trim();
+  if (!apiKey) {
+    printError('API key cannot be empty.');
+    return null;
+  }
+
+  try {
+    const entry = saveCustomProvider({ name, sdk, baseURL, defaultModel });
+    saveProviderKey(name, apiKey);
+    return entry;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    printError(message);
+    return null;
+  }
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -79,7 +79,12 @@ export async function runFirstTimeSetup(): Promise<boolean> {
 
     console.log(t.success('\n  Setup complete!'));
     console.log(t.muted(`  Provider: ${provider} | Model: ${model}`));
-    console.log(t.muted('  You can change these later with /provider and /model\n'));
+    console.log(t.muted('  You can change these later with /provider and /model'));
+    console.log(
+      t.muted(
+        '  Tip: running a local LLM? Use `bernard add-provider` to point at it (Ollama, LM Studio, OpenRouter, etc.)\n',
+      ),
+    );
 
     return true;
   } finally {

--- a/src/specialist-detector.test.ts
+++ b/src/specialist-detector.test.ts
@@ -13,12 +13,14 @@ vi.mock('node:fs', () => ({
 
 vi.mock('./providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getModelProfile: vi.fn(() => ({
     family: 'test',
     wrapUserMessage: (m: string) => m,
     systemSuffix: '',
   })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 const mockGenerateText = vi.fn();

--- a/src/specialist-detector.ts
+++ b/src/specialist-detector.ts
@@ -1,5 +1,5 @@
 import { generateText } from 'ai';
-import { getModel, getProviderOptions } from './providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
 import type { Specialist, SpecialistSummary } from './specialists.js';
@@ -126,8 +126,8 @@ export async function detectSpecialistCandidate(
 
   try {
     const result = await generateText({
-      model: getModel(config.provider, config.model),
-      providerOptions: getProviderOptions(config.provider),
+      model: getModelForConfig(config, config.provider, config.model),
+      providerOptions: getProviderOptionsForConfig(config, config.provider),
       maxTokens: 2048,
       system: DETECTION_SYSTEM_PROMPT,
       messages: [

--- a/src/tools/specialist-run.test.ts
+++ b/src/tools/specialist-run.test.ts
@@ -518,11 +518,7 @@ describe('specialist-run tool', () => {
       );
 
       expect(result).not.toContain('No API key found');
-      expect(mockGetModel).toHaveBeenCalledWith(
-        expect.anything(),
-        'anthropic',
-        expect.any(String),
-      );
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'anthropic', expect.any(String));
     });
 
     it('treats empty-string provider on saved specialist as not provided', async () => {
@@ -537,11 +533,7 @@ describe('specialist-run tool', () => {
       );
 
       expect(result).not.toContain('No API key found');
-      expect(mockGetModel).toHaveBeenCalledWith(
-        expect.anything(),
-        'anthropic',
-        expect.any(String),
-      );
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'anthropic', expect.any(String));
     });
   });
 

--- a/src/tools/specialist-run.test.ts
+++ b/src/tools/specialist-run.test.ts
@@ -16,7 +16,9 @@ const fs = await import('node:fs');
 
 vi.mock('../providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('../logger.js', () => ({
@@ -70,7 +72,7 @@ import { _resetPool } from './agent-pool.js';
 import { MemoryStore } from '../memory.js';
 import { SpecialistStore } from '../specialists.js';
 
-const { getModel: mockGetModel } = await import('../providers/index.js');
+const { getModelForConfig: mockGetModel } = await import('../providers/index.js');
 
 function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
   return {
@@ -401,7 +403,7 @@ describe('specialist-run tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('xai', 'grok-code-fast-1');
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'xai', 'grok-code-fast-1');
     });
 
     it('invocation override takes priority over specialist config', async () => {
@@ -416,7 +418,7 @@ describe('specialist-run tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('openai', 'gpt-4o-mini');
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'openai', 'gpt-4o-mini');
     });
 
     it('falls back to global config when no overrides', async () => {
@@ -429,7 +431,11 @@ describe('specialist-run tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-4-5-20250929');
+      expect(mockGetModel).toHaveBeenCalledWith(
+        expect.anything(),
+        'anthropic',
+        'claude-sonnet-4-5-20250929',
+      );
     });
 
     it('returns error when resolved provider has no API key', async () => {
@@ -463,7 +469,7 @@ describe('specialist-run tool', () => {
 
       // Should use xai's default model, not anthropic's model
       const { getDefaultModel } = await import('../config.js');
-      expect(mockGetModel).toHaveBeenCalledWith('xai', getDefaultModel('xai'));
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'xai', getDefaultModel('xai'));
     });
 
     it('uses provider default model when invocation overrides provider but not model', async () => {
@@ -478,7 +484,11 @@ describe('specialist-run tool', () => {
       );
 
       const { getDefaultModel } = await import('../config.js');
-      expect(mockGetModel).toHaveBeenCalledWith('openai', getDefaultModel('openai'));
+      expect(mockGetModel).toHaveBeenCalledWith(
+        expect.anything(),
+        'openai',
+        getDefaultModel('openai'),
+      );
     });
 
     it('returns error when specialist provider has no API key', async () => {
@@ -508,7 +518,11 @@ describe('specialist-run tool', () => {
       );
 
       expect(result).not.toContain('No API key found');
-      expect(mockGetModel).toHaveBeenCalledWith('anthropic', expect.any(String));
+      expect(mockGetModel).toHaveBeenCalledWith(
+        expect.anything(),
+        'anthropic',
+        expect.any(String),
+      );
     });
 
     it('treats empty-string provider on saved specialist as not provided', async () => {
@@ -523,7 +537,11 @@ describe('specialist-run tool', () => {
       );
 
       expect(result).not.toContain('No API key found');
-      expect(mockGetModel).toHaveBeenCalledWith('anthropic', expect.any(String));
+      expect(mockGetModel).toHaveBeenCalledWith(
+        expect.anything(),
+        'anthropic',
+        expect.any(String),
+      );
     });
   });
 

--- a/src/tools/specialist-run.ts
+++ b/src/tools/specialist-run.ts
@@ -1,6 +1,6 @@
 import { generateText, tool, type CoreMessage } from 'ai';
 import { z } from 'zod';
-import { getModel, getProviderOptions } from '../providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { createTools, type ToolOptions } from './index.js';
 import {
   printSpecialistStart,
@@ -200,8 +200,8 @@ export function createSpecialistRunTool(
         const baseMaxSteps = Math.ceil(config.maxSteps * SPECIALIST_STEP_RATIO);
         const maxSteps = computeEffectiveMaxSteps(baseMaxSteps, config.reactMode);
         let result = await generateText({
-          model: getModel(resolvedProvider, resolvedModel),
-          providerOptions: getProviderOptions(resolvedProvider),
+          model: getModelForConfig(config, resolvedProvider, resolvedModel),
+          providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
           tools: specialistTools,
           maxSteps,
           maxTokens: config.maxTokens,
@@ -219,8 +219,8 @@ export function createSpecialistRunTool(
             initialResult: result,
             regenerate: async (extraMessages) => {
               return generateText({
-                model: getModel(resolvedProvider, resolvedModel),
-                providerOptions: getProviderOptions(resolvedProvider),
+                model: getModelForConfig(config, resolvedProvider, resolvedModel),
+                providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
                 tools: specialistTools,
                 maxSteps: SPECIALIST_PAC_RETRY_STEPS,
                 maxTokens: config.maxTokens,
@@ -267,8 +267,8 @@ export function createSpecialistRunTool(
                 config.reactMode,
               );
               result = await generateText({
-                model: getModel(resolvedProvider, resolvedModel),
-                providerOptions: getProviderOptions(resolvedProvider),
+                model: getModelForConfig(config, resolvedProvider, resolvedModel),
+                providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
                 tools: specialistTools,
                 maxSteps: retryMaxSteps,
                 maxTokens: config.maxTokens,

--- a/src/tools/specialist-run.ts
+++ b/src/tools/specialist-run.ts
@@ -120,7 +120,7 @@ export function createSpecialistRunTool(
         config,
       });
       if (!resolution.ok) {
-        return `Error: ${defaultProviderErrorMessage(resolution.provider, resolution.envVar)}`;
+        return `Error: ${defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom)}`;
       }
       const { provider: resolvedProvider, model: resolvedModel } = resolution;
 

--- a/src/tools/subagent.test.ts
+++ b/src/tools/subagent.test.ts
@@ -16,7 +16,9 @@ const fs = await import('node:fs');
 
 vi.mock('../providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('../logger.js', () => ({
@@ -50,7 +52,7 @@ vi.mock('ai', async (importOriginal) => {
 import { createSubAgentTool, _resetSubAgentState } from './subagent.js';
 import { MemoryStore } from '../memory.js';
 
-const { getModel: mockGetModel } = await import('../providers/index.js');
+const { getModelForConfig: mockGetModel } = await import('../providers/index.js');
 
 function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
   return {
@@ -389,7 +391,7 @@ describe('subagent tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('xai', 'grok-code-fast-1');
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'xai', 'grok-code-fast-1');
     });
 
     it('falls back to global config when no override', async () => {
@@ -400,7 +402,11 @@ describe('subagent tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-4-5-20250929');
+      expect(mockGetModel).toHaveBeenCalledWith(
+        expect.anything(),
+        'anthropic',
+        'claude-sonnet-4-5-20250929',
+      );
     });
 
     it('uses provider default model when provider overridden but model not (avoids cross-provider mismatch)', async () => {
@@ -414,7 +420,7 @@ describe('subagent tool', () => {
 
       // Should use xai's default model, not anthropic's model
       const { getDefaultModel } = await import('../config.js');
-      expect(mockGetModel).toHaveBeenCalledWith('xai', getDefaultModel('xai'));
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'xai', getDefaultModel('xai'));
     });
 
     it('returns error when override provider has no API key', async () => {

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -98,7 +98,7 @@ export function createSubAgentTool(
     execute: async ({ task, context, provider, model }, execOptions) => {
       const resolution = resolveProviderAndModel({ provider, model, config });
       if (!resolution.ok) {
-        return `Error: ${defaultProviderErrorMessage(resolution.provider, resolution.envVar)}`;
+        return `Error: ${defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom)}`;
       }
       const { provider: resolvedProvider, model: resolvedModel } = resolution;
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -1,6 +1,6 @@
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
-import { getModel, getProviderOptions } from '../providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { createTools, type ToolOptions } from './index.js';
 import {
   printSubAgentStart,
@@ -155,8 +155,8 @@ export function createSubAgentTool(
 
         const maxSteps = Math.ceil(config.maxSteps * SUBAGENT_STEP_RATIO);
         const result = await generateText({
-          model: getModel(resolvedProvider, resolvedModel),
-          providerOptions: getProviderOptions(resolvedProvider),
+          model: getModelForConfig(config, resolvedProvider, resolvedModel),
+          providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
           tools: baseTools,
           maxSteps,
           maxTokens: config.maxTokens,
@@ -175,8 +175,8 @@ export function createSubAgentTool(
             regenerate: async (extraMessages) => {
               const retryMaxSteps = SUBAGENT_PAC_RETRY_STEPS;
               return generateText({
-                model: getModel(resolvedProvider, resolvedModel),
-                providerOptions: getProviderOptions(resolvedProvider),
+                model: getModelForConfig(config, resolvedProvider, resolvedModel),
+                providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
                 tools: baseTools,
                 maxSteps: retryMaxSteps,
                 maxTokens: config.maxTokens,

--- a/src/tools/task.test.ts
+++ b/src/tools/task.test.ts
@@ -16,7 +16,9 @@ const fs = await import('node:fs');
 
 vi.mock('../providers/index.js', () => ({
   getModel: vi.fn(() => ({ modelId: 'mock' })),
+  getModelForConfig: vi.fn(() => ({ modelId: 'mock' })),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('../logger.js', () => ({
@@ -59,7 +61,7 @@ import { _resetPool } from './agent-pool.js';
 import { MemoryStore } from '../memory.js';
 import { RoutineStore } from '../routines.js';
 
-const { getModel: mockGetModel } = await import('../providers/index.js');
+const { getModelForConfig: mockGetModel } = await import('../providers/index.js');
 
 function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
   return {
@@ -482,7 +484,7 @@ describe('task tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('xai', 'grok-code-fast-1');
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'xai', 'grok-code-fast-1');
     });
 
     it('falls back to global config when no override', async () => {
@@ -493,7 +495,11 @@ describe('task tool', () => {
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      expect(mockGetModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-4-5-20250929');
+      expect(mockGetModel).toHaveBeenCalledWith(
+        expect.anything(),
+        'anthropic',
+        'claude-sonnet-4-5-20250929',
+      );
     });
 
     it('uses provider default model when provider overridden but model not (avoids cross-provider mismatch)', async () => {
@@ -507,7 +513,7 @@ describe('task tool', () => {
 
       // Should use xai's default model, not anthropic's model
       const { getDefaultModel } = await import('../config.js');
-      expect(mockGetModel).toHaveBeenCalledWith('xai', getDefaultModel('xai'));
+      expect(mockGetModel).toHaveBeenCalledWith(expect.anything(), 'xai', getDefaultModel('xai'));
     });
 
     it('returns error JSON when override provider has no API key', async () => {

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -1,6 +1,6 @@
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
-import { getModel, getProviderOptions } from '../providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { createTools, type ToolOptions } from './index.js';
 import { extractJsonBlock } from '../structured-output.js';
 import {
@@ -250,8 +250,8 @@ export function createTaskTool(
 
         const taskMaxSteps = getTaskMaxSteps(config);
         const result = await generateText({
-          model: getModel(resolvedProvider, resolvedModel),
-          providerOptions: getProviderOptions(resolvedProvider),
+          model: getModelForConfig(config, resolvedProvider, resolvedModel),
+          providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
           tools: baseTools,
           maxSteps: taskMaxSteps,
           maxTokens: config.maxTokens,

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -169,9 +169,10 @@ export function createTaskTool(
     execute: async ({ task, taskId, context, provider, model }, execOptions) => {
       const resolution = resolveProviderAndModel({ provider, model, config });
       if (!resolution.ok) {
+        const envHint = resolution.isCustom ? '' : ` or set ${resolution.envVar}`;
         return JSON.stringify({
           status: 'error',
-          output: `No API key found for provider "${resolution.provider}". Run: bernard add-key ${resolution.provider} <your-api-key> or set ${resolution.envVar}.`,
+          output: `No API key found for provider "${resolution.provider}". Run: bernard add-key ${resolution.provider} <your-api-key>${envHint}.`,
         });
       }
       const { provider: resolvedProvider, model: resolvedModel } = resolution;

--- a/src/tools/tool-wrapper-run.test.ts
+++ b/src/tools/tool-wrapper-run.test.ts
@@ -9,7 +9,9 @@ vi.mock('ai', () => ({
 
 vi.mock('../providers/index.js', () => ({
   getModel: vi.fn(() => 'mock-model'),
+  getModelForConfig: vi.fn(() => 'mock-model'),
   getProviderOptions: vi.fn(() => undefined),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
 }));
 
 vi.mock('./index.js', () => ({

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -1,6 +1,6 @@
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
-import { getModel, getProviderOptions } from '../providers/index.js';
+import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { createTools, type ToolOptions } from './index.js';
 import { createSubAgentTool } from './subagent.js';
 import { createTaskTool } from './task.js';
@@ -296,8 +296,8 @@ export function createToolWrapperRunTool(
         };
 
         const result = await generateText({
-          model: getModel(resolvedProvider, resolvedModel),
-          providerOptions: getProviderOptions(resolvedProvider),
+          model: getModelForConfig(config, resolvedProvider, resolvedModel),
+          providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
           tools: childTools,
           maxSteps,
           maxTokens: config.maxTokens,

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -196,9 +196,12 @@ export function createToolWrapperRunTool(
         config,
       });
       if (!resolution.ok) {
+        const hint = resolution.isCustom
+          ? `Run: bernard add-key ${resolution.provider} <key>`
+          : `Set ${resolution.envVar} or run: bernard add-key ${resolution.provider} <key>`;
         return JSON.stringify({
           status: 'error',
-          result: `No API key for provider "${resolution.provider}". Set ${resolution.envVar} or run: bernard add-key ${resolution.provider} <key>.`,
+          result: `No API key for provider "${resolution.provider}". ${hint}.`,
           error: 'no_api_key',
         });
       }


### PR DESCRIPTION
## Summary
- Adds **named custom providers**: users can register a provider that wraps one of the installed SDKs (`openai` / `anthropic` / `xai`) and points it at any compatible endpoint — Ollama, LM Studio, OpenRouter, internal proxies, etc. Multiple custom providers coexist with the built-ins.
- CLI: `bernard add-provider <name> --sdk <s> --base-url <u> --model <m> [--key <k>]`, `bernard remove-provider <name>`, and the existing `bernard providers` command now lists built-ins and custom side-by-side.
- REPL: `/provider` ends with "+ Add custom provider…" (interactive wizard); for custom providers, `/model` ends with "+ Type a new model name…" and remembers the entry. Welcome banner shows an `Endpoint:` line when a base-URL override is active.
- Storage at `~/.config/bernard/custom-providers.json`. Keys stay in `keys.json` and are never injected into `process.env`. Reserved names: `anthropic`, `openai`, `xai`.
- Every `getModel(...)` call site routes through new `getModelForConfig` / `getProviderOptionsForConfig` helpers, so custom-endpoint routing is transparent to the agent loop, sub-agents, critic, PAC, prompt-rewriter, reference resolver, context compression, and the cron runner.

Closes #149.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 2117/2117 pass across 76 files
- [ ] Smoke against a local Ollama: `bernard add-provider ollama --sdk openai --base-url http://localhost:11434/v1 --model llama3.2 --key ollama` → REPL turn returns a response
- [ ] `/provider` wizard end-to-end (add → switch → use → `bernard remove-provider`)
- [ ] `/model` free-text on a custom provider persists the new entry
- [ ] Welcome banner shows `Endpoint:` line only when active provider has a base URL
- [ ] `bernard providers` lists the custom entry under built-ins

🤖 Generated with [Claude Code](https://claude.com/claude-code)