### PR TITLE
Route low-level tool calls through wrapper specialists + add tool-arg repair hooks

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -57,6 +57,8 @@ import { createPlanTool } from './tools/plan.js';
 import { createThinkTool } from './tools/think.js';
 import { createAskUserTool } from './tools/ask-user.js';
 import { createEvaluateTool } from './tools/evaluate.js';
+import { applyShimRouting } from './tools/wrap-with-specialist.js';
+import { makeRepairHook } from './tool-call-repair.js';
 
 /**
  * Directs the model to publish brief reasoning via the `think` tool so the
@@ -102,7 +104,10 @@ Before executing any task that requires more than two tool calls:
 This makes your reasoning visible and reduces errors on multi-step tasks. For simple tasks (1-2 tool calls), skip the plan and act directly.
 
 ## Temporary Scripts
-For complex multi-step shell work, JSON parsing pipelines, retry loops, or anything you expect to iterate on, prefer writing a short throwaway script to a temp path (e.g. \`/tmp/bernard-<task>.sh\`, \`/tmp/bernard-<task>.py\`, \`/tmp/bernard-<task>.mjs\`) and running it instead of cramming logic into a single inline shell command. Edit and re-run the script when you need to adjust — that is faster, more debuggable, and produces clearer error messages than rebuilding a long one-liner. Use \`file_edit_lines\` (or \`file_write\` for a fresh file) to author the script, then \`shell\` to execute it. Clean up temp files when the task is finished.
+For complex multi-step shell work, JSON parsing pipelines, retry loops, or anything you expect to iterate on, prefer writing a short throwaway script to a temp path (e.g. \`/tmp/bernard-<task>.sh\`, \`/tmp/bernard-<task>.py\`, \`/tmp/bernard-<task>.mjs\`) and running it instead of cramming logic into a single inline shell command. Use \`file_write\` to author the script, then \`shell\` to execute it. Edit and re-run with \`file_edit_lines\` when you need to adjust. Clean up temp files when the task is finished.
+
+## Tool-Call Argument Size
+Never embed file content, scripts, JSON bodies, or any other payload larger than ~500 bytes inside a \`shell\` command (no heredocs like \`cat > file <<EOF\`, no \`printf\`/\`echo\` of long literals, no inline JSON over a few lines). Large single-string tool arguments can be truncated mid-response, producing JSON-parse failures that abort the turn. The correct pattern is always: write the payload to a file with \`file_write\`, then reference that file from \`shell\`.
 
 ## Tool Execution Integrity
 - NEVER simulate, fabricate, or narrate tool execution. If a task requires running a command, you MUST call the shell tool — do not write prose describing what a command "would return" or pretend you already ran it.
@@ -662,8 +667,22 @@ export class Agent {
           : {}),
       };
 
-      // Wrap every tool's execute to observe errors and record profiles
-      const augmentedTools = augmentTools(tools, this.toolProfileStore);
+      // Route low-level tool calls (shell, web_read, file_*) through their
+      // wrapper specialists transparently, then wrap every tool's execute to
+      // observe errors and record profiles. Shim routing happens only at the
+      // main-agent level — sub-agents and specialists keep raw tools.
+      const shimmedTools = applyShimRouting(tools, {
+        config: this.config,
+        options: this.toolOptions,
+        memoryStore: this.memoryStore,
+        specialistStore: this.specialistStore,
+        correctionStore: this.correctionStore,
+        mcpTools: this.mcpTools,
+        ragStore: this.ragStore,
+        routineStore: this.routineStore,
+        candidateStore: this.candidateStore,
+      });
+      const augmentedTools = augmentTools(shimmedTools, this.toolProfileStore);
 
       // Coordinator (ReAct) mode triples the step budget for the main agent,
       // clamped to REACT_MAX_STEPS_CEILING to bound worst-case cost.
@@ -683,6 +702,11 @@ export class Agent {
           system: systemPrompt,
           messages: messages ?? this.history,
           abortSignal: this.abortController!.signal,
+          experimental_repairToolCall: makeRepairHook({
+            config: this.config,
+            label: 'main',
+            abortSignal: this.abortController!.signal,
+          }),
           onStepFinish: ({ text, toolCalls, toolResults, usage }) => {
             if (usage) {
               this.lastStepPromptTokens = usage.promptTokens;

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -22,6 +22,7 @@ import { createScopedCronNotesTools } from './scoped-notes-tools.js';
 import { sendNotification } from './notify.js';
 import type { CronJob } from './types.js';
 import { runPACLoop } from '../pac.js';
+import { makeRepairHook } from '../tool-call-repair.js';
 
 const DAEMON_SYSTEM_PROMPT = `You are Bernard, running as a background cron job in daemon mode. There is no interactive user present — you execute autonomously and have a limited step budget (20 steps), so work efficiently.
 
@@ -261,6 +262,11 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
       });
     };
 
+    const repairHook = makeRepairHook({
+      config,
+      label: 'cron',
+    });
+
     const result = await generateText({
       model: getModelForConfig(config, config.provider, config.model),
       providerOptions: getProviderOptionsForConfig(config, config.provider),
@@ -269,6 +275,7 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
       maxTokens: config.maxTokens,
       system: enrichedPrompt,
       messages: [{ role: 'user', content: job.prompt }],
+      experimental_repairToolCall: repairHook,
       onStepFinish,
     });
 
@@ -288,6 +295,7 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
             maxTokens: config.maxTokens,
             system: enrichedPrompt,
             messages: [{ role: 'user', content: job.prompt }, ...extraMessages],
+            experimental_repairToolCall: repairHook,
             onStepFinish,
           });
         },

--- a/src/tool-call-repair.test.ts
+++ b/src/tool-call-repair.test.ts
@@ -57,7 +57,9 @@ function makeRepairContext(overrides: Record<string, any> = {}) {
     parameterSchema: vi.fn(() => ({ type: 'object', properties: { command: { type: 'string' } } })),
     messages: [{ role: 'user', content: 'do a thing' }],
     system: 'you are bernard',
-    error: new (InvalidToolArgumentsError as any)('JSON parsing failed: Unterminated string at position 16602'),
+    error: new (InvalidToolArgumentsError as any)(
+      'JSON parsing failed: Unterminated string at position 16602',
+    ),
     ...overrides,
   };
 }

--- a/src/tool-call-repair.test.ts
+++ b/src/tool-call-repair.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('ai', async () => {
+  // Stand-in marker classes so .isInstance() can recognise mocked errors.
+  class InvalidToolArgumentsError extends Error {
+    static isInstance(err: unknown): err is InvalidToolArgumentsError {
+      return err instanceof InvalidToolArgumentsError;
+    }
+  }
+  class NoSuchToolError extends Error {
+    static isInstance(err: unknown): err is NoSuchToolError {
+      return err instanceof NoSuchToolError;
+    }
+  }
+  return {
+    generateText: vi.fn(),
+    InvalidToolArgumentsError,
+    NoSuchToolError,
+  };
+});
+
+vi.mock('./providers/index.js', () => ({
+  getModelForConfig: vi.fn(() => 'mock-model'),
+  getProviderOptionsForConfig: vi.fn(() => undefined),
+}));
+
+vi.mock('./logger.js', () => ({
+  debugLog: vi.fn(),
+}));
+
+// ── Deferred imports ──────────────────────────────────────────────────────────
+
+import { makeRepairHook } from './tool-call-repair.js';
+
+const { generateText, InvalidToolArgumentsError, NoSuchToolError } = await import('ai');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeConfig() {
+  return {
+    provider: 'anthropic',
+    model: 'claude-test',
+    maxTokens: 4096,
+  } as any;
+}
+
+function makeRepairContext(overrides: Record<string, any> = {}) {
+  return {
+    toolCall: {
+      toolCallId: 'tc-1',
+      toolName: 'shell',
+      args: 'invalid json{{',
+    },
+    tools: { shell: { description: 'shell' }, web_read: { description: 'web' } },
+    parameterSchema: vi.fn(() => ({ type: 'object', properties: { command: { type: 'string' } } })),
+    messages: [{ role: 'user', content: 'do a thing' }],
+    system: 'you are bernard',
+    error: new (InvalidToolArgumentsError as any)('JSON parsing failed: Unterminated string at position 16602'),
+    ...overrides,
+  };
+}
+
+describe('makeRepairHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a repaired tool call when the model re-emits valid args', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls -la' } }],
+    } as any);
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    const repaired = await hook(makeRepairContext() as any);
+
+    expect(repaired).not.toBeNull();
+    expect(repaired!.toolName).toBe('shell');
+    expect(repaired!.toolCallId).toBe('tc-1');
+    expect(repaired!.args).toBe(JSON.stringify({ command: 'ls -la' }));
+    expect(repaired!.toolCallType).toBe('function');
+    expect(vi.mocked(generateText)).toHaveBeenCalledOnce();
+  });
+
+  it('hints at file_write when the args appear to be truncated mid-string', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],
+    } as any);
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    await hook(makeRepairContext() as any);
+
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as any;
+    const userMessage = callArgs.messages[callArgs.messages.length - 1];
+    expect(userMessage.role).toBe('user');
+    expect(userMessage.content).toMatch(/file_write/);
+    expect(userMessage.content).toMatch(/truncated/i);
+  });
+
+  it('hints at available tools when the model picked a nonexistent tool', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],
+    } as any);
+
+    const ctx = makeRepairContext({
+      toolCall: { toolCallId: 'tc-2', toolName: 'bogus_tool', args: '{}' },
+      error: new (NoSuchToolError as any)('Tool not found: bogus_tool'),
+    });
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    await hook(ctx as any);
+
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as any;
+    const userMessage = callArgs.messages[callArgs.messages.length - 1];
+    expect(userMessage.content).toContain('does not exist');
+    expect(userMessage.content).toMatch(/shell|web_read/);
+    // NoSuchTool path should free toolChoice (model has to pick).
+    expect(callArgs.toolChoice).toBe('auto');
+  });
+
+  it('forces the same toolName for non-NoSuchTool errors via toolChoice', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],
+    } as any);
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    await hook(makeRepairContext() as any);
+
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArgs.toolChoice).toEqual({ type: 'tool', toolName: 'shell' });
+    expect(callArgs.maxSteps).toBe(1);
+  });
+
+  it('returns null when the repair generateText itself throws', async () => {
+    vi.mocked(generateText).mockRejectedValue(new Error('upstream blew up'));
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    const result = await hook(makeRepairContext() as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the model emits no tool calls', async () => {
+    vi.mocked(generateText).mockResolvedValue({ toolCalls: [] } as any);
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    const result = await hook(makeRepairContext() as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('includes the parameter schema in the recovery message when available', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],
+    } as any);
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    await hook(makeRepairContext() as any);
+
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as any;
+    const userMessage = callArgs.messages[callArgs.messages.length - 1];
+    expect(userMessage.content).toContain('Expected parameter schema');
+    expect(userMessage.content).toContain('command');
+  });
+
+  it('does not throw when parameterSchema itself throws (unknown tool)', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],
+    } as any);
+
+    const ctx = makeRepairContext({
+      parameterSchema: vi.fn(() => {
+        throw new Error('no such schema');
+      }),
+    });
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    const result = await hook(ctx as any);
+
+    expect(result).not.toBeNull();
+  });
+
+  it('only invokes generateText once per failed tool call (no looping)', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],
+    } as any);
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    await hook(makeRepairContext() as any);
+
+    expect(vi.mocked(generateText)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tool-call-repair.ts
+++ b/src/tool-call-repair.ts
@@ -1,0 +1,132 @@
+import {
+  generateText,
+  type CoreMessage,
+  type ToolCallRepairFunction,
+  type ToolSet,
+  NoSuchToolError,
+  InvalidToolArgumentsError,
+} from 'ai';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import type { BernardConfig } from './config.js';
+import { debugLog } from './logger.js';
+
+/** Identifies which generateText site produced the failed tool call. */
+export type RepairLabel = 'main' | 'specialist' | 'subagent' | 'tool-wrapper' | 'cron';
+
+export interface MakeRepairHookOpts {
+  config: BernardConfig;
+  /** Provider to use for the repair call. Defaults to config.provider. */
+  provider?: string;
+  /** Model to use for the repair call. Defaults to config.model. */
+  model?: string;
+  label: RepairLabel;
+  /** Optional abort signal forwarded to the repair generateText call. */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Heuristic detector for tool-call argument truncation. When the model emits a
+ * massive single string argument (e.g. a 16 KB heredoc inside a `command`
+ * field), the response may be cut off mid-string, producing
+ * "Unterminated string in JSON" or similar from JSON.parse.
+ */
+function looksLikeTruncationError(message: string): boolean {
+  return (
+    /unterminated string/i.test(message) ||
+    /unexpected end of (json|input)/i.test(message) ||
+    /expected.*after.*in json/i.test(message)
+  );
+}
+
+/**
+ * Produces an `experimental_repairToolCall` hook for `generateText`. When the
+ * AI SDK fails to parse a model's tool-call arguments (or the model targets a
+ * nonexistent tool), the hook runs ONE focused generation asking the model to
+ * re-emit a valid tool call. Returns the corrected call, or `null` to let the
+ * SDK throw.
+ *
+ * The repair attempt is bounded to a single retry per failed tool call — no
+ * looping, no escalation. Failures are logged to the debug stream.
+ *
+ * Special-cases JSON truncation (the model packed too much content into a
+ * single string arg) by hinting at `file_write` + `shell` as the safe pattern
+ * for large payloads.
+ */
+export function makeRepairHook<TOOLS extends ToolSet>(
+  opts: MakeRepairHookOpts,
+): ToolCallRepairFunction<TOOLS> {
+  const { config, provider, model, label, abortSignal } = opts;
+  const resolvedProvider = provider ?? config.provider;
+  const resolvedModel = model ?? config.model;
+
+  return async ({ toolCall, tools, parameterSchema, messages, system, error }) => {
+    try {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const isInvalidArgs = InvalidToolArgumentsError.isInstance(error);
+      const isNoSuchTool = NoSuchToolError.isInstance(error);
+
+      let hint = '';
+      if (isInvalidArgs && looksLikeTruncationError(errorMessage)) {
+        hint =
+          '\n\nThe arguments appear to have been truncated mid-string. For payloads larger than ~1 KB (file contents, scripts, JSON bodies), write the content to a file using `file_write` (or save a script with `file_write` and execute it with `shell`) instead of inlining it as a tool-call argument.';
+      } else if (isNoSuchTool) {
+        const available = Object.keys(tools).slice(0, 25).join(', ');
+        hint = `\n\nThe tool "${toolCall.toolName}" does not exist. Available tools include: ${available}.`;
+      }
+
+      let schemaText = '';
+      try {
+        const schema = parameterSchema({ toolName: toolCall.toolName });
+        schemaText = `\n\nExpected parameter schema for \`${toolCall.toolName}\`:\n\`\`\`json\n${JSON.stringify(schema, null, 2)}\n\`\`\``;
+      } catch {
+        // No schema available (e.g. unknown tool) — skip.
+      }
+
+      const recoveryMessage: CoreMessage = {
+        role: 'user',
+        content: `Your previous tool call to \`${toolCall.toolName}\` failed to parse:\n\n${errorMessage}${schemaText}${hint}\n\nRe-emit the tool call with valid arguments. Do not explain — just call the tool.`,
+      };
+
+      const repairMessages: CoreMessage[] = [...messages, recoveryMessage];
+
+      const result = await generateText({
+        model: getModelForConfig(config, resolvedProvider, resolvedModel),
+        providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
+        tools,
+        toolChoice: isNoSuchTool ? 'auto' : { type: 'tool', toolName: toolCall.toolName },
+        maxSteps: 1,
+        maxTokens: config.maxTokens,
+        system,
+        messages: repairMessages,
+        abortSignal,
+      });
+
+      const repaired = result.toolCalls?.[0];
+      if (!repaired) {
+        debugLog(`tool-call-repair:${label}:no-call`, {
+          toolName: toolCall.toolName,
+          errorMessage,
+        });
+        return null;
+      }
+
+      debugLog(`tool-call-repair:${label}:ok`, {
+        original: toolCall.toolName,
+        repaired: repaired.toolName,
+      });
+
+      return {
+        toolCallType: 'function',
+        toolCallId: toolCall.toolCallId,
+        toolName: repaired.toolName,
+        args: JSON.stringify(repaired.args),
+      };
+    } catch (err) {
+      debugLog(
+        `tool-call-repair:${label}:error`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+  };
+}

--- a/src/tool-call-repair.ts
+++ b/src/tool-call-repair.ts
@@ -122,10 +122,7 @@ export function makeRepairHook<TOOLS extends ToolSet>(
         args: JSON.stringify(repaired.args),
       };
     } catch (err) {
-      debugLog(
-        `tool-call-repair:${label}:error`,
-        err instanceof Error ? err.message : String(err),
-      );
+      debugLog(`tool-call-repair:${label}:error`, err instanceof Error ? err.message : String(err));
       return null;
     }
   };

--- a/src/tools/specialist-run.ts
+++ b/src/tools/specialist-run.ts
@@ -39,6 +39,7 @@ import {
   buildEnforcementFeedback,
 } from '../react.js';
 import { truncateToolResults } from '../context.js';
+import { makeRepairHook } from '../tool-call-repair.js';
 
 const SPECIALIST_STEP_RATIO = 0.5;
 const SPECIALIST_PAC_RETRY_STEPS = 10;
@@ -199,6 +200,13 @@ export function createSpecialistRunTool(
 
         const baseMaxSteps = Math.ceil(config.maxSteps * SPECIALIST_STEP_RATIO);
         const maxSteps = computeEffectiveMaxSteps(baseMaxSteps, config.reactMode);
+        const repairHook = makeRepairHook({
+          config,
+          provider: resolvedProvider,
+          model: resolvedModel,
+          label: 'specialist',
+          abortSignal: execOptions.abortSignal,
+        });
         let result = await generateText({
           model: getModelForConfig(config, resolvedProvider, resolvedModel),
           providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
@@ -209,6 +217,7 @@ export function createSpecialistRunTool(
           messages: [{ role: 'user', content: userMessage }],
           abortSignal: execOptions.abortSignal,
           experimental_prepareStep: makeLastStepTextOnly(maxSteps),
+          experimental_repairToolCall: repairHook,
           onStepFinish,
         });
 
@@ -228,6 +237,7 @@ export function createSpecialistRunTool(
                 messages: [{ role: 'user', content: userMessage }, ...extraMessages],
                 abortSignal: execOptions.abortSignal,
                 experimental_prepareStep: makeLastStepTextOnly(SPECIALIST_PAC_RETRY_STEPS),
+                experimental_repairToolCall: repairHook,
                 onStepFinish,
               });
             },
@@ -276,6 +286,7 @@ export function createSpecialistRunTool(
                 messages: retryMessages,
                 abortSignal: execOptions.abortSignal,
                 experimental_prepareStep: makeLastStepTextOnly(retryMaxSteps),
+                experimental_repairToolCall: repairHook,
                 onStepFinish,
               });
             } catch (retryErr) {

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -23,6 +23,7 @@ import { runPACLoop } from '../pac.js';
 import { capSubagentResult } from './result-cap.js';
 import { appendActivitySummary } from './activity-summary.js';
 import { makeLastStepTextOnly } from './task.js';
+import { makeRepairHook } from '../tool-call-repair.js';
 
 const SUBAGENT_STEP_RATIO = 0.5;
 const SUBAGENT_PAC_RETRY_STEPS = 10;
@@ -154,6 +155,13 @@ export function createSubAgentTool(
         };
 
         const maxSteps = Math.ceil(config.maxSteps * SUBAGENT_STEP_RATIO);
+        const repairHook = makeRepairHook({
+          config,
+          provider: resolvedProvider,
+          model: resolvedModel,
+          label: 'subagent',
+          abortSignal: execOptions.abortSignal,
+        });
         const result = await generateText({
           model: getModelForConfig(config, resolvedProvider, resolvedModel),
           providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
@@ -164,6 +172,7 @@ export function createSubAgentTool(
           messages: [{ role: 'user', content: userMessage }],
           abortSignal: execOptions.abortSignal,
           experimental_prepareStep: makeLastStepTextOnly(maxSteps),
+          experimental_repairToolCall: repairHook,
           onStepFinish,
         });
 
@@ -184,6 +193,7 @@ export function createSubAgentTool(
                 messages: [{ role: 'user', content: userMessage }, ...extraMessages],
                 abortSignal: execOptions.abortSignal,
                 experimental_prepareStep: makeLastStepTextOnly(retryMaxSteps),
+                experimental_repairToolCall: repairHook,
                 onStepFinish,
               });
             },

--- a/src/tools/tool-wrapper-run.test.ts
+++ b/src/tools/tool-wrapper-run.test.ts
@@ -99,8 +99,10 @@ import {
   captureLastToolCall,
   captureToolCalls,
   createToolWrapperRunTool,
+  renderWrapperParentView,
 } from './tool-wrapper-run.js';
 import { _resetPool } from './agent-pool.js';
+import { DEFAULT_SUBAGENT_RESULT_MAX_CHARS } from './result-cap.js';
 
 const { generateText } = await import('ai');
 const { acquireSlot, releaseSlot } = await import('./agent-pool.js');
@@ -447,6 +449,57 @@ describe('captureToolCalls', () => {
     const result = captureToolCalls(steps);
     expect(result).toHaveLength(1);
     expect(result[0].tool).toBe('shell');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('renderWrapperParentView', () => {
+  it('returns only status and result on success — never reasoning', () => {
+    const view = renderWrapperParentView({
+      status: 'ok',
+      result: 'done',
+      reasoning: ['decided to call shell', 'parsed output'],
+    });
+    const parsed = JSON.parse(view);
+    expect(parsed).toEqual({ status: 'ok', result: 'done' });
+    expect(parsed.reasoning).toBeUndefined();
+  });
+
+  it('includes error field on error and still strips reasoning', () => {
+    const view = renderWrapperParentView({
+      status: 'error',
+      result: 'command failed',
+      error: 'exit_code_1',
+      reasoning: ['internal note that should not leak'],
+    });
+    const parsed = JSON.parse(view);
+    expect(parsed).toEqual({
+      status: 'error',
+      result: 'command failed',
+      error: 'exit_code_1',
+    });
+    expect(parsed.reasoning).toBeUndefined();
+  });
+
+  it('omits the error field when it is absent', () => {
+    const view = renderWrapperParentView({
+      status: 'error',
+      result: 'opaque failure',
+    });
+    const parsed = JSON.parse(view);
+    expect(parsed).toEqual({ status: 'error', result: 'opaque failure' });
+    expect('error' in parsed).toBe(false);
+  });
+
+  it('applies capSubagentResult to the rendered JSON string', () => {
+    const longResult = 'x'.repeat(DEFAULT_SUBAGENT_RESULT_MAX_CHARS + 5000);
+    const view = renderWrapperParentView({
+      status: 'ok',
+      result: longResult,
+    });
+    expect(view.length).toBe(DEFAULT_SUBAGENT_RESULT_MAX_CHARS);
+    expect(view.endsWith(`chars]`)).toBe(true);
   });
 });
 

--- a/src/tools/tool-wrapper-run.test.ts
+++ b/src/tools/tool-wrapper-run.test.ts
@@ -492,14 +492,41 @@ describe('renderWrapperParentView', () => {
     expect('error' in parsed).toBe(false);
   });
 
-  it('applies capSubagentResult to the rendered JSON string', () => {
+  it('caps the result field before serialization so the envelope stays valid JSON', () => {
     const longResult = 'x'.repeat(DEFAULT_SUBAGENT_RESULT_MAX_CHARS + 5000);
     const view = renderWrapperParentView({
       status: 'ok',
       result: longResult,
     });
-    expect(view.length).toBe(DEFAULT_SUBAGENT_RESULT_MAX_CHARS);
-    expect(view.endsWith(`chars]`)).toBe(true);
+
+    // The outer envelope must remain parseable — that's the whole point of the fix.
+    const parsed = JSON.parse(view);
+    expect(parsed.status).toBe('ok');
+    expect(typeof parsed.result).toBe('string');
+
+    // Result was truncated (much shorter than the original) and carries the marker.
+    expect((parsed.result as string).length).toBeLessThan(longResult.length);
+    expect((parsed.result as string).endsWith('chars]')).toBe(true);
+
+    // Total envelope still bounded around the cap.
+    expect(view.length).toBeLessThanOrEqual(DEFAULT_SUBAGENT_RESULT_MAX_CHARS);
+  });
+
+  it('caps a non-string `result` by JSON-stringifying and truncating it', () => {
+    const big = { payload: 'y'.repeat(DEFAULT_SUBAGENT_RESULT_MAX_CHARS + 1000) };
+    const view = renderWrapperParentView({ status: 'ok', result: big });
+
+    const parsed = JSON.parse(view);
+    expect(parsed.status).toBe('ok');
+    // Non-string result that exceeds budget becomes a truncated string carrying the marker.
+    expect(typeof parsed.result).toBe('string');
+    expect((parsed.result as string).endsWith('chars]')).toBe(true);
+  });
+
+  it('preserves small non-string `result` payloads as native JSON', () => {
+    const small = { output: 'hi', is_error: false };
+    const view = renderWrapperParentView({ status: 'ok', result: small });
+    expect(JSON.parse(view)).toEqual({ status: 'ok', result: small });
   });
 });
 

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -30,7 +30,7 @@ import {
   type WrapperResult,
 } from '../structured-output.js';
 import { appendReasoningLog } from '../reasoning-log.js';
-import { capSubagentResult } from './result-cap.js';
+import { capSubagentResult, SUBAGENT_RESULT_MAX_CHARS } from './result-cap.js';
 
 /** Fraction of config.maxSteps allocated to a tool-wrapper run. Mirrors task/specialist ratios. */
 const TOOL_WRAPPER_STEP_RATIO = 0.5;
@@ -313,6 +313,7 @@ export async function dispatchToolWrapper(
       provider: resolvedProvider,
       model: resolvedModel,
       label: 'tool-wrapper',
+      abortSignal,
     });
 
     const result = await generateText({
@@ -388,20 +389,40 @@ export async function dispatchToolWrapper(
 
 /**
  * Strips internal fields (`reasoning`) from a wrapper result before it crosses
- * back into the parent agent's context, and applies the standard subagent
- * result cap. The reasoning array is already persisted to the JSONL trace via
+ * back into the parent agent's context, and caps the `result` field so the
+ * outer JSON envelope stays parseable when the wrapper output is large. The
+ * reasoning array is already persisted to the JSONL trace via
  * {@link appendReasoningLog}; the parent doesn't need it.
+ *
+ * The cap is applied to the `result` field *before* serialization rather than
+ * to the serialized envelope, so a truncated payload never produces invalid
+ * JSON.
  */
-export function renderWrapperParentView(wrapped: WrapperResult): string {
+export function renderWrapperParentView(
+  wrapped: WrapperResult,
+  maxChars: number = SUBAGENT_RESULT_MAX_CHARS,
+): string {
+  const errorLen = wrapped.error?.length ?? 0;
+  const resultBudget = Math.max(256, maxChars - errorLen - 80);
+
+  const cappedResult =
+    typeof wrapped.result === 'string'
+      ? capSubagentResult(wrapped.result, resultBudget)
+      : (() => {
+          const asJson = JSON.stringify(wrapped.result);
+          if (asJson === undefined || asJson.length <= resultBudget) return wrapped.result;
+          return capSubagentResult(asJson, resultBudget);
+        })();
+
   const parentView =
     wrapped.status === 'ok'
-      ? { status: 'ok' as const, result: wrapped.result }
+      ? { status: 'ok' as const, result: cappedResult }
       : {
           status: 'error' as const,
-          result: wrapped.result,
+          result: cappedResult,
           ...(wrapped.error !== undefined ? { error: wrapped.error } : {}),
         };
-  return capSubagentResult(JSON.stringify(parentView));
+  return JSON.stringify(parentView);
 }
 
 /**

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -24,8 +24,13 @@ import type { SpecialistStore, Specialist } from '../specialists.js';
 import type { CandidateStoreReader } from '../specialist-candidates.js';
 import type { CorrectionCandidateStore } from '../correction-candidates.js';
 import { osPromptBlock } from '../os-info.js';
-import { STRUCTURED_OUTPUT_RULES, wrapWrapperResult } from '../structured-output.js';
+import {
+  STRUCTURED_OUTPUT_RULES,
+  wrapWrapperResult,
+  type WrapperResult,
+} from '../structured-output.js';
 import { appendReasoningLog } from '../reasoning-log.js';
+import { capSubagentResult } from './result-cap.js';
 
 /** Fraction of config.maxSteps allocated to a tool-wrapper run. Mirrors task/specialist ratios. */
 const TOOL_WRAPPER_STEP_RATIO = 0.5;
@@ -125,6 +130,281 @@ export function captureToolCalls(steps: any[] | undefined): Array<{
   return out;
 }
 
+/** Dependencies that change per-process but never per-call. Passed once. */
+export interface ToolWrapperDeps {
+  config: BernardConfig;
+  options: ToolOptions;
+  memoryStore: MemoryStore;
+  specialistStore: SpecialistStore;
+  correctionStore: CorrectionCandidateStore;
+  mcpTools?: Record<string, any>;
+  ragStore?: RAGStore;
+  routineStore?: RoutineStore;
+  candidateStore?: CandidateStoreReader;
+}
+
+/** Per-call inputs to a tool-wrapper dispatch. */
+export interface DispatchToolWrapperArgs {
+  specialistId: string;
+  input: string;
+  context?: string;
+  provider?: string;
+  model?: string;
+  abortSignal?: AbortSignal;
+  /** Label shown to the user when announcing the wrapper run. Defaults to `[<kind>] <name>`. */
+  runLabel?: string;
+}
+
+/**
+ * Core dispatch for tool-wrapper specialists. Used by both the explicit
+ * `tool_wrapper_run` tool and the shim layer that routes raw tool calls
+ * (e.g. `shell`) through their corresponding wrapper specialist.
+ *
+ * Returns a {@link WrapperResult} so callers can shape the parent-facing
+ * response however they like (JSON envelope, raw result, error string).
+ * Pool acquisition, reasoning logging, and correction-candidate enqueue
+ * happen inside.
+ */
+export async function dispatchToolWrapper(
+  args: DispatchToolWrapperArgs,
+  deps: ToolWrapperDeps,
+): Promise<WrapperResult> {
+  const { specialistId, input, context, provider, model, abortSignal, runLabel } = args;
+  const {
+    config,
+    options,
+    memoryStore,
+    specialistStore,
+    correctionStore,
+    mcpTools,
+    ragStore,
+    routineStore,
+    candidateStore,
+  } = deps;
+
+  const specialist = specialistStore.get(specialistId);
+  if (!specialist) {
+    return {
+      status: 'error',
+      result: `No specialist found with id "${specialistId}".`,
+      error: 'not_found',
+    };
+  }
+  const kind = specialist.kind ?? 'persona';
+  if (kind === 'persona') {
+    return {
+      status: 'error',
+      result: `Specialist "${specialistId}" is a persona specialist. Use specialist_run instead, or update its kind to "tool-wrapper".`,
+      error: 'wrong_kind',
+    };
+  }
+
+  const resolution = resolveProviderAndModel({
+    provider,
+    model,
+    specialistProvider: specialist.provider,
+    specialistModel: specialist.model,
+    config,
+  });
+  if (!resolution.ok) {
+    const hint = resolution.isCustom
+      ? `Run: bernard add-key ${resolution.provider} <key>`
+      : `Set ${resolution.envVar} or run: bernard add-key ${resolution.provider} <key>`;
+    return {
+      status: 'error',
+      result: `No API key for provider "${resolution.provider}". ${hint}.`,
+      error: 'no_api_key',
+    };
+  }
+  const { provider: resolvedProvider, model: resolvedModel } = resolution;
+
+  const slot = acquireSlot();
+  if (!slot) {
+    return {
+      status: 'error',
+      result: `Maximum concurrent agents (${MAX_CONCURRENT_AGENTS}) reached.`,
+      error: 'pool_exhausted',
+    };
+  }
+
+  const id = slot.id;
+  const prefix = `wrap:${id}`;
+  const label = runLabel ?? `[${kind}] ${specialist.name}`;
+  printSpecialistStart(id, label, input);
+
+  try {
+    const baseTools = createTools(
+      options,
+      memoryStore,
+      mcpTools,
+      routineStore,
+      specialistStore,
+      candidateStore,
+      config,
+    );
+    const fullRegistry: Record<string, any> = {
+      ...baseTools,
+      agent: createSubAgentTool(config, options, memoryStore, mcpTools, ragStore),
+      task: createTaskTool(config, options, memoryStore, mcpTools, ragStore, routineStore),
+      specialist_run: createSpecialistRunTool(
+        config,
+        options,
+        memoryStore,
+        specialistStore,
+        mcpTools,
+        ragStore,
+      ),
+      tool_wrapper_run: createToolWrapperRunTool(
+        config,
+        options,
+        memoryStore,
+        specialistStore,
+        correctionStore,
+        mcpTools,
+        ragStore,
+        routineStore,
+        candidateStore,
+      ),
+    };
+    const childTools = buildChildTools(specialist, fullRegistry);
+
+    let systemPrompt = specialist.systemPrompt;
+    if (specialist.guidelines.length > 0) {
+      systemPrompt +=
+        '\n\nGuidelines:\n' + specialist.guidelines.map((g) => `- ${g}`).join('\n');
+    }
+    systemPrompt += '\n\n' + osPromptBlock();
+    systemPrompt += formatExamples(specialist);
+    // Default to structured output for tool-wrapper specialists unless explicitly disabled.
+    const wantStructured = specialist.structuredOutput ?? kind === 'tool-wrapper';
+    if (wantStructured) {
+      systemPrompt += STRUCTURED_OUTPUT_RULES;
+    }
+    systemPrompt += buildMemoryContext({
+      memoryStore,
+      ragResults: undefined,
+      includeScratch: true,
+    });
+    if (Object.keys(childTools).length > 0) {
+      systemPrompt += `\n\nAvailable tools for this run: ${Object.keys(childTools).join(', ')}`;
+    } else {
+      systemPrompt +=
+        '\n\nNo tools are available for this run. Produce the structured output based on reasoning alone.';
+    }
+
+    let userMessage = `Request: ${input}`;
+    if (context) userMessage += `\n\nContext: ${context}`;
+
+    const maxSteps = Math.max(2, Math.ceil(config.maxSteps * TOOL_WRAPPER_STEP_RATIO));
+
+    const onStepFinish = ({ text, toolCalls, toolResults }: any) => {
+      for (const tc of toolCalls ?? []) {
+        printToolCall(tc.toolName, tc.args as Record<string, unknown>, prefix);
+      }
+      for (const tr of toolResults ?? []) {
+        printToolResult(tr.toolName, tr.result, prefix);
+      }
+      if (text) printAssistantText(text, prefix);
+    };
+
+    // Lazy import to avoid a top-level cycle (tool-call-repair → providers).
+    const { makeRepairHook } = await import('../tool-call-repair.js');
+    const repairHook = makeRepairHook({
+      config,
+      provider: resolvedProvider,
+      model: resolvedModel,
+      label: 'tool-wrapper',
+    });
+
+    const result = await generateText({
+      model: getModelForConfig(config, resolvedProvider, resolvedModel),
+      providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
+      tools: childTools,
+      maxSteps,
+      maxTokens: config.maxTokens,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userMessage }],
+      abortSignal,
+      experimental_prepareStep: wantStructured ? makeLastStepTextOnly(maxSteps) : undefined,
+      experimental_repairToolCall: repairHook,
+      onStepFinish,
+    });
+
+    printSpecialistEnd(id);
+
+    const wrapped = wantStructured
+      ? wrapWrapperResult(result.text)
+      : { status: 'ok' as const, result: result.text };
+
+    appendReasoningLog({
+      ts: new Date().toISOString(),
+      specialistId,
+      input,
+      toolCalls: captureToolCalls(result.steps as any[]),
+      finalOutput: wrapped.result,
+      status:
+        wrapped.status === 'ok'
+          ? 'ok'
+          : wrapped.error === 'parse_failed'
+            ? 'parse_failed'
+            : 'error',
+      ...(wrapped.error !== undefined ? { error: wrapped.error } : {}),
+      ...(wrapped.reasoning !== undefined ? { reasoning: wrapped.reasoning } : {}),
+    });
+
+    if (wrapped.status === 'error' && kind === 'tool-wrapper') {
+      try {
+        correctionStore.enqueue({
+          specialistId,
+          input,
+          attemptedCall: captureLastToolCall(result.steps as any[]),
+          error: wrapped.error ?? String(wrapped.result),
+        });
+      } catch (err) {
+        debugLog(
+          'tool-wrapper:correction-enqueue:error',
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+
+    return wrapped;
+  } catch (err: unknown) {
+    printSpecialistEnd(id);
+    const message = err instanceof Error ? err.message : String(err);
+    appendReasoningLog({
+      ts: new Date().toISOString(),
+      specialistId,
+      input,
+      toolCalls: [],
+      finalOutput: message,
+      status: 'error',
+      error: 'runtime_error',
+    });
+    return { status: 'error', result: message, error: 'runtime_error' };
+  } finally {
+    releaseSlot();
+  }
+}
+
+/**
+ * Strips internal fields (`reasoning`) from a wrapper result before it crosses
+ * back into the parent agent's context, and applies the standard subagent
+ * result cap. The reasoning array is already persisted to the JSONL trace via
+ * {@link appendReasoningLog}; the parent doesn't need it.
+ */
+export function renderWrapperParentView(wrapped: WrapperResult): string {
+  const parentView =
+    wrapped.status === 'ok'
+      ? { status: 'ok' as const, result: wrapped.result }
+      : {
+          status: 'error' as const,
+          result: wrapped.result,
+          ...(wrapped.error !== undefined ? { error: wrapped.error } : {}),
+        };
+  return capSubagentResult(JSON.stringify(parentView));
+}
+
 /**
  * Creates the `tool_wrapper_run` tool for structured, isolated tool-wrapper
  * specialist execution with validated JSON output and failure-learning.
@@ -137,6 +417,8 @@ export function captureToolCalls(steps: any[] | undefined): Array<{
  *   - parses through a Zod schema and logs runs that reach `generateText`
  *     to the reasoning log (guard failures return early without logging)
  *   - enqueues a correction candidate on error for end-of-session learning
+ *   - strips `reasoning` and caps the JSON envelope before returning to the
+ *     parent agent — the full reasoning lives in the JSONL trace only
  */
 export function createToolWrapperRunTool(
   config: BernardConfig,
@@ -151,7 +433,7 @@ export function createToolWrapperRunTool(
 ) {
   return tool({
     description:
-      'Dispatch to a saved tool-wrapper specialist that handles a concrete tool or CLI (e.g. shell-wrapper, file-wrapper). Returns strict JSON {status, result, error?, reasoning?}. Use this for tool-heavy operations where domain-specific examples and error handling reduce misuse. Also used to invoke meta specialists (specialist-creator, correction-agent).',
+      'Dispatch to a saved tool-wrapper specialist that handles a concrete tool or CLI (e.g. shell-wrapper, file-wrapper). Returns JSON {status, result, error?}. Use this for tool-heavy operations where domain-specific examples and error handling reduce misuse. Also used to invoke meta specialists (specialist-creator, correction-agent).',
     parameters: z.object({
       specialistId: z
         .string()
@@ -171,205 +453,28 @@ export function createToolWrapperRunTool(
       model: z.string().optional().describe('Optional model override for this invocation.'),
     }),
     execute: async ({ specialistId, input, context, provider, model }, execOptions) => {
-      const specialist = specialistStore.get(specialistId);
-      if (!specialist) {
-        return JSON.stringify({
-          status: 'error',
-          result: `No specialist found with id "${specialistId}".`,
-          error: 'not_found',
-        });
-      }
-      const kind = specialist.kind ?? 'persona';
-      if (kind === 'persona') {
-        return JSON.stringify({
-          status: 'error',
-          result: `Specialist "${specialistId}" is a persona specialist. Use specialist_run instead, or update its kind to "tool-wrapper".`,
-          error: 'wrong_kind',
-        });
-      }
-
-      const resolution = resolveProviderAndModel({
-        provider,
-        model,
-        specialistProvider: specialist.provider,
-        specialistModel: specialist.model,
-        config,
-      });
-      if (!resolution.ok) {
-        const hint = resolution.isCustom
-          ? `Run: bernard add-key ${resolution.provider} <key>`
-          : `Set ${resolution.envVar} or run: bernard add-key ${resolution.provider} <key>`;
-        return JSON.stringify({
-          status: 'error',
-          result: `No API key for provider "${resolution.provider}". ${hint}.`,
-          error: 'no_api_key',
-        });
-      }
-      const { provider: resolvedProvider, model: resolvedModel } = resolution;
-
-      const slot = acquireSlot();
-      if (!slot) {
-        return JSON.stringify({
-          status: 'error',
-          result: `Maximum concurrent agents (${MAX_CONCURRENT_AGENTS}) reached.`,
-          error: 'pool_exhausted',
-        });
-      }
-
-      const id = slot.id;
-      const prefix = `wrap:${id}`;
-      const runLabel = `[${kind}] ${specialist.name}`;
-      printSpecialistStart(id, runLabel, input);
-
-      try {
-        // Base tools + dispatch tools so meta specialists can nest properly.
-        const baseTools = createTools(
+      const wrapped = await dispatchToolWrapper(
+        {
+          specialistId,
+          input,
+          context,
+          provider,
+          model,
+          abortSignal: execOptions.abortSignal,
+        },
+        {
+          config,
           options,
           memoryStore,
-          mcpTools,
-          routineStore,
           specialistStore,
+          correctionStore,
+          mcpTools,
+          ragStore,
+          routineStore,
           candidateStore,
-          config,
-        );
-        const fullRegistry: Record<string, any> = {
-          ...baseTools,
-          agent: createSubAgentTool(config, options, memoryStore, mcpTools, ragStore),
-          task: createTaskTool(config, options, memoryStore, mcpTools, ragStore, routineStore),
-          specialist_run: createSpecialistRunTool(
-            config,
-            options,
-            memoryStore,
-            specialistStore,
-            mcpTools,
-            ragStore,
-          ),
-          tool_wrapper_run: createToolWrapperRunTool(
-            config,
-            options,
-            memoryStore,
-            specialistStore,
-            correctionStore,
-            mcpTools,
-            ragStore,
-            routineStore,
-            candidateStore,
-          ),
-        };
-        const childTools = buildChildTools(specialist, fullRegistry);
-
-        // Build system prompt.
-        let systemPrompt = specialist.systemPrompt;
-        if (specialist.guidelines.length > 0) {
-          systemPrompt +=
-            '\n\nGuidelines:\n' + specialist.guidelines.map((g) => `- ${g}`).join('\n');
-        }
-        systemPrompt += '\n\n' + osPromptBlock();
-        systemPrompt += formatExamples(specialist);
-        // Default to structured output for tool-wrapper specialists unless explicitly disabled.
-        const wantStructured = specialist.structuredOutput ?? kind === 'tool-wrapper';
-        if (wantStructured) {
-          systemPrompt += STRUCTURED_OUTPUT_RULES;
-        }
-        systemPrompt += buildMemoryContext({
-          memoryStore,
-          ragResults: undefined,
-          includeScratch: true,
-        });
-        if (Object.keys(childTools).length > 0) {
-          systemPrompt += `\n\nAvailable tools for this run: ${Object.keys(childTools).join(', ')}`;
-        } else {
-          systemPrompt +=
-            '\n\nNo tools are available for this run. Produce the structured output based on reasoning alone.';
-        }
-
-        let userMessage = `Request: ${input}`;
-        if (context) userMessage += `\n\nContext: ${context}`;
-
-        const maxSteps = Math.max(2, Math.ceil(config.maxSteps * TOOL_WRAPPER_STEP_RATIO));
-
-        const onStepFinish = ({ text, toolCalls, toolResults }: any) => {
-          for (const tc of toolCalls ?? []) {
-            printToolCall(tc.toolName, tc.args as Record<string, unknown>, prefix);
-          }
-          for (const tr of toolResults ?? []) {
-            printToolResult(tr.toolName, tr.result, prefix);
-          }
-          if (text) printAssistantText(text, prefix);
-        };
-
-        const result = await generateText({
-          model: getModelForConfig(config, resolvedProvider, resolvedModel),
-          providerOptions: getProviderOptionsForConfig(config, resolvedProvider),
-          tools: childTools,
-          maxSteps,
-          maxTokens: config.maxTokens,
-          system: systemPrompt,
-          messages: [{ role: 'user', content: userMessage }],
-          abortSignal: execOptions.abortSignal,
-          experimental_prepareStep: wantStructured ? makeLastStepTextOnly(maxSteps) : undefined,
-          onStepFinish,
-        });
-
-        printSpecialistEnd(id);
-
-        const wrapped = wantStructured
-          ? wrapWrapperResult(result.text)
-          : { status: 'ok' as const, result: result.text };
-
-        // Reasoning log — always write, even when parsing fails.
-        appendReasoningLog({
-          ts: new Date().toISOString(),
-          specialistId,
-          input,
-          toolCalls: captureToolCalls(result.steps as any[]),
-          finalOutput: wrapped.result,
-          status:
-            wrapped.status === 'ok'
-              ? 'ok'
-              : wrapped.error === 'parse_failed'
-                ? 'parse_failed'
-                : 'error',
-          ...(wrapped.error !== undefined ? { error: wrapped.error } : {}),
-          ...(wrapped.reasoning !== undefined ? { reasoning: wrapped.reasoning } : {}),
-        });
-
-        // Enqueue correction candidate on failure (tool-wrapper only; meta specialists
-        // often manage their own error flows and don't benefit from auto-correction).
-        if (wrapped.status === 'error' && kind === 'tool-wrapper') {
-          try {
-            correctionStore.enqueue({
-              specialistId,
-              input,
-              attemptedCall: captureLastToolCall(result.steps as any[]),
-              error: wrapped.error ?? String(wrapped.result),
-            });
-          } catch (err) {
-            debugLog(
-              'tool-wrapper:correction-enqueue:error',
-              err instanceof Error ? err.message : String(err),
-            );
-          }
-        }
-
-        return JSON.stringify(wrapped);
-      } catch (err: unknown) {
-        printSpecialistEnd(id);
-        const message = err instanceof Error ? err.message : String(err);
-        const errorResult = { status: 'error' as const, result: message, error: 'runtime_error' };
-        appendReasoningLog({
-          ts: new Date().toISOString(),
-          specialistId,
-          input,
-          toolCalls: [],
-          finalOutput: message,
-          status: 'error',
-          error: 'runtime_error',
-        });
-        return JSON.stringify(errorResult);
-      } finally {
-        releaseSlot();
-      }
+        },
+      );
+      return renderWrapperParentView(wrapped);
     },
   });
 }

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -270,8 +270,7 @@ export async function dispatchToolWrapper(
 
     let systemPrompt = specialist.systemPrompt;
     if (specialist.guidelines.length > 0) {
-      systemPrompt +=
-        '\n\nGuidelines:\n' + specialist.guidelines.map((g) => `- ${g}`).join('\n');
+      systemPrompt += '\n\nGuidelines:\n' + specialist.guidelines.map((g) => `- ${g}`).join('\n');
     }
     systemPrompt += '\n\n' + osPromptBlock();
     systemPrompt += formatExamples(specialist);

--- a/src/tools/wrap-with-specialist.test.ts
+++ b/src/tools/wrap-with-specialist.test.ts
@@ -182,7 +182,10 @@ describe('wrapToolWithSpecialist', () => {
     });
 
     const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
-    const result = await wrapped.execute({ command: 'cat /etc/shadow' }, { abortSignal: undefined });
+    const result = await wrapped.execute(
+      { command: 'cat /etc/shadow' },
+      { abortSignal: undefined },
+    );
 
     expect(result).toBe('Error (exit_code_1): permission denied');
     expect(String(result)).not.toContain('should not leak');

--- a/src/tools/wrap-with-specialist.test.ts
+++ b/src/tools/wrap-with-specialist.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('./tool-wrapper-run.js', () => ({
+  dispatchToolWrapper: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  debugLog: vi.fn(),
+}));
+
+// ── Deferred imports ──────────────────────────────────────────────────────────
+
+import {
+  buildShimInput,
+  formatWrappedResult,
+  wrapToolWithSpecialist,
+  applyShimRouting,
+  DEFAULT_SHIM_ROUTING,
+} from './wrap-with-specialist.js';
+
+const { dispatchToolWrapper } = await import('./tool-wrapper-run.js');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBaseTool(executeImpl: (...args: any[]) => any) {
+  return {
+    description: 'base tool',
+    parameters: {},
+    execute: vi.fn(executeImpl),
+  };
+}
+
+function makeDeps(overrides: Record<string, any> = {}) {
+  return {
+    config: {} as any,
+    options: {} as any,
+    memoryStore: {} as any,
+    specialistStore: {
+      get: vi.fn(),
+    } as any,
+    correctionStore: { enqueue: vi.fn() } as any,
+    ...overrides,
+  };
+}
+
+// ── buildShimInput ────────────────────────────────────────────────────────────
+
+describe('buildShimInput', () => {
+  it('embeds the tool name and JSON-formatted args verbatim', () => {
+    const input = buildShimInput('shell', { command: 'ls -la' });
+    expect(input).toContain('`shell`');
+    expect(input).toContain('"command": "ls -la"');
+  });
+
+  it('falls back to String(args) when args cannot be JSON-serialised', () => {
+    const circular: any = {};
+    circular.self = circular;
+    const input = buildShimInput('shell', circular);
+    expect(input).toContain('`shell`');
+    // Just confirm it didn't throw and the description is present.
+    expect(input).toContain('Execute this tool call');
+  });
+
+  it('mentions that only `result` and `error` cross back to the parent', () => {
+    const input = buildShimInput('shell', { command: 'pwd' });
+    expect(input).toMatch(/result|error/i);
+  });
+});
+
+// ── formatWrappedResult ───────────────────────────────────────────────────────
+
+describe('formatWrappedResult', () => {
+  it('returns the raw string `result` on success', () => {
+    expect(formatWrappedResult({ status: 'ok', result: 'hello' })).toBe('hello');
+  });
+
+  it('JSON-stringifies non-string `result` on success', () => {
+    expect(formatWrappedResult({ status: 'ok', result: { a: 1 } })).toBe('{"a":1}');
+  });
+
+  it('prefixes with "Error (<code>):" when an error code is present', () => {
+    const out = formatWrappedResult({
+      status: 'error',
+      result: 'command failed',
+      error: 'exit_code_1',
+    });
+    expect(out).toBe('Error (exit_code_1): command failed');
+  });
+
+  it('prefixes with "Error:" when no error code is present', () => {
+    const out = formatWrappedResult({
+      status: 'error',
+      result: 'opaque failure',
+    });
+    expect(out).toBe('Error: opaque failure');
+  });
+
+  it('JSON-stringifies a non-string error body', () => {
+    const out = formatWrappedResult({
+      status: 'error',
+      result: { reason: 'bad' },
+      error: 'parse_failed',
+    });
+    expect(out).toBe('Error (parse_failed): {"reason":"bad"}');
+  });
+});
+
+// ── wrapToolWithSpecialist ────────────────────────────────────────────────────
+
+describe('wrapToolWithSpecialist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the base tool unchanged when execute is missing', () => {
+    const noExec = { description: 'no exec' } as any;
+    const deps = makeDeps();
+    const wrapped = wrapToolWithSpecialist(noExec, 'shell', 'shell-wrapper', deps);
+    expect(wrapped).toBe(noExec);
+  });
+
+  it('falls through to baseExecute when the specialist is missing', async () => {
+    const base = makeBaseTool(async () => 'raw output');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue(undefined);
+
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    const result = await wrapped.execute({ command: 'ls' }, { abortSignal: undefined });
+
+    expect(result).toBe('raw output');
+    expect(base.execute).toHaveBeenCalledOnce();
+    expect(vi.mocked(dispatchToolWrapper)).not.toHaveBeenCalled();
+  });
+
+  it('falls through to baseExecute when the specialist has wrong kind', async () => {
+    const base = makeBaseTool(async () => 'raw output');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue({ name: 'persona', kind: 'persona' });
+
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    const result = await wrapped.execute({ command: 'ls' }, { abortSignal: undefined });
+
+    expect(result).toBe('raw output');
+    expect(vi.mocked(dispatchToolWrapper)).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to the wrapper specialist when present, returning only result on ok', async () => {
+    const base = makeBaseTool(async () => 'should not run');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue({ name: 'Shell Wrapper', kind: 'tool-wrapper' });
+    vi.mocked(dispatchToolWrapper).mockResolvedValue({
+      status: 'ok',
+      result: 'wrapper output',
+      reasoning: ['this should be stripped'],
+    });
+
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    const result = await wrapped.execute({ command: 'ls' }, { abortSignal: undefined });
+
+    expect(result).toBe('wrapper output');
+    expect(base.execute).not.toHaveBeenCalled();
+    expect(vi.mocked(dispatchToolWrapper)).toHaveBeenCalledOnce();
+
+    const call = vi.mocked(dispatchToolWrapper).mock.calls[0][0];
+    expect(call.specialistId).toBe('shell-wrapper');
+    expect(call.input).toContain('`shell`');
+    expect(call.input).toContain('"command": "ls"');
+    expect(call.runLabel).toBe('[shim] shell → Shell Wrapper');
+  });
+
+  it('formats wrapper errors as "Error (code): body" without exposing reasoning', async () => {
+    const base = makeBaseTool(async () => 'should not run');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue({ name: 'Shell Wrapper', kind: 'tool-wrapper' });
+    vi.mocked(dispatchToolWrapper).mockResolvedValue({
+      status: 'error',
+      result: 'permission denied',
+      error: 'exit_code_1',
+      reasoning: ['should not leak'],
+    });
+
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    const result = await wrapped.execute({ command: 'cat /etc/shadow' }, { abortSignal: undefined });
+
+    expect(result).toBe('Error (exit_code_1): permission denied');
+    expect(String(result)).not.toContain('should not leak');
+  });
+
+  it('falls back to baseExecute when dispatch itself throws', async () => {
+    const base = makeBaseTool(async () => 'raw fallback');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue({ name: 'Shell Wrapper', kind: 'tool-wrapper' });
+    vi.mocked(dispatchToolWrapper).mockRejectedValue(new Error('dispatch crashed'));
+
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    const result = await wrapped.execute({ command: 'ls' }, { abortSignal: undefined });
+
+    expect(result).toBe('raw fallback');
+    expect(base.execute).toHaveBeenCalledOnce();
+  });
+
+  it('forwards abortSignal from execOptions to dispatchToolWrapper', async () => {
+    const base = makeBaseTool(async () => 'unused');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue({ name: 'Shell Wrapper', kind: 'tool-wrapper' });
+    vi.mocked(dispatchToolWrapper).mockResolvedValue({
+      status: 'ok',
+      result: 'ok',
+    });
+
+    const ac = new AbortController();
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    await wrapped.execute({ command: 'ls' }, { abortSignal: ac.signal });
+
+    const call = vi.mocked(dispatchToolWrapper).mock.calls[0][0];
+    expect(call.abortSignal).toBe(ac.signal);
+  });
+
+  it('preserves the base tool description and parameters (model sees same schema)', () => {
+    const base = {
+      description: 'Run a shell command',
+      parameters: { foo: 'bar' },
+      execute: vi.fn(),
+    } as any;
+    const deps = makeDeps();
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    expect(wrapped.description).toBe('Run a shell command');
+    expect(wrapped.parameters).toEqual({ foo: 'bar' });
+  });
+});
+
+// ── applyShimRouting ──────────────────────────────────────────────────────────
+
+describe('applyShimRouting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('only wraps tools present in both routing table and tool set', () => {
+    const shell = makeBaseTool(async () => 'shell ran');
+    const web = makeBaseTool(async () => 'web ran');
+    const tools = { shell, web_read: web };
+
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue(undefined);
+
+    const out = applyShimRouting(tools, deps, { shell: 'shell-wrapper', missing: 'never' });
+    expect(out.shell).not.toBe(shell);
+    expect(out.web_read).toBe(web);
+    expect((out as any).missing).toBeUndefined();
+  });
+
+  it('uses DEFAULT_SHIM_ROUTING when no routing arg is provided', () => {
+    const shell = makeBaseTool(async () => 'shell');
+    const file_read_lines = makeBaseTool(async () => 'read');
+    const file_edit_lines = makeBaseTool(async () => 'edit');
+    const web_read = makeBaseTool(async () => 'web');
+    const tools = { shell, file_read_lines, file_edit_lines, web_read };
+
+    const deps = makeDeps();
+    const out = applyShimRouting(tools, deps);
+
+    // All four DEFAULT_SHIM_ROUTING tools should have been wrapped (new ref).
+    for (const name of Object.keys(DEFAULT_SHIM_ROUTING)) {
+      expect(out[name]).not.toBe(tools[name as keyof typeof tools]);
+    }
+  });
+
+  it('returns a new object — does not mutate the input', () => {
+    const shell = makeBaseTool(async () => 'shell');
+    const tools = { shell };
+    const deps = makeDeps();
+    const out = applyShimRouting(tools, deps, { shell: 'shell-wrapper' });
+    expect(out).not.toBe(tools);
+    expect(tools.shell).toBe(shell);
+  });
+});

--- a/src/tools/wrap-with-specialist.test.ts
+++ b/src/tools/wrap-with-specialist.test.ts
@@ -76,33 +76,65 @@ describe('formatWrappedResult', () => {
     expect(formatWrappedResult({ status: 'ok', result: 'hello' })).toBe('hello');
   });
 
-  it('JSON-stringifies non-string `result` on success', () => {
-    expect(formatWrappedResult({ status: 'ok', result: { a: 1 } })).toBe('{"a":1}');
+  it('preserves a structured `result` object on success (does not JSON-stringify)', () => {
+    const obj = { output: 'hi', is_error: false };
+    const out = formatWrappedResult({ status: 'ok', result: obj }, 'shell');
+    expect(out).toEqual(obj);
+    // Same reference — passed through as-is so detectToolError sees native shape.
+    expect(out).toBe(obj);
   });
 
-  it('prefixes with "Error (<code>):" when an error code is present', () => {
-    const out = formatWrappedResult({
-      status: 'error',
-      result: 'command failed',
-      error: 'exit_code_1',
+  it('maps shell errors into native `{ output, is_error: true }` shape', () => {
+    const out = formatWrappedResult(
+      { status: 'error', result: 'command failed', error: 'exit_code_1' },
+      'shell',
+    );
+    expect(out).toEqual({
+      output: 'Error (exit_code_1): command failed',
+      is_error: true,
     });
-    expect(out).toBe('Error (exit_code_1): command failed');
   });
 
-  it('prefixes with "Error:" when no error code is present', () => {
-    const out = formatWrappedResult({
+  it('maps file_read_lines errors into native `{ error }` shape', () => {
+    const out = formatWrappedResult(
+      { status: 'error', result: 'no such file', error: 'enoent' },
+      'file_read_lines',
+    );
+    expect(out).toEqual({ error: 'Error (enoent): no such file' });
+  });
+
+  it('maps file_edit_lines and file_write errors into native `{ error }` shape', () => {
+    const editOut = formatWrappedResult(
+      { status: 'error', result: 'range invalid' },
+      'file_edit_lines',
+    );
+    expect(editOut).toEqual({ error: 'Error: range invalid' });
+    const writeOut = formatWrappedResult(
+      { status: 'error', result: 'permission denied', error: 'eperm' },
+      'file_write',
+    );
+    expect(writeOut).toEqual({ error: 'Error (eperm): permission denied' });
+  });
+
+  it('returns an `Error (...): ...` string for web_* / generic tools on error', () => {
+    const web = formatWrappedResult(
+      { status: 'error', result: '404 not found', error: 'http_404' },
+      'web_read',
+    );
+    expect(web).toBe('Error (http_404): 404 not found');
+
+    const generic = formatWrappedResult({
       status: 'error',
       result: 'opaque failure',
     });
-    expect(out).toBe('Error: opaque failure');
+    expect(generic).toBe('Error: opaque failure');
   });
 
-  it('JSON-stringifies a non-string error body', () => {
-    const out = formatWrappedResult({
-      status: 'error',
-      result: { reason: 'bad' },
-      error: 'parse_failed',
-    });
+  it('JSON-stringifies a non-string error body inside the error message', () => {
+    const out = formatWrappedResult(
+      { status: 'error', result: { reason: 'bad' }, error: 'parse_failed' },
+      'web_read',
+    );
     expect(out).toBe('Error (parse_failed): {"reason":"bad"}');
   });
 });
@@ -170,7 +202,7 @@ describe('wrapToolWithSpecialist', () => {
     expect(call.runLabel).toBe('[shim] shell → Shell Wrapper');
   });
 
-  it('formats wrapper errors as "Error (code): body" without exposing reasoning', async () => {
+  it('maps wrapper errors to the native shell error shape without exposing reasoning', async () => {
     const base = makeBaseTool(async () => 'should not run');
     const deps = makeDeps();
     deps.specialistStore.get.mockReturnValue({ name: 'Shell Wrapper', kind: 'tool-wrapper' });
@@ -187,8 +219,26 @@ describe('wrapToolWithSpecialist', () => {
       { abortSignal: undefined },
     );
 
-    expect(result).toBe('Error (exit_code_1): permission denied');
-    expect(String(result)).not.toContain('should not leak');
+    expect(result).toEqual({
+      output: 'Error (exit_code_1): permission denied',
+      is_error: true,
+    });
+    expect(JSON.stringify(result)).not.toContain('should not leak');
+  });
+
+  it('preserves a structured shell success result so detectToolError sees native shape', async () => {
+    const base = makeBaseTool(async () => 'should not run');
+    const deps = makeDeps();
+    deps.specialistStore.get.mockReturnValue({ name: 'Shell Wrapper', kind: 'tool-wrapper' });
+    vi.mocked(dispatchToolWrapper).mockResolvedValue({
+      status: 'ok',
+      result: { output: 'file1\nfile2', is_error: false },
+    });
+
+    const wrapped = wrapToolWithSpecialist(base, 'shell', 'shell-wrapper', deps);
+    const result = await wrapped.execute({ command: 'ls' }, { abortSignal: undefined });
+
+    expect(result).toEqual({ output: 'file1\nfile2', is_error: false });
   });
 
   it('falls back to baseExecute when dispatch itself throws', async () => {

--- a/src/tools/wrap-with-specialist.ts
+++ b/src/tools/wrap-with-specialist.ts
@@ -1,0 +1,137 @@
+import { dispatchToolWrapper, type ToolWrapperDeps } from './tool-wrapper-run.js';
+import { debugLog } from '../logger.js';
+
+/**
+ * Builds the natural-language input handed to a wrapper specialist when the
+ * shim forwards a direct tool call. The wrapper sees the original tool name
+ * and its arguments verbatim so it can validate, transform, or pass through.
+ */
+export function buildShimInput(toolName: string, args: unknown): string {
+  let argsJson: string;
+  try {
+    argsJson = JSON.stringify(args, null, 2);
+  } catch {
+    argsJson = String(args);
+  }
+  return `The main agent issued a direct call to the \`${toolName}\` tool with these arguments:
+
+\`\`\`json
+${argsJson}
+\`\`\`
+
+Execute this tool call (or a safer/equivalent variant if you spot a clear problem) and return the structured JSON output. Keep your \`result\` field tight — the parent agent only sees \`result\` and any \`error\`, never your \`reasoning\` array.`;
+}
+
+/**
+ * Formats a wrapper's structured result into a string suitable for return
+ * from a regular tool's `execute` — i.e. what the main agent will see in its
+ * tool-result message. On success, returns the `result` field directly
+ * (stringifying non-string values). On error, prefixes with `Error:` so the
+ * model treats it like any other tool error.
+ */
+export function formatWrappedResult(wrapped: {
+  status: 'ok' | 'error';
+  result: unknown;
+  error?: string;
+}): string {
+  if (wrapped.status === 'ok') {
+    return typeof wrapped.result === 'string'
+      ? wrapped.result
+      : JSON.stringify(wrapped.result);
+  }
+  const body =
+    typeof wrapped.result === 'string' ? wrapped.result : JSON.stringify(wrapped.result);
+  return wrapped.error ? `Error (${wrapped.error}): ${body}` : `Error: ${body}`;
+}
+
+/**
+ * Wraps a base tool so that, when the corresponding wrapper specialist is
+ * registered, the model's call is transparently routed through
+ * {@link dispatchToolWrapper}. The model sees the same name, description, and
+ * schema — only the execution path changes.
+ *
+ * When the specialist is absent (or its kind is wrong, etc.), the shim falls
+ * through to the base tool's `execute` so behavior degrades gracefully.
+ *
+ * Only the wrapper's `result` (or `error` message) crosses back to the parent
+ * agent; the wrapper's `reasoning` array is logged separately and never enters
+ * the parent's context.
+ */
+export function wrapToolWithSpecialist<TArgs, TResult>(
+  baseTool: any,
+  toolName: string,
+  specialistId: string,
+  deps: ToolWrapperDeps,
+): any {
+  const baseExecute = baseTool.execute;
+  if (typeof baseExecute !== 'function') {
+    return baseTool;
+  }
+
+  return {
+    ...baseTool,
+    execute: async (args: TArgs, execOptions: any): Promise<TResult | string> => {
+      const specialist = deps.specialistStore.get(specialistId);
+      if (!specialist) {
+        return baseExecute(args, execOptions);
+      }
+      const kind = specialist.kind ?? 'persona';
+      if (kind !== 'tool-wrapper') {
+        // Not the right kind for shim routing — let the raw tool handle it.
+        return baseExecute(args, execOptions);
+      }
+
+      try {
+        const wrapped = await dispatchToolWrapper(
+          {
+            specialistId,
+            input: buildShimInput(toolName, args),
+            abortSignal: execOptions?.abortSignal,
+            runLabel: `[shim] ${toolName} → ${specialist.name}`,
+          },
+          deps,
+        );
+        return formatWrappedResult(wrapped) as TResult | string;
+      } catch (err) {
+        // Defensive: if the dispatch itself throws, fall back to the raw tool
+        // rather than killing the turn.
+        debugLog(
+          `wrap-with-specialist:${toolName}:dispatch-error`,
+          err instanceof Error ? err.message : String(err),
+        );
+        return baseExecute(args, execOptions);
+      }
+    },
+  };
+}
+
+/**
+ * The default routing table mapping low-level tool names to their wrapper
+ * specialist IDs. Used by the main agent to auto-route raw calls.
+ */
+export const DEFAULT_SHIM_ROUTING: Record<string, string> = {
+  shell: 'shell-wrapper',
+  web_read: 'web-wrapper',
+  file_read_lines: 'file-wrapper',
+  file_edit_lines: 'file-wrapper',
+};
+
+/**
+ * Applies {@link wrapToolWithSpecialist} to every tool name in the given
+ * routing table. Tools not present in the registry are skipped silently.
+ *
+ * Routing is only applied on the main agent — sub-agents, specialists, and
+ * the wrapper specialists themselves keep their raw tools to avoid recursion.
+ */
+export function applyShimRouting(
+  tools: Record<string, any>,
+  deps: ToolWrapperDeps,
+  routing: Record<string, string> = DEFAULT_SHIM_ROUTING,
+): Record<string, any> {
+  const out: Record<string, any> = { ...tools };
+  for (const [toolName, specialistId] of Object.entries(routing)) {
+    if (!out[toolName]) continue;
+    out[toolName] = wrapToolWithSpecialist(out[toolName], toolName, specialistId, deps);
+  }
+  return out;
+}

--- a/src/tools/wrap-with-specialist.ts
+++ b/src/tools/wrap-with-specialist.ts
@@ -35,12 +35,9 @@ export function formatWrappedResult(wrapped: {
   error?: string;
 }): string {
   if (wrapped.status === 'ok') {
-    return typeof wrapped.result === 'string'
-      ? wrapped.result
-      : JSON.stringify(wrapped.result);
+    return typeof wrapped.result === 'string' ? wrapped.result : JSON.stringify(wrapped.result);
   }
-  const body =
-    typeof wrapped.result === 'string' ? wrapped.result : JSON.stringify(wrapped.result);
+  const body = typeof wrapped.result === 'string' ? wrapped.result : JSON.stringify(wrapped.result);
   return wrapped.error ? `Error (${wrapped.error}): ${body}` : `Error: ${body}`;
 }
 

--- a/src/tools/wrap-with-specialist.ts
+++ b/src/tools/wrap-with-specialist.ts
@@ -23,22 +23,42 @@ Execute this tool call (or a safer/equivalent variant if you spot a clear proble
 }
 
 /**
- * Formats a wrapper's structured result into a string suitable for return
- * from a regular tool's `execute` — i.e. what the main agent will see in its
- * tool-result message. On success, returns the `result` field directly
- * (stringifying non-string values). On error, prefixes with `Error:` so the
- * model treats it like any other tool error.
+ * Formats a wrapper's structured result so the main agent — and the
+ * tool-augmentation layer's `detectToolError` — observe the *native* tool
+ * return shape, just as if the shim had been bypassed.
+ *
+ * - On `status: 'ok'`, returns `wrapped.result` as-is (no JSON-stringifying
+ *   structured payloads), so e.g. `shell`'s `{ output, is_error }` and
+ *   `file_*`'s `{ ... }` propagate unchanged.
+ * - On `status: 'error'`, maps the wrapper error to the *same shape* the
+ *   native tool would have produced for an error:
+ *     - `shell` → `{ output: 'Error (...): ...', is_error: true }`
+ *     - `file_read_lines` / `file_edit_lines` / `file_write` → `{ error: '...' }`
+ *     - everything else (web_*, MCP, generic) → `'Error (...): ...'` string
+ *   This keeps `detectToolError` and tool-profile learning working whether or
+ *   not the shim is active.
  */
-export function formatWrappedResult(wrapped: {
-  status: 'ok' | 'error';
-  result: unknown;
-  error?: string;
-}): string {
+export function formatWrappedResult(
+  wrapped: { status: 'ok' | 'error'; result: unknown; error?: string },
+  toolName?: string,
+): unknown {
   if (wrapped.status === 'ok') {
-    return typeof wrapped.result === 'string' ? wrapped.result : JSON.stringify(wrapped.result);
+    return wrapped.result;
   }
   const body = typeof wrapped.result === 'string' ? wrapped.result : JSON.stringify(wrapped.result);
-  return wrapped.error ? `Error (${wrapped.error}): ${body}` : `Error: ${body}`;
+  const message = wrapped.error ? `Error (${wrapped.error}): ${body}` : `Error: ${body}`;
+
+  if (toolName === 'shell') {
+    return { output: message, is_error: true };
+  }
+  if (
+    toolName === 'file_read_lines' ||
+    toolName === 'file_edit_lines' ||
+    toolName === 'file_write'
+  ) {
+    return { error: message };
+  }
+  return message;
 }
 
 /**
@@ -54,7 +74,7 @@ export function formatWrappedResult(wrapped: {
  * agent; the wrapper's `reasoning` array is logged separately and never enters
  * the parent's context.
  */
-export function wrapToolWithSpecialist<TArgs, TResult>(
+export function wrapToolWithSpecialist<TArgs>(
   baseTool: any,
   toolName: string,
   specialistId: string,
@@ -67,7 +87,7 @@ export function wrapToolWithSpecialist<TArgs, TResult>(
 
   return {
     ...baseTool,
-    execute: async (args: TArgs, execOptions: any): Promise<TResult | string> => {
+    execute: async (args: TArgs, execOptions: any): Promise<unknown> => {
       const specialist = deps.specialistStore.get(specialistId);
       if (!specialist) {
         return baseExecute(args, execOptions);
@@ -88,7 +108,7 @@ export function wrapToolWithSpecialist<TArgs, TResult>(
           },
           deps,
         );
-        return formatWrappedResult(wrapped) as TResult | string;
+        return formatWrappedResult(wrapped, toolName);
       } catch (err) {
         // Defensive: if the dispatch itself throws, fall back to the raw tool
         // rather than killing the turn.


### PR DESCRIPTION
## Summary

The main agent was bypassing `shell-wrapper` and calling `shell` directly with a ~16 KB heredoc, which truncated mid-string and aborted the turn with `InvalidToolArgumentsError: Unterminated string in JSON`. Three stacked gaps caused this: (1) no enforcement of wrapper routing, (2) no SDK repair on tool-arg parse failures, and (3) `tool_wrapper_run` leaked its full `reasoning` array into the parent agent's context.

This PR addresses all three.

- **Shim routing** (`src/tools/wrap-with-specialist.ts`, new): transparently routes `shell`, `web_read`, and `file_*_lines` through their wrapper specialists on the **main agent only**. Same tool name and schema — the model sees no difference, only `execute` changes. Falls through to the raw tool when the specialist is missing or has the wrong `kind`.
- **Tool-call repair hook** (`src/tool-call-repair.ts`, new): one-shot re-prompt on `InvalidToolArgumentsError` / `NoSuchToolError`. Special-cases JSON truncation with a hint to use `file_write` instead of inlining payloads into `shell` arguments. Wired into every `generateText` site — main agent, `specialist_run`, `subagent`, `tool_wrapper_run`'s child, and the cron runner.
- **Clean parent context**: extracted `dispatchToolWrapper` core from `tool_wrapper_run`; the new `renderWrapperParentView` strips the `reasoning` array and applies `capSubagentResult` before returning. Reasoning still lands in `logs/tool-wrappers.jsonl` for debugging — the parent agent never sees it.
- **Prompt audit**: rewrote `BASE_SYSTEM_PROMPT`'s "Temporary Scripts" section and added a new "Tool-Call Argument Size" section steering the model toward `file_write` + `shell` for payloads over ~500 bytes.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — all 2149 tests across 78 files pass, including:
  - `wrap-with-specialist.test.ts` (19 new tests): shim dispatch, fallthrough on missing/wrong-kind specialist, error formatting, abortSignal forwarding, schema preservation, `applyShimRouting` behavior
  - `tool-call-repair.test.ts` (9 new tests): truncation hint, unknown-tool hint, `toolChoice` selection, no-loop guarantee, schema inclusion, graceful failure
  - `tool-wrapper-run.test.ts` (+4 cases): `renderWrapperParentView` strips reasoning, omits absent error field, applies cap
- [ ] Manual repro: trigger the original 16 KB heredoc scenario — confirm the shim routes the call through `shell-wrapper` and that a residual truncation is recovered by the repair hook
- [ ] Inspect `~/.local/state/bernard/conversation-history.json` after a wrapper-routed call — confirm the parent context only sees `{status, result, error?}`, no `reasoning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)