### PR TITLE
Introduce AgentContext DI container (Phase A)

### DIFF
--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -10,6 +10,7 @@ import type { BernardConfig } from './config.js';
 import { MemoryStore } from './memory.js';
 import { printWarning, printInfo } from './output.js';
 import { getModelProfile } from './providers/index.js';
+import { assembleContext } from './framework/context.js';
 
 vi.mock('node:fs', () => ({
   mkdirSync: vi.fn(),
@@ -104,6 +105,24 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     anthropicApiKey: 'sk-test',
     ...overrides,
   };
+}
+
+function makeAgent(
+  config: BernardConfig,
+  toolOptions: any,
+  store: MemoryStore,
+  opts: { rag?: any; alertContext?: string; initialHistory?: any } = {},
+): Agent {
+  const ctx = assembleContext({
+    config,
+    toolOptions,
+    rag: opts.rag,
+    stores: { memory: store },
+  });
+  return new Agent(ctx, {
+    alertContext: opts.alertContext,
+    initialHistory: opts.initialHistory,
+  });
 }
 
 describe('buildSystemPrompt', () => {
@@ -581,7 +600,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
   });
@@ -591,7 +610,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
     const call = mockGenerateText.mock.calls[0][0];
     const userMsg = call.messages.find((m: any) => m.role === 'user');
@@ -610,7 +629,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'ok' }] },
       usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('hello');
     const call = mockGenerateText.mock.calls[0][0];
     const userMsg = call.messages.find((m: any) => m.role === 'user');
@@ -630,7 +649,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'ok' }] },
       usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('hello');
     const call = mockGenerateText.mock.calls[0][0];
     expect(call.system).toContain('CUSTOM_MODEL_SUFFIX_TOKEN');
@@ -642,7 +661,7 @@ describe('Agent', () => {
       response: { messages: [responseMsg] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
 
     // Second call should have both the user message, response, and new user message
@@ -657,14 +676,14 @@ describe('Agent', () => {
 
   it('clearHistory resets messages and clears scratch', () => {
     store.writeScratch('todo', 'test');
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     agent.clearHistory();
     expect(store.listScratch()).toEqual([]);
   });
 
   it('wraps errors with "Agent error:" prefix', async () => {
     mockGenerateText.mockRejectedValue(new Error('API rate limit'));
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await expect(agent.processInput('Hello')).rejects.toThrow('Agent error: API rate limit');
   });
 
@@ -673,7 +692,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
     const call = mockGenerateText.mock.calls[0][0];
     expect(call.tools).toHaveProperty('agent');
@@ -686,7 +705,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
     const call = mockGenerateText.mock.calls[0][0];
     expect(call.system).toContain('agent tool');
@@ -698,7 +717,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
     const call = mockGenerateText.mock.calls[0][0];
     expect(call.system).toContain('Success criteria');
@@ -710,7 +729,7 @@ describe('Agent', () => {
       response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
     const call = mockGenerateText.mock.calls[0][0];
     expect(call.system).toContain('web_read');
@@ -777,16 +796,7 @@ describe('Agent', () => {
       addFacts: vi.fn(),
     };
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     // Should not throw
     await agent.processInput('Hello');
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
@@ -806,16 +816,7 @@ describe('Agent', () => {
       addFacts: vi.fn(),
     };
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
     expect(compressHistory).toHaveBeenCalledWith(
@@ -840,7 +841,7 @@ describe('Agent', () => {
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
 
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
 
     expect(truncateToolResults).toHaveBeenCalledWith(responseMessages);
@@ -858,7 +859,7 @@ describe('Agent', () => {
       usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
     });
 
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
 
     expect(emergencyTruncate).toHaveBeenCalled();
@@ -882,7 +883,7 @@ describe('Agent', () => {
       };
     });
 
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
 
     // generateText called twice (first fails, second succeeds)
@@ -903,25 +904,10 @@ describe('Agent', () => {
       addFacts: vi.fn(),
     };
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
-    expect(createSubAgentTool).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.any(Object),
-      expect.any(Object),
-      undefined,
-      mockRagStore,
-    );
+    expect(createSubAgentTool).toHaveBeenCalledWith(expect.objectContaining({ rag: mockRagStore }));
   });
 
   it('retry uses 0.6 ratio when pre-flight already truncated', async () => {
@@ -945,7 +931,7 @@ describe('Agent', () => {
       };
     });
 
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await agent.processInput('Hello');
 
     // emergencyTruncate called twice: pre-flight + retry
@@ -961,7 +947,7 @@ describe('Agent', () => {
     vi.mocked(isTokenOverflowError).mockReturnValue(false);
 
     mockGenerateText.mockRejectedValue(new Error('API rate limit'));
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     await expect(agent.processInput('Hello')).rejects.toThrow('Agent error: API rate limit');
   });
 
@@ -980,16 +966,7 @@ describe('Agent', () => {
     mockExtractRecentUserTexts.mockReturnValueOnce(['what build tools do we use?']);
     mockBuildRAGQuery.mockReturnValueOnce('what build tools do we use?. how about compile?');
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('how about compile?');
 
     expect(mockRagStore.search).toHaveBeenCalledWith(
@@ -1012,16 +989,7 @@ describe('Agent', () => {
     mockExtractRecentUserTexts.mockReturnValueOnce([]);
     mockBuildRAGQuery.mockReturnValueOnce('Hello');
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
     expect(mockRagStore.search).toHaveBeenCalledWith('Hello');
@@ -1043,23 +1011,14 @@ describe('Agent', () => {
 
     mockApplyStickiness.mockReturnValueOnce(boostedResults);
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
     expect(mockApplyStickiness).toHaveBeenCalledWith(ragResults, expect.any(Set));
   });
 
   it('getLastRAGResults returns empty array before any input', () => {
-    const agent = new Agent(makeConfig(), toolOptions, store);
+    const agent = makeAgent(makeConfig(), toolOptions, store);
     expect(agent.getLastRAGResults()).toEqual([]);
   });
 
@@ -1081,16 +1040,7 @@ describe('Agent', () => {
 
     mockApplyStickiness.mockReturnValueOnce(ragResults);
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
     expect(agent.getLastRAGResults()).toEqual(ragResults);
@@ -1111,16 +1061,7 @@ describe('Agent', () => {
 
     mockApplyStickiness.mockReturnValueOnce(firstResults);
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
     expect(agent.getLastRAGResults()).toEqual(firstResults);
 
@@ -1143,16 +1084,7 @@ describe('Agent', () => {
       addFacts: vi.fn(),
     };
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
     expect(agent.getLastRAGResults()).toEqual([]);
   });
@@ -1172,16 +1104,7 @@ describe('Agent', () => {
 
     mockApplyStickiness.mockReturnValueOnce(ragResults);
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
     expect(agent.getLastRAGResults()).toEqual(ragResults);
 
@@ -1204,16 +1127,7 @@ describe('Agent', () => {
     mockExtractRecentToolContext.mockReturnValueOnce('shell(command=ls)');
     mockBuildRAGQuery.mockReturnValueOnce('Hello');
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
     expect(mockBuildRAGQuery).toHaveBeenCalledWith('Hello', [], {
@@ -1236,16 +1150,7 @@ describe('Agent', () => {
     mockExtractRecentToolContext.mockReturnValueOnce('');
     mockBuildRAGQuery.mockReturnValueOnce('Hello');
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
     await agent.processInput('Hello');
 
     expect(mockBuildRAGQuery).toHaveBeenCalledWith('Hello', [], {
@@ -1255,7 +1160,7 @@ describe('Agent', () => {
 
   describe('compactHistory', () => {
     it('returns compacted: false when history is too short to compress', async () => {
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       const result = await agent.compactHistory();
       expect(result.compacted).toBe(false);
     });
@@ -1277,7 +1182,7 @@ describe('Agent', () => {
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
 
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('Hello');
 
       callCount = 0;
@@ -1298,7 +1203,7 @@ describe('Agent', () => {
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
 
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('Hello');
       await agent.compactHistory();
 
@@ -1311,7 +1216,7 @@ describe('Agent', () => {
       vi.mocked(compressHistory).mockImplementation((history: any) => Promise.resolve(history));
       vi.mocked(estimateHistoryTokens).mockReturnValue(1000);
 
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       const result = await agent.compactHistory();
       expect(result.compacted).toBe(false);
       expect(result.tokensBefore).toBe(1000);
@@ -1322,7 +1227,7 @@ describe('Agent', () => {
       const { compressHistory } = await import('./context.js');
       vi.mocked(compressHistory).mockRejectedValueOnce(new Error('LLM down'));
 
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await expect(agent.compactHistory()).rejects.toThrow('LLM down');
     });
   });
@@ -1342,16 +1247,7 @@ describe('Agent', () => {
 
     mockApplyStickiness.mockImplementation((results: any) => results);
 
-    const agent = new Agent(
-      makeConfig(),
-      toolOptions,
-      store,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      mockRagStore as any,
-    );
+    const agent = makeAgent(makeConfig(), toolOptions, store, { rag: mockRagStore as any });
 
     // First call — builds up previousRAGFacts
     await agent.processInput('Hello');
@@ -1376,7 +1272,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Partial' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(config, toolOptions, store);
+      const agent = makeAgent(config, toolOptions, store);
       await agent.processInput('Do many things');
       const hit = agent.getStepLimitHit();
       expect(hit).not.toBeNull();
@@ -1391,7 +1287,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Done' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('Hello');
       expect(agent.getStepLimitHit()).toBeNull();
     });
@@ -1404,7 +1300,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Partial' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(config, toolOptions, store);
+      const agent = makeAgent(config, toolOptions, store);
 
       await agent.processInput('First');
       expect(agent.getStepLimitHit()!.hitCount).toBe(1);
@@ -1421,7 +1317,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Partial' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(config, toolOptions, store);
+      const agent = makeAgent(config, toolOptions, store);
 
       await agent.processInput('First');
       expect(agent.getStepLimitHit()).not.toBeNull();
@@ -1441,7 +1337,7 @@ describe('Agent', () => {
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
 
-      const agent = new Agent(config, toolOptions, store);
+      const agent = makeAgent(config, toolOptions, store);
       await agent.processInput('First');
       expect(agent.getStepLimitHit()).not.toBeNull();
 
@@ -1464,7 +1360,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(makeConfig({ reactMode: false }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ reactMode: false }), toolOptions, store);
       await agent.processInput('Hello');
       const call = mockGenerateText.mock.calls[0][0];
       expect(call.tools).not.toHaveProperty('plan');
@@ -1477,7 +1373,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(makeConfig({ reactMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ reactMode: true }), toolOptions, store);
       await agent.processInput('Hello');
       const call = mockGenerateText.mock.calls[0][0];
       expect(call.tools).toHaveProperty('plan');
@@ -1490,7 +1386,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(makeConfig({ reactMode: true, maxSteps: 10 }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ reactMode: true, maxSteps: 10 }), toolOptions, store);
       await agent.processInput('Hello');
       const call = mockGenerateText.mock.calls[0][0];
       expect(call.maxSteps).toBe(30);
@@ -1501,7 +1397,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(makeConfig({ reactMode: false, maxSteps: 10 }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ reactMode: false, maxSteps: 10 }), toolOptions, store);
       await agent.processInput('Hello');
       const call = mockGenerateText.mock.calls[0][0];
       expect(call.maxSteps).toBe(10);
@@ -1516,7 +1412,7 @@ describe('Agent', () => {
       };
 
       it('re-prompts once when plan still has unresolved steps, then exits when resolved', async () => {
-        const agent = new Agent(makeConfig({ reactMode: true }), toolOptions, store);
+        const agent = makeAgent(makeConfig({ reactMode: true }), toolOptions, store);
         const planStore = (agent as unknown as { planStore: any }).planStore;
         let call = 0;
         mockGenerateText.mockImplementation(async () => {
@@ -1540,7 +1436,7 @@ describe('Agent', () => {
       });
 
       it('does not re-prompt when plan is already complete', async () => {
-        const agent = new Agent(makeConfig({ reactMode: true }), toolOptions, store);
+        const agent = makeAgent(makeConfig({ reactMode: true }), toolOptions, store);
         const planStore = (agent as unknown as { planStore: any }).planStore;
         mockGenerateText.mockImplementation(async () => {
           if (planStore.view().length === 0) {
@@ -1554,14 +1450,14 @@ describe('Agent', () => {
       });
 
       it('does not re-prompt when no plan was created', async () => {
-        const agent = new Agent(makeConfig({ reactMode: true }), toolOptions, store);
+        const agent = makeAgent(makeConfig({ reactMode: true }), toolOptions, store);
         mockGenerateText.mockResolvedValue(baseResult);
         await agent.processInput('trivial');
         expect(mockGenerateText).toHaveBeenCalledTimes(1);
       });
 
       it('stops re-prompting when abort fires mid-loop', async () => {
-        const agent = new Agent(makeConfig({ reactMode: true }), toolOptions, store);
+        const agent = makeAgent(makeConfig({ reactMode: true }), toolOptions, store);
         const planStore = (agent as unknown as { planStore: any }).planStore;
         let call = 0;
         mockGenerateText.mockImplementation(async () => {
@@ -1577,7 +1473,7 @@ describe('Agent', () => {
       });
 
       it('exhausts retries, auto-cancels remaining steps, and emits info when plan never resolves', async () => {
-        const agent = new Agent(makeConfig({ reactMode: true }), toolOptions, store);
+        const agent = makeAgent(makeConfig({ reactMode: true }), toolOptions, store);
         const planStore = (agent as unknown as { planStore: any }).planStore;
         mockGenerateText.mockImplementation(async () => {
           if (planStore.view().length === 0)
@@ -1595,7 +1491,7 @@ describe('Agent', () => {
       });
 
       it('does not re-prompt when reactMode is false even with unresolved steps', async () => {
-        const agent = new Agent(makeConfig({ reactMode: false }), toolOptions, store);
+        const agent = makeAgent(makeConfig({ reactMode: false }), toolOptions, store);
         const planStore = (agent as unknown as { planStore: any }).planStore;
         mockGenerateText.mockImplementation(async () => {
           if (planStore.view().length === 0)
@@ -1620,7 +1516,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'I see an image.' }] },
         usage: { promptTokens: 200, completionTokens: 50, totalTokens: 250 },
       });
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('Describe this', [mockImageAttachment]);
 
       const call = mockGenerateText.mock.calls[0][0];
@@ -1638,7 +1534,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Done' }] },
         usage: { promptTokens: 200, completionTokens: 50, totalTokens: 250 },
       });
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('What is this?', [mockImageAttachment]);
 
       const call = mockGenerateText.mock.calls[0][0];
@@ -1654,7 +1550,7 @@ describe('Agent', () => {
         response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
         usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
       });
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('Hello');
 
       const call = mockGenerateText.mock.calls[0][0];
@@ -1672,7 +1568,7 @@ describe('Agent', () => {
         mimeType: 'image/jpeg',
         data: Buffer.from('fake-jpg-data'),
       };
-      const agent = new Agent(makeConfig(), toolOptions, store);
+      const agent = makeAgent(makeConfig(), toolOptions, store);
       await agent.processInput('Compare these', [mockImageAttachment, secondImage]);
 
       const call = mockGenerateText.mock.calls[0][0];

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -58,7 +58,9 @@ import { createThinkTool } from './tools/think.js';
 import { createAskUserTool } from './tools/ask-user.js';
 import { createEvaluateTool } from './tools/evaluate.js';
 import { applyShimRouting } from './tools/wrap-with-specialist.js';
+import { ctxToToolWrapperDeps } from './tools/tool-wrapper-run.js';
 import { makeRepairHook } from './tool-call-repair.js';
+import type { AgentContext } from './framework/context.js';
 
 /**
  * Directs the model to publish brief reasoning via the `think` tool so the
@@ -399,35 +401,25 @@ export class Agent {
   private lastStepLimitHit: boolean = false;
   private planStore: PlanStore = new PlanStore();
 
-  constructor(
-    config: BernardConfig,
-    toolOptions: ToolOptions,
-    memoryStore: MemoryStore,
-    mcpTools?: Record<string, any>,
-    mcpServerNames?: string[],
-    alertContext?: string,
-    initialHistory?: CoreMessage[],
-    ragStore?: RAGStore,
-    routineStore?: RoutineStore,
-    specialistStore?: SpecialistStore,
-    candidateStore?: CandidateStoreReader,
-    correctionStore?: CorrectionCandidateStore,
-  ) {
-    this.config = config;
-    this.toolOptions = toolOptions;
-    this.memoryStore = memoryStore;
-    this.mcpTools = mcpTools;
-    this.mcpServerNames = mcpServerNames;
-    this.alertContext = alertContext;
-    this.ragStore = ragStore;
-    this.routineStore = routineStore ?? new RoutineStore();
-    this.specialistStore = specialistStore ?? new SpecialistStore();
-    this.candidateStore = candidateStore;
-    this.correctionStore = correctionStore ?? new CorrectionCandidateStore();
-    this.toolProfileStore = new ToolProfileStore();
-    if (initialHistory) {
-      this.history = [...initialHistory];
-      this.lastPromptTokens = Math.ceil(JSON.stringify(initialHistory).length / 4);
+  private ctx: AgentContext;
+
+  constructor(ctx: AgentContext, opts?: { alertContext?: string; initialHistory?: CoreMessage[] }) {
+    this.ctx = ctx;
+    this.config = ctx.config;
+    this.toolOptions = ctx.toolOptions;
+    this.memoryStore = ctx.stores.memory;
+    this.mcpTools = ctx.mcp.tools;
+    this.mcpServerNames = ctx.mcp.serverNames;
+    this.alertContext = opts?.alertContext;
+    this.ragStore = ctx.rag;
+    this.routineStore = ctx.stores.routines;
+    this.specialistStore = ctx.stores.specialists;
+    this.candidateStore = ctx.stores.candidates;
+    this.correctionStore = ctx.stores.correction;
+    this.toolProfileStore = ctx.stores.toolProfiles;
+    if (opts?.initialHistory) {
+      this.history = [...opts.initialHistory];
+      this.lastPromptTokens = Math.ceil(JSON.stringify(opts.initialHistory).length / 4);
     }
   }
 
@@ -623,40 +615,10 @@ export class Agent {
       );
       const tools = {
         ...baseTools,
-        agent: createSubAgentTool(
-          this.config,
-          this.toolOptions,
-          this.memoryStore,
-          this.mcpTools,
-          this.ragStore,
-        ),
-        task: createTaskTool(
-          this.config,
-          this.toolOptions,
-          this.memoryStore,
-          this.mcpTools,
-          this.ragStore,
-          this.routineStore,
-        ),
-        specialist_run: createSpecialistRunTool(
-          this.config,
-          this.toolOptions,
-          this.memoryStore,
-          this.specialistStore,
-          this.mcpTools,
-          this.ragStore,
-        ),
-        tool_wrapper_run: createToolWrapperRunTool(
-          this.config,
-          this.toolOptions,
-          this.memoryStore,
-          this.specialistStore,
-          this.correctionStore,
-          this.mcpTools,
-          this.ragStore,
-          this.routineStore,
-          this.candidateStore,
-        ),
+        agent: createSubAgentTool(this.ctx),
+        task: createTaskTool(this.ctx),
+        specialist_run: createSpecialistRunTool(this.ctx),
+        tool_wrapper_run: createToolWrapperRunTool(this.ctx),
         think: createThinkTool(),
         ask_user: createAskUserTool(this.toolOptions.askUser),
         ...(this.config.reactMode
@@ -671,17 +633,7 @@ export class Agent {
       // wrapper specialists transparently, then wrap every tool's execute to
       // observe errors and record profiles. Shim routing happens only at the
       // main-agent level — sub-agents and specialists keep raw tools.
-      const shimmedTools = applyShimRouting(tools, {
-        config: this.config,
-        options: this.toolOptions,
-        memoryStore: this.memoryStore,
-        specialistStore: this.specialistStore,
-        correctionStore: this.correctionStore,
-        mcpTools: this.mcpTools,
-        ragStore: this.ragStore,
-        routineStore: this.routineStore,
-        candidateStore: this.candidateStore,
-      });
+      const shimmedTools = applyShimRouting(tools, ctxToToolWrapperDeps(this.ctx));
       const augmentedTools = augmentTools(shimmedTools, this.toolProfileStore);
 
       // Coordinator (ReAct) mode triples the step budget for the main agent,

--- a/src/correction.test.ts
+++ b/src/correction.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runCorrectionAgent, extractOutcome } from './correction.js';
 import type { RunCorrectionDeps } from './correction.js';
 import type { CorrectionCandidate } from './correction-candidates.js';
+import type { AgentContext } from './framework/context.js';
 
 vi.mock('./logger.js', () => ({ debugLog: vi.fn() }));
 vi.mock('./output.js', () => ({ printInfo: vi.fn() }));
@@ -12,14 +13,35 @@ vi.mock('./output.js', () => ({ printInfo: vi.fn() }));
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createMockDeps(overrides?: Partial<RunCorrectionDeps>): RunCorrectionDeps {
-  return {
+type MockDeps = RunCorrectionDeps & {
+  specialistStore: { get: ReturnType<typeof vi.fn> };
+  correctionStore: { listPending: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+};
+
+function createMockDeps(overrides?: Partial<RunCorrectionDeps>): MockDeps {
+  const specialistStore = { get: vi.fn() };
+  const correctionStore = {
+    listPending: vi.fn(() => [] as CorrectionCandidate[]),
+    update: vi.fn(),
+  };
+  const ctx: AgentContext = {
     config: {} as any,
     toolOptions: {} as any,
-    memoryStore: {} as any,
-    specialistStore: { get: vi.fn() } as any,
-    correctionStore: { listPending: vi.fn(() => []), update: vi.fn() } as any,
+    stores: {
+      memory: {} as any,
+      specialists: specialistStore as any,
+      correction: correctionStore as any,
+      routines: {} as any,
+      candidates: {} as any,
+      toolProfiles: {} as any,
+    },
+    mcp: { tools: {}, serverNames: [] },
+  };
+  return {
+    ctx,
     ...overrides,
+    specialistStore,
+    correctionStore,
   };
 }
 
@@ -116,7 +138,7 @@ describe('extractOutcome', () => {
 // ---------------------------------------------------------------------------
 
 describe('runCorrectionAgent', () => {
-  let deps: RunCorrectionDeps;
+  let deps: MockDeps;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/correction.ts
+++ b/src/correction.ts
@@ -1,12 +1,6 @@
-import type { BernardConfig } from './config.js';
-import type { MemoryStore } from './memory.js';
-import type { RAGStore } from './rag.js';
-import type { RoutineStore } from './routines.js';
-import type { ToolOptions } from './tools/types.js';
-import type { CandidateStoreReader } from './specialist-candidates.js';
-import { SpecialistStore } from './specialists.js';
-import { CorrectionCandidateStore, type CorrectionCandidate } from './correction-candidates.js';
+import { type CorrectionCandidate } from './correction-candidates.js';
 import { createToolWrapperRunTool } from './tools/tool-wrapper-run.js';
+import type { AgentContext } from './framework/context.js';
 import { parseStructuredOutput, WrapperResultSchema } from './structured-output.js';
 import { z } from 'zod';
 import { debugLog } from './logger.js';
@@ -29,16 +23,8 @@ const CorrectionOutcomeSchema = z.object({
 type CorrectionOutcome = z.infer<typeof CorrectionOutcomeSchema>;
 
 export interface RunCorrectionDeps {
-  config: BernardConfig;
-  toolOptions: ToolOptions;
-  memoryStore: MemoryStore;
-  specialistStore: SpecialistStore;
-  correctionStore: CorrectionCandidateStore;
-  ragStore?: RAGStore;
-  routineStore?: RoutineStore;
-  candidateStore?: CandidateStoreReader;
-  mcpTools?: Record<string, any>;
-  /** Optional pre-built tool for testing. Falls back to createToolWrapperRunTool(...) when absent. */
+  ctx: AgentContext;
+  /** Optional pre-built tool for testing. Falls back to createToolWrapperRunTool(ctx) when absent. */
   toolWrapperRun?: { execute: (args: any, opts: any) => Promise<any> };
 }
 
@@ -69,29 +55,18 @@ export async function runCorrectionAgent(
   applied: number;
   skipped: number;
 }> {
-  const pending = prefetchedPending ?? deps.correctionStore.listPending();
+  const correctionStore = deps.ctx.stores.correction;
+  const pending = prefetchedPending ?? correctionStore.listPending();
   if (pending.length === 0) return { processed: 0, applied: 0, skipped: 0 };
 
-  const correctionSpecialist = deps.specialistStore.get(CORRECTION_SPECIALIST_ID);
+  const correctionSpecialist = deps.ctx.stores.specialists.get(CORRECTION_SPECIALIST_ID);
   if (!correctionSpecialist) {
     debugLog('correction:skip', `No specialist named "${CORRECTION_SPECIALIST_ID}" — skipping.`);
     return { processed: 0, applied: 0, skipped: pending.length };
   }
 
   const batch = pending.slice(0, MAX_CANDIDATES_PER_RUN);
-  const toolWrapperRun =
-    deps.toolWrapperRun ??
-    createToolWrapperRunTool(
-      deps.config,
-      deps.toolOptions,
-      deps.memoryStore,
-      deps.specialistStore,
-      deps.correctionStore,
-      deps.mcpTools,
-      deps.ragStore,
-      deps.routineStore,
-      deps.candidateStore,
-    );
+  const toolWrapperRun = deps.toolWrapperRun ?? createToolWrapperRunTool(deps.ctx);
 
   let applied = 0;
   let processed = 0;
@@ -116,19 +91,19 @@ export async function runCorrectionAgent(
       const outcome = extractOutcome(text);
       if (outcome && outcome.applied) {
         applied++;
-        deps.correctionStore.update(candidate.id, {
+        correctionStore.update(candidate.id, {
           status: 'applied',
           validated: true,
           notes: outcome.notes,
         });
       } else if (outcome && outcome.validated) {
-        deps.correctionStore.update(candidate.id, {
+        correctionStore.update(candidate.id, {
           status: 'rejected',
           validated: true,
           notes: outcome.notes ?? 'Validated but not applied (agent declined commit).',
         });
       } else {
-        deps.correctionStore.update(candidate.id, {
+        correctionStore.update(candidate.id, {
           status: 'invalid',
           validated: false,
           notes: outcome?.notes ?? 'Correction agent could not validate a fix.',
@@ -137,7 +112,7 @@ export async function runCorrectionAgent(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       debugLog('correction:error', { candidateId: candidate.id, message });
-      deps.correctionStore.update(candidate.id, {
+      correctionStore.update(candidate.id, {
         status: 'invalid',
         validated: false,
         notes: `Correction agent errored: ${message}`,

--- a/src/critic.test.ts
+++ b/src/critic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildSystemPrompt, Agent } from './agent.js';
 import type { BernardConfig } from './config.js';
 import { MemoryStore } from './memory.js';
+import { assembleContext } from './framework/context.js';
 
 vi.mock('node:fs', () => ({
   mkdirSync: vi.fn(),
@@ -113,6 +114,15 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
 
 const toolOptions = { shellTimeout: 30000, confirmDangerous: async () => true };
 
+function makeAgent(config: BernardConfig, opts: any, store: MemoryStore): Agent {
+  const ctx = assembleContext({
+    config,
+    toolOptions: opts,
+    stores: { memory: store },
+  });
+  return new Agent(ctx);
+}
+
 describe('critic mode', () => {
   let store: MemoryStore;
 
@@ -163,7 +173,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Create a file');
 
       // Should have been called twice: main + critic
@@ -189,7 +199,7 @@ describe('critic mode', () => {
         usage: { promptTokens: 100, completionTokens: 50 },
       });
 
-      const agent = new Agent(makeConfig({ criticMode: false }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: false }), toolOptions, store);
       await agent.processInput('List files');
 
       expect(mockGenerateText).toHaveBeenCalledTimes(1);
@@ -203,7 +213,7 @@ describe('critic mode', () => {
         usage: { promptTokens: 100, completionTokens: 50 },
       });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('What is the meaning of life?');
 
       // Only one call — no critic needed
@@ -225,7 +235,7 @@ describe('critic mode', () => {
         })
         .mockRejectedValueOnce(new Error('API error'));
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       // Should not throw — critic failure is non-fatal
       await expect(agent.processInput('Say hi')).resolves.toBeUndefined();
     });
@@ -262,7 +272,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Do multi-step work');
 
       // Verify critic received all 3 tool calls in order
@@ -317,7 +327,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       // Should not throw — the tr?.result guard handles undefined
       await expect(agent.processInput('Run commands')).resolves.toBeUndefined();
 
@@ -350,7 +360,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Generate long output');
 
       const criticCall = mockGenerateText.mock.calls[1][0];
@@ -385,7 +395,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Read big file');
 
       const criticCall = mockGenerateText.mock.calls[1][0];
@@ -416,7 +426,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Read big file');
 
       const criticCall = mockGenerateText.mock.calls[1][0];
@@ -451,7 +461,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Run many commands');
 
       const criticCall = mockGenerateText.mock.calls[1][0];
@@ -485,7 +495,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Run long command');
 
       const criticCall = mockGenerateText.mock.calls[1][0];
@@ -519,7 +529,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Do work');
 
       const criticCall = mockGenerateText.mock.calls[1][0];
@@ -555,7 +565,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('list files');
 
       expect(mockVerdict).toHaveBeenCalledWith('VERDICT: PASS\nAll good.', undefined);
@@ -606,7 +616,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Create a file');
 
       // 4 calls: main + critic(WARN) + retry + critic(PASS)
@@ -650,7 +660,7 @@ describe('critic mode', () => {
         // 6. Critic FAIL (at max retries, loop exits)
         .mockResolvedValueOnce(makeCriticFail());
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Do something');
 
       // 6 calls: main + critic + retry + critic + retry + critic
@@ -678,7 +688,7 @@ describe('critic mode', () => {
         // 2. Critic throws error
         .mockRejectedValueOnce(new Error('API error'));
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await expect(agent.processInput('Say hi')).resolves.toBeUndefined();
 
       // Only 2 calls: main + critic (errored)
@@ -709,7 +719,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 50, completionTokens: 20 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('List files');
 
       // 2 calls: main + critic(PASS)
@@ -746,7 +756,7 @@ describe('critic mode', () => {
           usage: { promptTokens: 120, completionTokens: 40 },
         });
 
-      const agent = new Agent(makeConfig({ criticMode: true }), toolOptions, store);
+      const agent = makeAgent(makeConfig({ criticMode: true }), toolOptions, store);
       await agent.processInput('Do something');
 
       // 3 calls: main + critic(WARN) + retry(no tools, loop exits)

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -4,7 +4,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { loadConfig } from '../config.js';
-import { MemoryStore } from '../memory.js';
+import { assembleContext } from '../framework/context.js';
 import { RAGStore } from '../rag.js';
 import { buildMemoryContext } from '../memory-context.js';
 import { debugLog } from '../logger.js';
@@ -89,7 +89,6 @@ export interface RunJobResult {
  */
 export async function runJob(job: CronJob, log: (msg: string) => void): Promise<RunJobResult> {
   const config = loadConfig();
-  const memoryStore = new MemoryStore();
   const store = new CronStore();
 
   // Conditionally create RAGStore for memory context enrichment
@@ -118,6 +117,18 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
     const message = err instanceof Error ? err.message : String(err);
     log(`MCP initialization failed, continuing without MCP tools: ${message}`);
   }
+
+  const ctx = assembleContext({
+    config,
+    toolOptions: {
+      shellTimeout: config.shellTimeout,
+      confirmDangerous: async () => false, // Auto-deny in daemon mode
+      // askUser intentionally omitted — no interactive user; the ask_user tool returns {unavailable}.
+    },
+    mcp: { tools: mcpTools, serverNames },
+    rag: ragStore,
+  });
+  const memoryStore = ctx.stores.memory;
 
   const logStore = new CronLogStore();
   const runId = crypto.randomUUID();

--- a/src/framework/__tests__/context.test.ts
+++ b/src/framework/__tests__/context.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import { assembleContext } from '../context.js';
+import type { BernardConfig } from '../../config.js';
+import type { ToolOptions } from '../../tools/types.js';
+
+// Tests construct stores against the real filesystem; isolate via BERNARD_HOME.
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+function makeConfig(): BernardConfig {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5-20250929',
+    maxTokens: 4096,
+    shellTimeout: 30000,
+    tokenWindow: 0,
+    maxSteps: 25,
+    ragEnabled: false,
+    theme: 'bernard',
+    criticMode: false,
+    reactMode: false,
+    autoCreateSpecialists: false,
+    autoCreateThreshold: 0.8,
+    anthropicApiKey: 'sk-test',
+  } as BernardConfig;
+}
+
+function makeToolOptions(): ToolOptions {
+  return {
+    shellTimeout: 30000,
+    confirmDangerous: async () => false,
+  };
+}
+
+describe('assembleContext', () => {
+  it('carries config and toolOptions through', () => {
+    const config = makeConfig();
+    const toolOptions = makeToolOptions();
+    const ctx = assembleContext({ config, toolOptions });
+    expect(ctx.config).toBe(config);
+    expect(ctx.toolOptions).toBe(toolOptions);
+  });
+
+  it('defaults mcp to empty registry + serverNames', () => {
+    const ctx = assembleContext({ config: makeConfig(), toolOptions: makeToolOptions() });
+    expect(ctx.mcp.tools).toEqual({});
+    expect(ctx.mcp.serverNames).toEqual([]);
+  });
+
+  it('honors provided mcp registry', () => {
+    const tools = { foo: { description: 'mock' } };
+    const ctx = assembleContext({
+      config: makeConfig(),
+      toolOptions: makeToolOptions(),
+      mcp: { tools, serverNames: ['a', 'b'] },
+    });
+    expect(ctx.mcp.tools).toBe(tools);
+    expect(ctx.mcp.serverNames).toEqual(['a', 'b']);
+  });
+
+  it('honors store overrides for testing', () => {
+    const fakeMemory = { sentinel: 'memory' } as any;
+    const fakeSpecialists = { sentinel: 'specialists' } as any;
+    const ctx = assembleContext({
+      config: makeConfig(),
+      toolOptions: makeToolOptions(),
+      stores: {
+        memory: fakeMemory,
+        specialists: fakeSpecialists,
+      },
+    });
+    expect(ctx.stores.memory).toBe(fakeMemory);
+    expect(ctx.stores.specialists).toBe(fakeSpecialists);
+    // Non-overridden stores still get defaults
+    expect(ctx.stores.routines).toBeDefined();
+    expect(ctx.stores.candidates).toBeDefined();
+    expect(ctx.stores.correction).toBeDefined();
+    expect(ctx.stores.toolProfiles).toBeDefined();
+  });
+
+  it('defaults all stores when none are provided', () => {
+    const ctx = assembleContext({ config: makeConfig(), toolOptions: makeToolOptions() });
+    expect(ctx.stores.memory).toBeDefined();
+    expect(ctx.stores.routines).toBeDefined();
+    expect(ctx.stores.specialists).toBeDefined();
+    expect(ctx.stores.candidates).toBeDefined();
+    expect(ctx.stores.correction).toBeDefined();
+    expect(ctx.stores.toolProfiles).toBeDefined();
+  });
+
+  it('passes rag through unchanged', () => {
+    const fakeRag = { sentinel: 'rag' } as any;
+    const ctx = assembleContext({
+      config: makeConfig(),
+      toolOptions: makeToolOptions(),
+      rag: fakeRag,
+    });
+    expect(ctx.rag).toBe(fakeRag);
+  });
+});

--- a/src/framework/context.ts
+++ b/src/framework/context.ts
@@ -1,0 +1,61 @@
+import type { BernardConfig } from '../config.js';
+import { MemoryStore } from '../memory.js';
+import { RoutineStore } from '../routines.js';
+import { SpecialistStore } from '../specialists.js';
+import { CandidateStore, type CandidateStoreReader } from '../specialist-candidates.js';
+import { CorrectionCandidateStore } from '../correction-candidates.js';
+import { ToolProfileStore } from '../tool-profiles.js';
+import type { RAGStore } from '../rag.js';
+import type { ToolOptions } from '../tools/types.js';
+
+export interface AgentContextStores {
+  memory: MemoryStore;
+  routines: RoutineStore;
+  specialists: SpecialistStore;
+  candidates: CandidateStoreReader;
+  correction: CorrectionCandidateStore;
+  toolProfiles: ToolProfileStore;
+}
+
+export interface AgentContextMCP {
+  tools: Record<string, any>;
+  serverNames: string[];
+}
+
+export interface AgentContext {
+  config: BernardConfig;
+  stores: AgentContextStores;
+  mcp: AgentContextMCP;
+  rag?: RAGStore;
+  toolOptions: ToolOptions;
+}
+
+export interface AssembleContextInput {
+  config: BernardConfig;
+  toolOptions: ToolOptions;
+  mcp?: Partial<AgentContextMCP>;
+  rag?: RAGStore;
+  stores?: Partial<AgentContextStores>;
+}
+
+export function assembleContext(input: AssembleContextInput): AgentContext {
+  const overrides = input.stores ?? {};
+  const stores: AgentContextStores = {
+    memory: overrides.memory ?? new MemoryStore(),
+    routines: overrides.routines ?? new RoutineStore(),
+    specialists: overrides.specialists ?? new SpecialistStore(),
+    candidates: overrides.candidates ?? new CandidateStore(),
+    correction: overrides.correction ?? new CorrectionCandidateStore(),
+    toolProfiles: overrides.toolProfiles ?? new ToolProfileStore(),
+  };
+  return {
+    config: input.config,
+    stores,
+    mcp: {
+      tools: input.mcp?.tools ?? {},
+      serverNames: input.mcp?.serverNames ?? [],
+    },
+    rag: input.rag,
+    toolOptions: input.toolOptions,
+  };
+}

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -88,6 +88,7 @@ import { RoutineStore } from './routines.js';
 import { SpecialistStore, getBuiltinSpecialistIds } from './specialists.js';
 import { runCorrectionAgent } from './correction.js';
 import { CandidateStore } from './specialist-candidates.js';
+import { assembleContext } from './framework/context.js';
 import {
   bootstrapPendingCandidates,
   buildCandidateContextBlock,
@@ -952,19 +953,19 @@ export async function startRepl(
     alertContext = alertContext ? alertContext + '\n\n' + contextBlock : contextBlock;
   }
 
-  const agent = new Agent(
+  const agentCtx = assembleContext({
     config,
     toolOptions,
-    memoryStore,
-    mcpTools,
-    mcpServerNames,
-    alertContext,
-    initialHistory,
-    ragStore,
-    routineStore,
-    specialistStore,
-    candidateStore,
-  );
+    mcp: { tools: mcpTools, serverNames: mcpServerNames },
+    rag: ragStore,
+    stores: {
+      memory: memoryStore,
+      routines: routineStore,
+      specialists: specialistStore,
+      candidates: candidateStore,
+    },
+  });
+  const agent = new Agent(agentCtx, { alertContext, initialHistory });
 
   let cleanedUp = false;
   const cleanup = async () => {
@@ -1015,20 +1016,7 @@ export async function startRepl(
         const pending = correctionStore.listPending();
         if (pending.length > 0) {
           printInfo(`Reviewing ${pending.length} tool-wrapper failure(s) for learning...`);
-          const result = await runCorrectionAgent(
-            {
-              config,
-              toolOptions,
-              memoryStore,
-              specialistStore: agent.getSpecialistStore(),
-              correctionStore,
-              ragStore,
-              routineStore,
-              candidateStore,
-              mcpTools,
-            },
-            pending,
-          );
+          const result = await runCorrectionAgent({ ctx: agentCtx }, pending);
           if (result.applied > 0) {
             printInfo(
               `  Learned from ${result.applied}/${result.processed} failure(s); examples updated.`,

--- a/src/tools/specialist-run.test.ts
+++ b/src/tools/specialist-run.test.ts
@@ -71,8 +71,24 @@ import { createSpecialistRunTool } from './specialist-run.js';
 import { _resetPool } from './agent-pool.js';
 import { MemoryStore } from '../memory.js';
 import { SpecialistStore } from '../specialists.js';
+import { assembleContext } from '../framework/context.js';
 
 const { getModelForConfig: mockGetModel } = await import('../providers/index.js');
+
+function makeCtx(
+  config: BernardConfig,
+  toolOptions: ToolOptions,
+  memoryStore: MemoryStore,
+  specialistStore: SpecialistStore,
+  opts: { rag?: any } = {},
+) {
+  return assembleContext({
+    config,
+    toolOptions,
+    rag: opts.rag,
+    stores: { memory: memoryStore, specialists: specialistStore },
+  });
+}
 
 function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
   return {
@@ -121,14 +137,18 @@ describe('specialist-run tool', () => {
   });
 
   it('has correct description and execute function', () => {
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     expect(tool).toBeDefined();
     expect(tool.description).toContain('specialist');
     expect(tool.execute).toBeDefined();
   });
 
   it('returns error when specialist not found', async () => {
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     const result = await tool.execute!(
       { specialistId: 'nonexistent', task: 'Do something' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -143,7 +163,9 @@ describe('specialist-run tool', () => {
     // Mock the specialist store to return our specialist
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'Triage these emails' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -163,7 +185,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       {
         specialistId: 'email-triage',
@@ -181,7 +205,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockResolvedValue({ text: 'Email triage complete: 3 urgent, 5 normal' });
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     const result = await tool.execute!(
       { specialistId: 'email-triage', task: 'Triage emails' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -194,7 +220,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockRejectedValue(new Error('API rate limit'));
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     const result = await tool.execute!(
       { specialistId: 'email-triage', task: 'Triage emails' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -213,7 +241,9 @@ describe('specialist-run tool', () => {
         }),
     );
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     const execOptions = { toolCallId: '1', messages: [], abortSignal: undefined as any };
 
     // Start 4 concurrent agents
@@ -238,7 +268,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'Triage emails' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -251,7 +283,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockRejectedValue(new Error('fail'));
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -264,7 +298,9 @@ describe('specialist-run tool', () => {
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
     const controller = new AbortController();
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: controller.signal },
@@ -278,7 +314,9 @@ describe('specialist-run tool', () => {
     const noGuidelinesSpec = { ...mockSpecialist, guidelines: [] };
     vi.spyOn(specialistStore, 'get').mockReturnValue(noGuidelinesSpec);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -301,12 +339,9 @@ describe('specialist-run tool', () => {
     };
 
     const tool = createSpecialistRunTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      specialistStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore, {
+        rag: mockRagStore as any,
+      }),
     );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'check preferences' },
@@ -326,12 +361,9 @@ describe('specialist-run tool', () => {
     };
 
     const tool = createSpecialistRunTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      specialistStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore, {
+        rag: mockRagStore as any,
+      }),
     );
     const result = await tool.execute!(
       { specialistId: 'email-triage', task: 'test' },
@@ -349,12 +381,9 @@ describe('specialist-run tool', () => {
     };
 
     const tool = createSpecialistRunTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      specialistStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore, {
+        rag: mockRagStore as any,
+      }),
     );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'triage urgent emails' },
@@ -368,7 +397,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -381,7 +412,9 @@ describe('specialist-run tool', () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
     vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-    const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+    const tool = createSpecialistRunTool(
+      makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+    );
     await tool.execute!(
       { specialistId: 'email-triage', task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -397,7 +430,9 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(specWithModel);
 
       const config = makeConfig({ xaiApiKey: 'xai-test' });
-      const tool = createSpecialistRunTool(config, toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(config, toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -412,7 +447,9 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(specWithModel);
 
       const config = makeConfig({ openaiApiKey: 'sk-openai', xaiApiKey: 'xai-test' });
-      const tool = createSpecialistRunTool(config, toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(config, toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test', provider: 'openai', model: 'gpt-4o-mini' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -425,7 +462,9 @@ describe('specialist-run tool', () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -442,7 +481,9 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
       const config = makeConfig(); // only has anthropicApiKey
-      const tool = createSpecialistRunTool(config, toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(config, toolOptions, memoryStore, specialistStore),
+      );
       const result = await tool.execute!(
         { specialistId: 'email-triage', task: 'test', provider: 'xai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -461,7 +502,9 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(specProviderOnly);
 
       const config = makeConfig({ xaiApiKey: 'xai-test' });
-      const tool = createSpecialistRunTool(config, toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(config, toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -477,7 +520,9 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
       const config = makeConfig({ openaiApiKey: 'sk-openai' });
-      const tool = createSpecialistRunTool(config, toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(config, toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test', provider: 'openai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -496,7 +541,9 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(specWithModel);
 
       const config = makeConfig(); // only has anthropicApiKey
-      const tool = createSpecialistRunTool(config, toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(config, toolOptions, memoryStore, specialistStore),
+      );
       const result = await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -511,7 +558,9 @@ describe('specialist-run tool', () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       const result = await tool.execute!(
         { specialistId: 'email-triage', task: 'test', provider: '', model: '   ' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -526,7 +575,9 @@ describe('specialist-run tool', () => {
       const specWithBlankProvider = { ...mockSpecialist, provider: '', model: '' };
       vi.spyOn(specialistStore, 'get').mockReturnValue(specWithBlankProvider);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       const result = await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -550,7 +601,9 @@ describe('specialist-run tool', () => {
       });
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       const result = (await tool.execute!(
         { specialistId: 'email-triage', task: 'review the PR' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -567,7 +620,9 @@ describe('specialist-run tool', () => {
       mockGenerateText.mockResolvedValue({ text: '', steps: [] });
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       const result = (await tool.execute!(
         { specialistId: 'email-triage', task: 'noop' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -581,7 +636,9 @@ describe('specialist-run tool', () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -608,10 +665,7 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
       const tool = createSpecialistRunTool(
-        makeConfig({ criticMode: false }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ criticMode: false }), toolOptions, memoryStore, specialistStore),
       );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'review' },
@@ -645,10 +699,7 @@ describe('specialist-run tool', () => {
       });
 
       const tool = createSpecialistRunTool(
-        makeConfig({ criticMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ criticMode: true }), toolOptions, memoryStore, specialistStore),
       );
       const result = (await tool.execute!(
         { specialistId: 'email-triage', task: 'review' },
@@ -684,10 +735,7 @@ describe('specialist-run tool', () => {
       });
 
       const tool = createSpecialistRunTool(
-        makeConfig({ criticMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ criticMode: true }), toolOptions, memoryStore, specialistStore),
       );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'review' },
@@ -716,7 +764,9 @@ describe('specialist-run tool', () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -734,10 +784,7 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
       const tool = createSpecialistRunTool(
-        makeConfig({ reactMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ reactMode: true }), toolOptions, memoryStore, specialistStore),
       );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
@@ -755,10 +802,7 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
       const offTool = createSpecialistRunTool(
-        makeConfig(),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
       );
       await offTool.execute!(
         { specialistId: 'email-triage', task: 'test' },
@@ -769,10 +813,7 @@ describe('specialist-run tool', () => {
       mockGenerateText.mockClear();
 
       const onTool = createSpecialistRunTool(
-        makeConfig({ reactMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ reactMode: true }), toolOptions, memoryStore, specialistStore),
       );
       await onTool.execute!(
         { specialistId: 'email-triage', task: 'test' },
@@ -786,10 +827,7 @@ describe('specialist-run tool', () => {
       vi.spyOn(specialistStore, 'get').mockReturnValue(mockSpecialist);
 
       const tool = createSpecialistRunTool(
-        makeConfig({ reactMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ reactMode: true }), toolOptions, memoryStore, specialistStore),
       );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
@@ -824,10 +862,7 @@ describe('specialist-run tool', () => {
       });
 
       const tool = createSpecialistRunTool(
-        makeConfig({ reactMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ reactMode: true }), toolOptions, memoryStore, specialistStore),
       );
       const result = (await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
@@ -856,10 +891,7 @@ describe('specialist-run tool', () => {
       });
 
       const tool = createSpecialistRunTool(
-        makeConfig({ reactMode: true }),
-        toolOptions,
-        memoryStore,
-        specialistStore,
+        makeCtx(makeConfig({ reactMode: true }), toolOptions, memoryStore, specialistStore),
       );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
@@ -886,7 +918,9 @@ describe('specialist-run tool', () => {
         return { text: '', steps: [], response: { messages: [] } };
       });
 
-      const tool = createSpecialistRunTool(makeConfig(), toolOptions, memoryStore, specialistStore);
+      const tool = createSpecialistRunTool(
+        makeCtx(makeConfig(), toolOptions, memoryStore, specialistStore),
+      );
       await tool.execute!(
         { specialistId: 'email-triage', task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },

--- a/src/tools/specialist-run.ts
+++ b/src/tools/specialist-run.ts
@@ -1,7 +1,7 @@
 import { generateText, tool, type CoreMessage } from 'ai';
 import { z } from 'zod';
 import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
-import { createTools, type ToolOptions } from './index.js';
+import { createTools } from './index.js';
 import {
   printSpecialistStart,
   printSpecialistEnd,
@@ -14,15 +14,9 @@ import {
 import { debugLog } from '../logger.js';
 import { buildMemoryContext } from '../memory-context.js';
 import { acquireSlot, releaseSlot, MAX_CONCURRENT_AGENTS } from './agent-pool.js';
-import {
-  type BernardConfig,
-  resolveProviderAndModel,
-  defaultProviderErrorMessage,
-} from '../config.js';
-import type { MemoryStore } from '../memory.js';
-import type { RAGStore } from '../rag.js';
-import type { SpecialistStore } from '../specialists.js';
+import { resolveProviderAndModel, defaultProviderErrorMessage } from '../config.js';
 import { runPACLoop } from '../pac.js';
+import type { AgentContext } from '../framework/context.js';
 import { capSubagentResult } from './result-cap.js';
 import { appendActivitySummary } from './activity-summary.js';
 import { makeLastStepTextOnly } from './task.js';
@@ -68,21 +62,15 @@ Rules:
  * The specialist's system prompt and guidelines are used as the persona. Shares
  * the concurrency pool with sub-agents and tasks.
  *
- * @param config - Bernard configuration (provider, model, token limits).
- * @param options - Shell execution options forwarded to child tool sets.
- * @param memoryStore - Shared memory store for persistent/scratch context.
- * @param specialistStore - Store for looking up specialist profiles.
- * @param mcpTools - Optional MCP-provided tools available to specialist runs.
- * @param ragStore - Optional RAG store for retrieval-augmented context.
+ * @param ctx - Assembled AgentContext (config, stores, mcp, toolOptions, optional RAG).
  */
-export function createSpecialistRunTool(
-  config: BernardConfig,
-  options: ToolOptions,
-  memoryStore: MemoryStore,
-  specialistStore: SpecialistStore,
-  mcpTools?: Record<string, any>,
-  ragStore?: RAGStore,
-) {
+export function createSpecialistRunTool(ctx: AgentContext) {
+  const { config } = ctx;
+  const options = ctx.toolOptions;
+  const memoryStore = ctx.stores.memory;
+  const specialistStore = ctx.stores.specialists;
+  const mcpTools = ctx.mcp.tools;
+  const ragStore = ctx.rag;
   return tool({
     description:
       "Invoke a saved specialist agent to handle a task using its custom persona, instructions, and behavioral guidelines. The specialist runs as an independent sub-agent with its own system prompt. Use this when the task matches an existing specialist's domain.",

--- a/src/tools/subagent.test.ts
+++ b/src/tools/subagent.test.ts
@@ -51,8 +51,24 @@ vi.mock('ai', async (importOriginal) => {
 
 import { createSubAgentTool, _resetSubAgentState } from './subagent.js';
 import { MemoryStore } from '../memory.js';
+import { assembleContext } from '../framework/context.js';
 
 const { getModelForConfig: mockGetModel } = await import('../providers/index.js');
+
+function makeCtx(
+  config: BernardConfig,
+  toolOptions: ToolOptions,
+  memoryStore: MemoryStore,
+  opts: { rag?: any; mcpTools?: any } = {},
+) {
+  return assembleContext({
+    config,
+    toolOptions,
+    rag: opts.rag,
+    mcp: opts.mcpTools ? { tools: opts.mcpTools } : undefined,
+    stores: { memory: memoryStore },
+  });
+}
 
 function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
   return {
@@ -89,7 +105,7 @@ describe('subagent tool', () => {
   });
 
   it('has correct description and execute function', () => {
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     expect(agentTool).toBeDefined();
     expect(agentTool.description).toContain('sub-agent');
     expect(agentTool.description).toContain('self-contained');
@@ -98,7 +114,7 @@ describe('subagent tool', () => {
 
   it('calls generateText with task in messages and proportional maxSteps', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'List files' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -111,7 +127,7 @@ describe('subagent tool', () => {
 
   it('uses the correct model from config', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -122,7 +138,7 @@ describe('subagent tool', () => {
 
   it('includes context in user message when provided', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'Analyze code', context: 'Focus on error handling' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -133,7 +149,7 @@ describe('subagent tool', () => {
 
   it('returns result.text on success with appended activity log', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Analysis complete: all good' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const result = await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -144,7 +160,7 @@ describe('subagent tool', () => {
 
   it('returns error string (not throw) on API failure', async () => {
     mockGenerateText.mockRejectedValue(new Error('API rate limit'));
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const result = await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -163,7 +179,7 @@ describe('subagent tool', () => {
         }),
     );
 
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const execOptions = { toolCallId: '1', messages: [], abortSignal: undefined as any };
 
     // Start 4 concurrent agents
@@ -184,7 +200,7 @@ describe('subagent tool', () => {
   it('passes abortSignal to inner generateText', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
     const controller = new AbortController();
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: controller.signal },
@@ -195,7 +211,7 @@ describe('subagent tool', () => {
 
   it('calls printSubAgentStart and printSubAgentEnd lifecycle hooks', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'List files' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -206,7 +222,7 @@ describe('subagent tool', () => {
 
   it('calls printSubAgentEnd even on error', async () => {
     mockGenerateText.mockRejectedValue(new Error('fail'));
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -216,7 +232,7 @@ describe('subagent tool', () => {
 
   it('assigns incrementing IDs to sub-agents', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const execOptions = { toolCallId: '1', messages: [], abortSignal: undefined as any };
 
     await agentTool.execute!({ task: 'first' }, execOptions);
@@ -239,11 +255,7 @@ describe('subagent tool', () => {
     };
 
     const agentTool = createSubAgentTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
     await agentTool.execute!(
       { task: 'check preferences' },
@@ -262,7 +274,7 @@ describe('subagent tool', () => {
     vi.mocked(fs.readFileSync).mockReturnValue('dark mode enabled');
     memoryStore = new MemoryStore();
 
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -277,7 +289,7 @@ describe('subagent tool', () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
     memoryStore.writeScratch('plan', 'step 1 done');
 
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -290,7 +302,7 @@ describe('subagent tool', () => {
 
   it('works without ragStore (graceful degradation)', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -308,11 +320,7 @@ describe('subagent tool', () => {
     };
 
     const agentTool = createSubAgentTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
     const result = await agentTool.execute!(
       { task: 'test' },
@@ -327,7 +335,7 @@ describe('subagent tool', () => {
 
   it('includes tool execution integrity rule in system prompt', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -340,7 +348,7 @@ describe('subagent tool', () => {
 
   it('includes error handling guidance prohibiting identical retries', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -351,7 +359,7 @@ describe('subagent tool', () => {
 
   it('includes eventual consistency guidance', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Done' });
-    const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+    const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await agentTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -367,11 +375,7 @@ describe('subagent tool', () => {
     };
 
     const agentTool = createSubAgentTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
     await agentTool.execute!(
       { task: 'check disk usage' },
@@ -385,7 +389,7 @@ describe('subagent tool', () => {
     it('uses override provider/model when specified', async () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
       const config = makeConfig({ xaiApiKey: 'xai-test' });
-      const agentTool = createSubAgentTool(config, toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(config, toolOptions, memoryStore));
       await agentTool.execute!(
         { task: 'test', provider: 'xai', model: 'grok-code-fast-1' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -396,7 +400,7 @@ describe('subagent tool', () => {
 
     it('falls back to global config when no override', async () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
-      const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       await agentTool.execute!(
         { task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -412,7 +416,7 @@ describe('subagent tool', () => {
     it('uses provider default model when provider overridden but model not (avoids cross-provider mismatch)', async () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
       const config = makeConfig({ xaiApiKey: 'xai-test' });
-      const agentTool = createSubAgentTool(config, toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(config, toolOptions, memoryStore));
       await agentTool.execute!(
         { task: 'test', provider: 'xai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -424,7 +428,7 @@ describe('subagent tool', () => {
     });
 
     it('returns error when override provider has no API key', async () => {
-      const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       const result = await agentTool.execute!(
         { task: 'test', provider: 'xai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -448,7 +452,7 @@ describe('subagent tool', () => {
         ],
       });
 
-      const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       const result = (await agentTool.execute!(
         { task: 'review the PR' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -464,7 +468,7 @@ describe('subagent tool', () => {
     it('emits "(no tool calls)" when text and steps are both empty', async () => {
       mockGenerateText.mockResolvedValue({ text: '', steps: [] });
 
-      const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       const result = (await agentTool.execute!(
         { task: 'noop' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -477,7 +481,7 @@ describe('subagent tool', () => {
     it('forces a text-only final step via experimental_prepareStep', async () => {
       mockGenerateText.mockResolvedValue({ text: 'Done' });
 
-      const agentTool = createSubAgentTool(makeConfig(), toolOptions, memoryStore);
+      const agentTool = createSubAgentTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       await agentTool.execute!(
         { task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -1,7 +1,7 @@
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
-import { createTools, type ToolOptions } from './index.js';
+import { createTools } from './index.js';
 import {
   printSubAgentStart,
   printSubAgentEnd,
@@ -12,14 +12,9 @@ import {
 import { debugLog } from '../logger.js';
 import { buildMemoryContext } from '../memory-context.js';
 import { acquireSlot, releaseSlot, _resetPool, MAX_CONCURRENT_AGENTS } from './agent-pool.js';
-import {
-  type BernardConfig,
-  resolveProviderAndModel,
-  defaultProviderErrorMessage,
-} from '../config.js';
-import type { MemoryStore } from '../memory.js';
-import type { RAGStore } from '../rag.js';
+import { resolveProviderAndModel, defaultProviderErrorMessage } from '../config.js';
 import { runPACLoop } from '../pac.js';
+import type { AgentContext } from '../framework/context.js';
 import { capSubagentResult } from './result-cap.js';
 import { appendActivitySummary } from './activity-summary.js';
 import { makeLastStepTextOnly } from './task.js';
@@ -60,19 +55,14 @@ export function _resetSubAgentState(): void {
  * budget and no conversation history, so task descriptions must be fully
  * self-contained. Up to {@link MAX_CONCURRENT_AGENTS} may run concurrently.
  *
- * @param config - Bernard configuration (provider, model, token limits).
- * @param options - Shell execution options forwarded to child tool sets.
- * @param memoryStore - Shared memory store for persistent/scratch context.
- * @param mcpTools - Optional MCP-provided tools available to sub-agents.
- * @param ragStore - Optional RAG store for retrieval-augmented context.
+ * @param ctx - Assembled AgentContext (config, stores, mcp, toolOptions, optional RAG).
  */
-export function createSubAgentTool(
-  config: BernardConfig,
-  options: ToolOptions,
-  memoryStore: MemoryStore,
-  mcpTools?: Record<string, any>,
-  ragStore?: RAGStore,
-) {
+export function createSubAgentTool(ctx: AgentContext) {
+  const { config } = ctx;
+  const options = ctx.toolOptions;
+  const memoryStore = ctx.stores.memory;
+  const mcpTools = ctx.mcp.tools;
+  const ragStore = ctx.rag;
   return tool({
     description:
       'Delegate a task to an independent sub-agent that runs in parallel. Sub-agents have NO conversation history and limited steps — your task description must be fully self-contained and highly prescriptive. Specify exact commands, file paths, expected output format, edge cases, and success/failure criteria. Call multiple times in one response for parallel execution.',

--- a/src/tools/task.test.ts
+++ b/src/tools/task.test.ts
@@ -60,8 +60,26 @@ import {
 import { _resetPool } from './agent-pool.js';
 import { MemoryStore } from '../memory.js';
 import { RoutineStore } from '../routines.js';
+import { assembleContext } from '../framework/context.js';
 
 const { getModelForConfig: mockGetModel } = await import('../providers/index.js');
+
+function makeCtx(
+  config: BernardConfig,
+  toolOptions: ToolOptions,
+  memoryStore: MemoryStore,
+  opts: { rag?: any; routines?: RoutineStore } = {},
+) {
+  return assembleContext({
+    config,
+    toolOptions,
+    rag: opts.rag,
+    stores: {
+      memory: memoryStore,
+      ...(opts.routines ? { routines: opts.routines } : {}),
+    },
+  });
+}
 
 function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
   return {
@@ -195,7 +213,7 @@ describe('task tool', () => {
   });
 
   it('has correct description and execute function', () => {
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     expect(taskTool).toBeDefined();
     expect(taskTool.description).toContain('isolated');
     expect(taskTool.description).toContain('structured JSON');
@@ -205,7 +223,7 @@ describe('task tool', () => {
 
   it('calls generateText with proportional maxSteps and prepareStep', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'List files' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -238,7 +256,7 @@ describe('task tool', () => {
 
   it('returns structured JSON on success', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"found 3 files"}' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const result = await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -250,7 +268,7 @@ describe('task tool', () => {
 
   it('returns error for non-JSON output', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Just some plain text response' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const result = await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -263,7 +281,7 @@ describe('task tool', () => {
 
   it('returns error JSON on API failure (does not throw)', async () => {
     mockGenerateText.mockRejectedValue(new Error('API rate limit'));
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const result = await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -282,7 +300,7 @@ describe('task tool', () => {
         }),
     );
 
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     const execOptions = { toolCallId: '1', messages: [], abortSignal: undefined as any };
 
     // Start 4 concurrent tasks
@@ -303,7 +321,7 @@ describe('task tool', () => {
 
   it('includes context in user message when provided', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'Analyze code', context: 'Focus on error handling' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -315,7 +333,7 @@ describe('task tool', () => {
   it('passes abortSignal to inner generateText', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
     const controller = new AbortController();
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: controller.signal },
@@ -326,7 +344,7 @@ describe('task tool', () => {
 
   it('calls printTaskStart and printTaskEnd lifecycle hooks', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'List files' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -337,7 +355,7 @@ describe('task tool', () => {
 
   it('calls printTaskEnd even on error', async () => {
     mockGenerateText.mockRejectedValue(new Error('fail'));
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -347,7 +365,7 @@ describe('task tool', () => {
 
   it('uses task-specific system prompt with auto-context', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -371,11 +389,7 @@ describe('task tool', () => {
     };
 
     const taskTool = createTaskTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
     await taskTool.execute!(
       { task: 'check preferences' },
@@ -394,11 +408,7 @@ describe('task tool', () => {
     };
 
     const taskTool = createTaskTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
     await taskTool.execute!(
       { task: 'check disk usage' },
@@ -422,12 +432,10 @@ describe('task tool', () => {
     });
 
     const taskTool = createTaskTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
-      routineStore,
+      makeCtx(makeConfig(), toolOptions, memoryStore, {
+        rag: mockRagStore as any,
+        routines: routineStore,
+      }),
     );
     await taskTool.execute!(
       { taskId: 'task-check-issues' },
@@ -446,11 +454,7 @@ describe('task tool', () => {
     };
 
     const taskTool = createTaskTool(
-      makeConfig(),
-      toolOptions,
-      memoryStore,
-      undefined,
-      mockRagStore as any,
+      makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
     const result = await taskTool.execute!(
       { task: 'test' },
@@ -464,7 +468,7 @@ describe('task tool', () => {
 
   it('includes error handling guidance', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
-    const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
     await taskTool.execute!(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -478,7 +482,7 @@ describe('task tool', () => {
     it('uses override provider/model when specified', async () => {
       mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
       const config = makeConfig({ xaiApiKey: 'xai-test' });
-      const taskTool = createTaskTool(config, toolOptions, memoryStore);
+      const taskTool = createTaskTool(makeCtx(config, toolOptions, memoryStore));
       await taskTool.execute!(
         { task: 'test', provider: 'xai', model: 'grok-code-fast-1' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -489,7 +493,7 @@ describe('task tool', () => {
 
     it('falls back to global config when no override', async () => {
       mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
-      const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+      const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       await taskTool.execute!(
         { task: 'test' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -505,7 +509,7 @@ describe('task tool', () => {
     it('uses provider default model when provider overridden but model not (avoids cross-provider mismatch)', async () => {
       mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"done"}' });
       const config = makeConfig({ xaiApiKey: 'xai-test' });
-      const taskTool = createTaskTool(config, toolOptions, memoryStore);
+      const taskTool = createTaskTool(makeCtx(config, toolOptions, memoryStore));
       await taskTool.execute!(
         { task: 'test', provider: 'xai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -517,7 +521,7 @@ describe('task tool', () => {
     });
 
     it('returns error JSON when override provider has no API key', async () => {
-      const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+      const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       const result = await taskTool.execute!(
         { task: 'test', provider: 'xai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -543,12 +547,7 @@ describe('task tool', () => {
       });
 
       const taskTool = createTaskTool(
-        makeConfig(),
-        toolOptions,
-        memoryStore,
-        undefined,
-        undefined,
-        routineStore,
+        makeCtx(makeConfig(), toolOptions, memoryStore, { routines: routineStore }),
       );
       await taskTool.execute!(
         { task: 'task-check-issues', taskId: 'task-check-issues' },
@@ -564,12 +563,7 @@ describe('task tool', () => {
       vi.spyOn(routineStore, 'get').mockReturnValue(undefined);
 
       const taskTool = createTaskTool(
-        makeConfig(),
-        toolOptions,
-        memoryStore,
-        undefined,
-        undefined,
-        routineStore,
+        makeCtx(makeConfig(), toolOptions, memoryStore, { routines: routineStore }),
       );
       const result = await taskTool.execute!(
         { task: 'task-nonexistent', taskId: 'task-nonexistent' },
@@ -593,12 +587,7 @@ describe('task tool', () => {
       });
 
       const taskTool = createTaskTool(
-        makeConfig(),
-        toolOptions,
-        memoryStore,
-        undefined,
-        undefined,
-        routineStore,
+        makeCtx(makeConfig(), toolOptions, memoryStore, { routines: routineStore }),
       );
       await taskTool.execute!(
         { taskId: 'task-check-issues' },
@@ -609,8 +598,8 @@ describe('task tool', () => {
       expect(call.messages[0].content).toContain('List all open GitHub issues');
     });
 
-    it('returns error when taskId provided but routineStore is missing', async () => {
-      const taskTool = createTaskTool(makeConfig(), toolOptions, memoryStore);
+    it('returns error when taskId references a routine that does not exist', async () => {
+      const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
       const result = await taskTool.execute!(
         { taskId: 'task-check-issues' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
@@ -618,7 +607,7 @@ describe('task tool', () => {
 
       const parsed = JSON.parse(result);
       expect(parsed.status).toBe('error');
-      expect(parsed.output).toContain('routine store is not available');
+      expect(parsed.output).toContain('not found');
       expect(mockGenerateText).not.toHaveBeenCalled();
     });
 
@@ -633,12 +622,7 @@ describe('task tool', () => {
       });
 
       const taskTool = createTaskTool(
-        makeConfig(),
-        toolOptions,
-        memoryStore,
-        undefined,
-        undefined,
-        routineStore,
+        makeCtx(makeConfig(), toolOptions, memoryStore, { routines: routineStore }),
       );
       await taskTool.execute!(
         { task: 'only critical bugs', taskId: 'task-check-issues' },

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -1,7 +1,7 @@
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
-import { createTools, type ToolOptions } from './index.js';
+import { createTools } from './index.js';
 import { extractJsonBlock } from '../structured-output.js';
 import {
   printTaskStart,
@@ -14,9 +14,7 @@ import { debugLog } from '../logger.js';
 import { buildMemoryContext } from '../memory-context.js';
 import { acquireSlot, releaseSlot, MAX_CONCURRENT_AGENTS } from './agent-pool.js';
 import { type BernardConfig, resolveProviderAndModel } from '../config.js';
-import type { MemoryStore } from '../memory.js';
-import type { RAGStore } from '../rag.js';
-import type { RoutineStore } from '../routines.js';
+import type { AgentContext } from '../framework/context.js';
 
 export const TASK_SYSTEM_PROMPT = `You are a task executor for Bernard, a CLI AI assistant. You have been given a focused, isolated task.
 
@@ -124,14 +122,13 @@ export function wrapTaskResult(text: string): TaskResult {
  * agent/task tools (preventing recursion). The final step forces text-only output
  * via `experimental_prepareStep` to ensure structured JSON is produced.
  */
-export function createTaskTool(
-  config: BernardConfig,
-  options: ToolOptions,
-  memoryStore: MemoryStore,
-  mcpTools?: Record<string, any>,
-  ragStore?: RAGStore,
-  routineStore?: RoutineStore,
-) {
+export function createTaskTool(ctx: AgentContext) {
+  const { config } = ctx;
+  const options = ctx.toolOptions;
+  const memoryStore = ctx.stores.memory;
+  const mcpTools = ctx.mcp.tools;
+  const ragStore = ctx.rag;
+  const routineStore = ctx.stores.routines;
   return tool({
     description:
       'Execute a focused, isolated task with structured JSON output {status, output, details?}. Tasks have no conversation history and a limited step budget. Use when you need a discrete, machine-readable result — especially during routine execution for chaining outcomes.',

--- a/src/tools/tool-wrapper-run.test.ts
+++ b/src/tools/tool-wrapper-run.test.ts
@@ -103,6 +103,29 @@ import {
 } from './tool-wrapper-run.js';
 import { _resetPool } from './agent-pool.js';
 import { DEFAULT_SUBAGENT_RESULT_MAX_CHARS } from './result-cap.js';
+import type { AgentContext } from '../framework/context.js';
+
+function makeCtx(
+  config: any,
+  options: any,
+  memoryStore: any,
+  specialistStore: any,
+  correctionStore: any,
+): AgentContext {
+  return {
+    config,
+    toolOptions: options,
+    stores: {
+      memory: memoryStore,
+      specialists: specialistStore,
+      correction: correctionStore,
+      routines: {} as any,
+      candidates: {} as any,
+      toolProfiles: {} as any,
+    },
+    mcp: { tools: {}, serverNames: [] },
+  };
+}
 
 const { generateText } = await import('ai');
 const { acquireSlot, releaseSlot } = await import('./agent-pool.js');
@@ -564,11 +587,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     specialistStore.get.mockReturnValue(undefined);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'missing', input: 'do something' },
@@ -587,11 +606,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     specialistStore.get.mockReturnValue(makeToolWrapperSpecialist({ kind: 'persona' }));
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'do something' },
@@ -609,11 +624,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     specialistStore.get.mockReturnValue(noKindSpec);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'do something' },
@@ -636,11 +647,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     });
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'do something' },
@@ -660,11 +667,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     vi.mocked(acquireSlot).mockReturnValue(null);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'do something' },
@@ -687,11 +690,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     } as any);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'list files' },
@@ -724,11 +723,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     } as any);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'run bad command' },
@@ -756,11 +751,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     } as any);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     await toolDef.execute(
       { specialistId: 'specialist-creator', input: 'create something' },
@@ -777,11 +768,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     vi.mocked(generateText).mockRejectedValue(new Error('network timeout'));
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     const result = await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'do something' },
@@ -802,11 +789,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     vi.mocked(generateText).mockRejectedValue(new Error('api crash'));
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'do something' },
@@ -829,11 +812,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
     } as any);
 
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     await toolDef.execute({ specialistId: 'shell-wrapper', input: 'list' }, DEFAULT_EXEC_OPTIONS);
 
@@ -849,11 +828,7 @@ describe('createToolWrapperRunTool – execute guard branches', () => {
       steps: [],
     } as any);
     const toolDef = createToolWrapperRunTool(
-      config,
-      options,
-      memoryStore,
-      specialistStore,
-      correctionStore,
+      makeCtx(config, options, memoryStore, specialistStore, correctionStore),
     );
     await toolDef.execute(
       { specialistId: 'shell-wrapper', input: 'success run' },

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -19,10 +19,12 @@ import { acquireSlot, releaseSlot, MAX_CONCURRENT_AGENTS } from './agent-pool.js
 import { type BernardConfig, resolveProviderAndModel } from '../config.js';
 import type { MemoryStore } from '../memory.js';
 import type { RAGStore } from '../rag.js';
-import type { RoutineStore } from '../routines.js';
-import type { SpecialistStore, Specialist } from '../specialists.js';
-import type { CandidateStoreReader } from '../specialist-candidates.js';
+import { RoutineStore } from '../routines.js';
+import type { Specialist, SpecialistStore } from '../specialists.js';
+import { CandidateStore, type CandidateStoreReader } from '../specialist-candidates.js';
 import type { CorrectionCandidateStore } from '../correction-candidates.js';
+import { ToolProfileStore } from '../tool-profiles.js';
+import type { AgentContext } from '../framework/context.js';
 import { osPromptBlock } from '../os-info.js';
 import {
   STRUCTURED_OUTPUT_RULES,
@@ -143,6 +145,39 @@ export interface ToolWrapperDeps {
   candidateStore?: CandidateStoreReader;
 }
 
+/** Derives the legacy {@link ToolWrapperDeps} shape from an {@link AgentContext}. */
+export function ctxToToolWrapperDeps(ctx: AgentContext): ToolWrapperDeps {
+  return {
+    config: ctx.config,
+    options: ctx.toolOptions,
+    memoryStore: ctx.stores.memory,
+    specialistStore: ctx.stores.specialists,
+    correctionStore: ctx.stores.correction,
+    mcpTools: ctx.mcp.tools,
+    ragStore: ctx.rag,
+    routineStore: ctx.stores.routines,
+    candidateStore: ctx.stores.candidates,
+  };
+}
+
+/** Lifts {@link ToolWrapperDeps} into a full {@link AgentContext} for child factories. */
+export function depsToCtx(deps: ToolWrapperDeps): AgentContext {
+  return {
+    config: deps.config,
+    stores: {
+      memory: deps.memoryStore,
+      routines: deps.routineStore ?? new RoutineStore(),
+      specialists: deps.specialistStore,
+      candidates: deps.candidateStore ?? new CandidateStore(),
+      correction: deps.correctionStore,
+      toolProfiles: new ToolProfileStore(),
+    },
+    mcp: { tools: deps.mcpTools ?? {}, serverNames: [] },
+    rag: deps.ragStore,
+    toolOptions: deps.options,
+  };
+}
+
 /** Per-call inputs to a tool-wrapper dispatch. */
 export interface DispatchToolWrapperArgs {
   specialistId: string;
@@ -242,29 +277,13 @@ export async function dispatchToolWrapper(
       candidateStore,
       config,
     );
+    const innerCtx = depsToCtx(deps);
     const fullRegistry: Record<string, any> = {
       ...baseTools,
-      agent: createSubAgentTool(config, options, memoryStore, mcpTools, ragStore),
-      task: createTaskTool(config, options, memoryStore, mcpTools, ragStore, routineStore),
-      specialist_run: createSpecialistRunTool(
-        config,
-        options,
-        memoryStore,
-        specialistStore,
-        mcpTools,
-        ragStore,
-      ),
-      tool_wrapper_run: createToolWrapperRunTool(
-        config,
-        options,
-        memoryStore,
-        specialistStore,
-        correctionStore,
-        mcpTools,
-        ragStore,
-        routineStore,
-        candidateStore,
-      ),
+      agent: createSubAgentTool(innerCtx),
+      task: createTaskTool(innerCtx),
+      specialist_run: createSpecialistRunTool(innerCtx),
+      tool_wrapper_run: createToolWrapperRunTool(innerCtx),
     };
     const childTools = buildChildTools(specialist, fullRegistry);
 
@@ -440,17 +459,8 @@ export function renderWrapperParentView(
  *   - strips `reasoning` and caps the JSON envelope before returning to the
  *     parent agent — the full reasoning lives in the JSONL trace only
  */
-export function createToolWrapperRunTool(
-  config: BernardConfig,
-  options: ToolOptions,
-  memoryStore: MemoryStore,
-  specialistStore: SpecialistStore,
-  correctionStore: CorrectionCandidateStore,
-  mcpTools?: Record<string, any>,
-  ragStore?: RAGStore,
-  routineStore?: RoutineStore,
-  candidateStore?: CandidateStoreReader,
-) {
+export function createToolWrapperRunTool(ctx: AgentContext) {
+  const deps = ctxToToolWrapperDeps(ctx);
   return tool({
     description:
       'Dispatch to a saved tool-wrapper specialist that handles a concrete tool or CLI (e.g. shell-wrapper, file-wrapper). Returns JSON {status, result, error?}. Use this for tool-heavy operations where domain-specific examples and error handling reduce misuse. Also used to invoke meta specialists (specialist-creator, correction-agent).',
@@ -482,17 +492,7 @@ export function createToolWrapperRunTool(
           model,
           abortSignal: execOptions.abortSignal,
         },
-        {
-          config,
-          options,
-          memoryStore,
-          specialistStore,
-          correctionStore,
-          mcpTools,
-          ragStore,
-          routineStore,
-          candidateStore,
-        },
+        deps,
       );
       return renderWrapperParentView(wrapped);
     },

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -212,7 +212,6 @@ export async function dispatchToolWrapper(
     specialistStore,
     correctionStore,
     mcpTools,
-    ragStore,
     routineStore,
     candidateStore,
   } = deps;

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -143,6 +143,7 @@ export interface ToolWrapperDeps {
   ragStore?: RAGStore;
   routineStore?: RoutineStore;
   candidateStore?: CandidateStoreReader;
+  toolProfileStore?: ToolProfileStore;
 }
 
 /** Derives the legacy {@link ToolWrapperDeps} shape from an {@link AgentContext}. */
@@ -157,6 +158,7 @@ export function ctxToToolWrapperDeps(ctx: AgentContext): ToolWrapperDeps {
     ragStore: ctx.rag,
     routineStore: ctx.stores.routines,
     candidateStore: ctx.stores.candidates,
+    toolProfileStore: ctx.stores.toolProfiles,
   };
 }
 
@@ -170,7 +172,7 @@ export function depsToCtx(deps: ToolWrapperDeps): AgentContext {
       specialists: deps.specialistStore,
       candidates: deps.candidateStore ?? new CandidateStore(),
       correction: deps.correctionStore,
-      toolProfiles: new ToolProfileStore(),
+      toolProfiles: deps.toolProfileStore ?? new ToolProfileStore(),
     },
     mcp: { tools: deps.mcpTools ?? {}, serverNames: [] },
     rag: deps.ragStore,


### PR DESCRIPTION
Closes #156. Part of the framework refactor epic (#155).

## Summary
- Adds `src/framework/context.ts` with `AgentContext` + `assembleContext()`, a single DI container carrying config, stores (memory/routines/specialists/candidates/correction/toolProfiles), MCP tools, RAG, and per-callsite `toolOptions`.
- Collapses positional DI everywhere: `Agent` constructor goes from 12 args to `(ctx, opts?)`; `createSubAgentTool`, `createSpecialistRunTool`, `createTaskTool`, and `createToolWrapperRunTool` each take one `AgentContext`; `RunCorrectionDeps` shrinks to `{ ctx, toolWrapperRun? }`.
- Fixes prior drift in `src/cron/runner.ts` — the daemon now assembles the same store set the REPL does (previously missing `routineStore` / `specialistStore` / `correctionStore`). Phase A is plumbing only — no behavior change.

Phases B–E (BernardTool standard, AgentRunner, ExecutionStrategy, AgentDefinition) ship in separate PRs (#157, #158, #159, #160).

## Test plan
- [x] `npm test` — 2160/2160 passing across 79 files
- [x] `npm run build` — clean
- [x] New unit tests in `src/framework/__tests__/context.test.ts` cover `assembleContext` defaulting + store overrides
- [ ] REPL smoke walk: plain turn, `specialist_run` of `shell-wrapper`, sub-agent dispatch, `task` tool, shutdown with a queued correction candidate
- [ ] Cron smoke walk: `bernard cron run-now <existing-job>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)