### PR TITLE
Phase B: BernardTool standard + ToolResult envelope

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,6 +7,7 @@ import {
 import { createTools, type ToolOptions } from './tools/index.js';
 import { createSubAgentTool } from './tools/subagent.js';
 import { createTaskTool } from './tools/task.js';
+import { toolToAISDK } from './framework/tools/adapter.js';
 import {
   printAssistantText,
   printToolCall,
@@ -616,7 +617,7 @@ export class Agent {
       const tools = {
         ...baseTools,
         agent: createSubAgentTool(this.ctx),
-        task: createTaskTool(this.ctx),
+        task: toolToAISDK(createTaskTool(this.ctx)),
         specialist_run: createSpecialistRunTool(this.ctx),
         tool_wrapper_run: createToolWrapperRunTool(this.ctx),
         think: createThinkTool(),

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -14,6 +14,7 @@ import { createDateTimeTool, formatCurrentDateTime } from '../tools/datetime.js'
 import { createWebReadTool } from '../tools/web.js';
 import { createWaitTool } from '../tools/wait.js';
 import { createTimeTools } from '../tools/time.js';
+import { toolToAISDK } from '../framework/tools/adapter.js';
 import { MCPManager } from '../mcp.js';
 import { CronStore } from './store.js';
 import { CronLogStore, type CronLogStep } from './log-store.js';
@@ -190,9 +191,9 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
     const notesStore = new CronNotesStore();
 
     const tools = {
-      shell: shellTool,
-      memory: createMemoryTool(memoryStore),
-      scratch: createScratchTool(memoryStore),
+      shell: toolToAISDK(shellTool),
+      memory: toolToAISDK(createMemoryTool(memoryStore)),
+      scratch: toolToAISDK(createScratchTool(memoryStore)),
       datetime: createDateTimeTool(),
       web_read: createWebReadTool(),
       wait: createWaitTool(),

--- a/src/framework/tools/__tests__/adapter.test.ts
+++ b/src/framework/tools/__tests__/adapter.test.ts
@@ -15,8 +15,7 @@ function makeMigrated(): BernardTool<{ x: number }, { doubled: number }> {
       }
       return ok({ doubled: x * 2 });
     },
-    serializeForModel: (r) =>
-      r.status === 'ok' ? r.result : `Error: ${r.error.message}`,
+    serializeForModel: (r) => (r.status === 'ok' ? r.result : `Error: ${r.error.message}`),
   };
 }
 

--- a/src/framework/tools/__tests__/adapter.test.ts
+++ b/src/framework/tools/__tests__/adapter.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { tool } from 'ai';
+import { z } from 'zod';
+import { toolToAISDK, legacyTool, readToolMeta } from '../adapter.js';
+import { ok, err, type BernardTool } from '../types.js';
+
+function makeMigrated(): BernardTool<{ x: number }, { doubled: number }> {
+  return {
+    meta: { name: 'demo', kind: 'read' },
+    description: 'demo',
+    parameters: z.object({ x: z.number() }),
+    execute: async ({ x }) => {
+      if (x < 0) {
+        return err({ type: 'invalid_args', message: 'x must be non-negative' });
+      }
+      return ok({ doubled: x * 2 });
+    },
+    serializeForModel: (r) =>
+      r.status === 'ok' ? r.result : `Error: ${r.error.message}`,
+  };
+}
+
+describe('toolToAISDK', () => {
+  it('passes the envelope result through serializeForModel on success', async () => {
+    const aisdk = toolToAISDK(makeMigrated());
+    const result = await (aisdk as { execute: (a: unknown, o: unknown) => unknown }).execute(
+      { x: 21 },
+      {},
+    );
+    expect(result).toEqual({ doubled: 42 });
+  });
+
+  it('passes the envelope result through serializeForModel on error', async () => {
+    const aisdk = toolToAISDK(makeMigrated());
+    const result = await (aisdk as { execute: (a: unknown, o: unknown) => unknown }).execute(
+      { x: -1 },
+      {},
+    );
+    expect(result).toBe('Error: x must be non-negative');
+  });
+
+  it('attaches __bernardMeta non-enumerably', () => {
+    const aisdk = toolToAISDK(makeMigrated());
+    expect(readToolMeta(aisdk)).toEqual({ name: 'demo', kind: 'read' });
+    expect(Object.keys(aisdk)).not.toContain('__bernardMeta');
+  });
+});
+
+describe('legacyTool', () => {
+  it('wraps a successful AI-SDK return in a status:"ok" envelope', async () => {
+    const legacy = tool({
+      description: 'echo',
+      parameters: z.object({ msg: z.string() }),
+      execute: async ({ msg }) => `you said: ${msg}`,
+    });
+    const wrapped = legacyTool(legacy, { name: 'echo', kind: 'inert' });
+    const result = await wrapped.execute({ msg: 'hi' }, {});
+    expect(result).toEqual({ status: 'ok', result: 'you said: hi' });
+  });
+
+  it('converts a thrown error into a status:"error" envelope', async () => {
+    const legacy = tool({
+      description: 'fail',
+      parameters: z.object({}),
+      execute: async () => {
+        throw new Error('boom');
+      },
+    });
+    const wrapped = legacyTool(legacy, { name: 'fail', kind: 'inert' });
+    const result = await wrapped.execute({}, {});
+    expect(result).toEqual({
+      status: 'error',
+      error: { type: 'exec_failed', message: 'boom' },
+    });
+  });
+
+  it('passes an already-envelope return through untouched', async () => {
+    const legacy = tool({
+      description: 'returns envelope',
+      parameters: z.object({}),
+      execute: async () => ({ status: 'ok' as const, result: 'pre-wrapped' }),
+    });
+    const wrapped = legacyTool(legacy, { name: 'env', kind: 'inert' });
+    const result = await wrapped.execute({}, {});
+    expect(result).toEqual({ status: 'ok', result: 'pre-wrapped' });
+  });
+
+  it('serializeForModel preserves the legacy plain-value shape on success', async () => {
+    const legacy = tool({
+      description: 'val',
+      parameters: z.object({}),
+      execute: async () => ({ output: 'hi', is_error: false }),
+    });
+    const wrapped = legacyTool(legacy, { name: 'val', kind: 'inert' });
+    const envelope = await wrapped.execute({}, {});
+    expect(wrapped.serializeForModel(envelope)).toEqual({ output: 'hi', is_error: false });
+  });
+});

--- a/src/framework/tools/__tests__/registry.test.ts
+++ b/src/framework/tools/__tests__/registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { ToolRegistry } from '../registry.js';
+import { ok, type BernardTool } from '../types.js';
+
+function makeTool(name: string, kind: 'read' | 'write' | 'dangerous' | 'inert'): BernardTool<unknown, unknown> {
+  return {
+    meta: { name, kind },
+    description: name,
+    parameters: z.object({}),
+    execute: async () => ok({ name }),
+    serializeForModel: (r) => (r.status === 'ok' ? r.result : `Error: ${r.error.message}`),
+  };
+}
+
+describe('ToolRegistry', () => {
+  it('starts empty by default', () => {
+    const r = new ToolRegistry();
+    expect(r.all()).toEqual([]);
+  });
+
+  it('seeds from a constructor iterable, keyed by meta.name', () => {
+    const r = new ToolRegistry([makeTool('a', 'read'), makeTool('b', 'write')]);
+    expect(r.has('a')).toBe(true);
+    expect(r.has('b')).toBe(true);
+    expect(r.get('a')?.meta.kind).toBe('read');
+  });
+
+  it('add() replaces an entry with the same name', () => {
+    const r = new ToolRegistry([makeTool('x', 'read')]);
+    r.add(makeTool('x', 'write'));
+    expect(r.all()).toHaveLength(1);
+    expect(r.get('x')?.meta.kind).toBe('write');
+  });
+
+  it('byMetadata({kind:"read"}) returns only read tools', () => {
+    const r = new ToolRegistry([
+      makeTool('search', 'read'),
+      makeTool('list', 'read'),
+      makeTool('write-file', 'write'),
+      makeTool('shell', 'dangerous'),
+    ]);
+    const reads = r.byMetadata({ kind: 'read' });
+    expect(reads.map((t) => t.meta.name).sort()).toEqual(['list', 'search']);
+  });
+
+  it('byMetadata({}) returns every tool', () => {
+    const r = new ToolRegistry([makeTool('a', 'read'), makeTool('b', 'write')]);
+    expect(r.byMetadata({}).map((t) => t.meta.name).sort()).toEqual(['a', 'b']);
+  });
+
+  it('byMetadata ignores undefined filter values', () => {
+    const r = new ToolRegistry([makeTool('a', 'read'), makeTool('b', 'write')]);
+    expect(r.byMetadata({ kind: undefined }).length).toBe(2);
+  });
+
+  it('byMetadata supports multi-key filters', () => {
+    const a: BernardTool<unknown, unknown> = {
+      ...makeTool('a', 'read'),
+      meta: { name: 'a', kind: 'read', category: 'fs' },
+    };
+    const b: BernardTool<unknown, unknown> = {
+      ...makeTool('b', 'read'),
+      meta: { name: 'b', kind: 'read', category: 'net' },
+    };
+    const r = new ToolRegistry([a, b]);
+    const fsReads = r.byMetadata({ kind: 'read', category: 'fs' });
+    expect(fsReads.map((t) => t.meta.name)).toEqual(['a']);
+  });
+
+  it('toAISDKRecord() produces a Record keyed by meta.name with callable execute', async () => {
+    const r = new ToolRegistry([makeTool('a', 'read')]);
+    const aisdk = r.toAISDKRecord();
+    expect(Object.keys(aisdk)).toEqual(['a']);
+    const result = await (aisdk.a as { execute: (a: unknown, o: unknown) => unknown }).execute(
+      {},
+      {},
+    );
+    expect(result).toEqual({ name: 'a' });
+  });
+});

--- a/src/framework/tools/__tests__/registry.test.ts
+++ b/src/framework/tools/__tests__/registry.test.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 import { ToolRegistry } from '../registry.js';
 import { ok, type BernardTool } from '../types.js';
 
-function makeTool(name: string, kind: 'read' | 'write' | 'dangerous' | 'inert'): BernardTool<unknown, unknown> {
+function makeTool(
+  name: string,
+  kind: 'read' | 'write' | 'dangerous' | 'inert',
+): BernardTool<unknown, unknown> {
   return {
     meta: { name, kind },
     description: name,
@@ -46,7 +49,12 @@ describe('ToolRegistry', () => {
 
   it('byMetadata({}) returns every tool', () => {
     const r = new ToolRegistry([makeTool('a', 'read'), makeTool('b', 'write')]);
-    expect(r.byMetadata({}).map((t) => t.meta.name).sort()).toEqual(['a', 'b']);
+    expect(
+      r
+        .byMetadata({})
+        .map((t) => t.meta.name)
+        .sort(),
+    ).toEqual(['a', 'b']);
   });
 
   it('byMetadata ignores undefined filter values', () => {

--- a/src/framework/tools/__tests__/types.test.ts
+++ b/src/framework/tools/__tests__/types.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { ok, err, isToolResult, type ToolResult } from '../types.js';
+
+describe('ToolResult helpers', () => {
+  it('ok() wraps a value in a status:"ok" envelope', () => {
+    const r = ok({ greeting: 'hi' });
+    expect(r).toEqual({ status: 'ok', result: { greeting: 'hi' } });
+  });
+
+  it('err() wraps an error in a status:"error" envelope', () => {
+    const r = err({ type: 'exec_failed', message: 'boom' });
+    expect(r).toEqual({
+      status: 'error',
+      error: { type: 'exec_failed', message: 'boom' },
+    });
+  });
+
+  it('narrows the union correctly via the status discriminator', () => {
+    const r: ToolResult<number> = ok(42);
+    if (r.status === 'ok') {
+      // Type-narrow check — would be a TS error if discriminator were broken.
+      expect(r.result + 1).toBe(43);
+    } else {
+      throw new Error('unreachable');
+    }
+  });
+
+  it('isToolResult() recognizes ok and error envelopes', () => {
+    expect(isToolResult(ok('x'))).toBe(true);
+    expect(isToolResult(err({ type: 'unknown', message: '' }))).toBe(true);
+  });
+
+  it('isToolResult() rejects non-envelope shapes', () => {
+    expect(isToolResult(null)).toBe(false);
+    expect(isToolResult(undefined)).toBe(false);
+    expect(isToolResult('plain string')).toBe(false);
+    expect(isToolResult({ output: 'x', is_error: false })).toBe(false);
+    expect(isToolResult({ status: 'success', result: 'x' })).toBe(false);
+    expect(isToolResult(42)).toBe(false);
+  });
+});

--- a/src/framework/tools/adapter.ts
+++ b/src/framework/tools/adapter.ts
@@ -1,0 +1,113 @@
+import { tool, type Tool } from 'ai';
+import type { BernardTool, ToolMeta, ToolResult } from './types.js';
+import { isToolResult } from './types.js';
+
+/**
+ * Wraps a `BernardTool` so it satisfies the AI SDK's `tool()` contract. The
+ * adapter swallows execution-level throws and rethrows them — the model still
+ * sees the historical shape via `serializeForModel`; downstream Bernard code
+ * sees the envelope when it inspects the wrapped tool's return.
+ *
+ * Returns the AI-SDK `Tool` object **plus** a non-enumerable `meta` field so
+ * the augmentation layer and the registry can read metadata without holding a
+ * separate reference to the `BernardTool`.
+ */
+export function toolToAISDK<TArgs, TData>(t: BernardTool<TArgs, TData>): Tool {
+  const aisdk = tool({
+    description: t.description,
+    parameters: t.parameters,
+    execute: async (args, opts) => {
+      const envelope = await t.execute(args as TArgs, opts as never);
+      return t.serializeForModel(envelope);
+    },
+  });
+  Object.defineProperty(aisdk, '__bernardMeta', {
+    value: t.meta,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  // Stash the source BernardTool so augmentation can re-run execute and
+  // inspect the raw envelope without rebuilding the adapter chain.
+  Object.defineProperty(aisdk, '__bernardSource', {
+    value: t,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return aisdk;
+}
+
+/**
+ * Reads the source {@link BernardTool} attached to a `Tool` by
+ * {@link toolToAISDK}. Returns `undefined` for legacy/MCP tools that did not
+ * pass through the adapter.
+ */
+export function readBernardSource(t: unknown): BernardTool<unknown, unknown> | undefined {
+  if (!t || typeof t !== 'object') return undefined;
+  const src = (t as { __bernardSource?: unknown }).__bernardSource;
+  if (
+    src &&
+    typeof src === 'object' &&
+    typeof (src as BernardTool<unknown, unknown>).execute === 'function' &&
+    typeof (src as BernardTool<unknown, unknown>).serializeForModel === 'function'
+  ) {
+    return src as BernardTool<unknown, unknown>;
+  }
+  return undefined;
+}
+
+/**
+ * Lifts an existing AI-SDK `Tool` into a `BernardTool` slot so the registry
+ * can hold mixed migrated/unmigrated entries without losing type safety on the
+ * migrated ones. The returned `execute` wraps the legacy return in an envelope
+ * by treating any thrown error as `{status: 'error', ...}` and any value as
+ * `{status: 'ok', result: <value>}`. `serializeForModel` is a passthrough.
+ */
+export function legacyTool(t: Tool, meta: ToolMeta): BernardTool<unknown, unknown> {
+  return {
+    meta,
+    description: typeof t.description === 'string' ? t.description : '',
+    // The AI SDK's parameter shape is opaque here; cast through unknown so the
+    // registry's TS slot is satisfied. Runtime behavior is unaffected.
+    parameters: t.parameters as never,
+    execute: async (args, opts) => {
+      try {
+        const value = await (t as { execute: (a: unknown, o: unknown) => unknown }).execute(
+          args,
+          opts,
+        );
+        // If the legacy tool happens to already return an envelope, pass it through.
+        if (isToolResult(value)) return value as ToolResult<unknown>;
+        return { status: 'ok', result: value };
+      } catch (e) {
+        return {
+          status: 'error',
+          error: {
+            type: 'exec_failed',
+            message: e instanceof Error ? e.message : String(e),
+          },
+        };
+      }
+    },
+    serializeForModel: (r) => (r.status === 'ok' ? r.result : `Error: ${r.error.message}`),
+  };
+}
+
+/**
+ * Reads the metadata attached to a `Tool` by `toolToAISDK`. Returns
+ * `undefined` for tools that did not pass through the adapter (legacy or MCP).
+ */
+export function readToolMeta(t: unknown): ToolMeta | undefined {
+  if (!t || typeof t !== 'object') return undefined;
+  const meta = (t as { __bernardMeta?: unknown }).__bernardMeta;
+  if (
+    meta &&
+    typeof meta === 'object' &&
+    typeof (meta as ToolMeta).name === 'string' &&
+    typeof (meta as ToolMeta).kind === 'string'
+  ) {
+    return meta as ToolMeta;
+  }
+  return undefined;
+}

--- a/src/framework/tools/mcp.ts
+++ b/src/framework/tools/mcp.ts
@@ -34,9 +34,10 @@ export function wrapMCPTool(
     parameters: mcpTool.parameters as never,
     execute: async (args, opts): Promise<ToolResult<unknown>> => {
       try {
-        const value = await (
-          mcpTool as { execute: (a: unknown, o: unknown) => unknown }
-        ).execute(args, opts);
+        const value = await (mcpTool as { execute: (a: unknown, o: unknown) => unknown }).execute(
+          args,
+          opts,
+        );
         if (isToolResult(value)) return value as ToolResult<unknown>;
         // Heuristic: MCP servers historically return string errors prefixed
         // with "Error". detectToolError used to catch these; localize it here.

--- a/src/framework/tools/mcp.ts
+++ b/src/framework/tools/mcp.ts
@@ -1,0 +1,66 @@
+import type { Tool } from 'ai';
+import type { BernardTool, ToolMeta, ToolResult } from './types.js';
+import { isToolResult } from './types.js';
+
+/**
+ * Wraps an MCP tool at the boundary so it satisfies `BernardTool` with a
+ * generic envelope. This is the **one place** that retains heuristic error
+ * detection for MCP-provided returns — any string starting with `"Error"` (or
+ * a result that fails to serialize) is treated as an error envelope. Thrown
+ * exceptions in the MCP `execute` (reconnect/network) propagate up as
+ * `status: 'error'` rather than throwing, so the augment layer can record
+ * them deterministically.
+ *
+ * Pass the AI-SDK MCP `Tool` (already reconnect-wrapped by `MCPManager.getTools`)
+ * plus the originating server name. Defaults to `kind: 'inert'` — callers that
+ * know an MCP tool is read-only can override via the optional `metaOverride`.
+ */
+export function wrapMCPTool(
+  name: string,
+  mcpTool: Tool,
+  serverName: string,
+  metaOverride?: Partial<ToolMeta>,
+): BernardTool<unknown, unknown> {
+  const meta: ToolMeta = {
+    name,
+    kind: 'inert',
+    category: `mcp.${serverName}`,
+    ...metaOverride,
+  };
+
+  return {
+    meta,
+    description: typeof mcpTool.description === 'string' ? mcpTool.description : '',
+    parameters: mcpTool.parameters as never,
+    execute: async (args, opts): Promise<ToolResult<unknown>> => {
+      try {
+        const value = await (
+          mcpTool as { execute: (a: unknown, o: unknown) => unknown }
+        ).execute(args, opts);
+        if (isToolResult(value)) return value as ToolResult<unknown>;
+        // Heuristic: MCP servers historically return string errors prefixed
+        // with "Error". detectToolError used to catch these; localize it here.
+        if (typeof value === 'string' && value.startsWith('Error')) {
+          return {
+            status: 'error',
+            error: { type: 'exec_failed', message: value.slice(0, 200) },
+          };
+        }
+        return { status: 'ok', result: value };
+      } catch (e) {
+        return {
+          status: 'error',
+          error: {
+            type: 'exec_failed',
+            message: e instanceof Error ? e.message : String(e),
+          },
+        };
+      }
+    },
+    serializeForModel: (r) => {
+      if (r.status === 'ok') return r.result;
+      // Match the historical MCP error string shape so model-facing bytes are stable.
+      return `Error: ${r.error.message}`;
+    },
+  };
+}

--- a/src/framework/tools/registry.ts
+++ b/src/framework/tools/registry.ts
@@ -1,0 +1,59 @@
+import type { Tool } from 'ai';
+import type { BernardTool, ToolMeta } from './types.js';
+import { toolToAISDK } from './adapter.js';
+
+/**
+ * Typed registry that holds `BernardTool` entries (native + legacy + MCP via
+ * `legacyTool` / `wrapMCPTool`) and exposes capability filtering. Call sites
+ * that still expect the AI-SDK shape get it back via `toAISDKRecord()`.
+ */
+export class ToolRegistry {
+  private readonly tools: Map<string, BernardTool<unknown, unknown>>;
+
+  constructor(entries: Iterable<BernardTool<unknown, unknown>> = []) {
+    this.tools = new Map();
+    for (const t of entries) this.tools.set(t.meta.name, t);
+  }
+
+  /** Adds or replaces an entry by `meta.name`. */
+  add(t: BernardTool<unknown, unknown>): this {
+    this.tools.set(t.meta.name, t);
+    return this;
+  }
+
+  get(name: string): BernardTool<unknown, unknown> | undefined {
+    return this.tools.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.tools.has(name);
+  }
+
+  all(): BernardTool<unknown, unknown>[] {
+    return Array.from(this.tools.values());
+  }
+
+  /**
+   * Returns every tool whose `meta` matches all keys in `filter`. Undefined
+   * filter values are ignored. Useful for capability gates like
+   * `byMetadata({kind: 'read'})`.
+   */
+  byMetadata(filter: Partial<ToolMeta>): BernardTool<unknown, unknown>[] {
+    const entries = Object.entries(filter).filter(([, v]) => v !== undefined);
+    if (entries.length === 0) return this.all();
+    return this.all().filter((t) =>
+      entries.every(
+        ([key, expected]) => (t.meta as unknown as Record<string, unknown>)[key] === expected,
+      ),
+    );
+  }
+
+  /** Converts the registry into the `Record<string, Tool>` shape the AI SDK expects. */
+  toAISDKRecord(): Record<string, Tool> {
+    const out: Record<string, Tool> = {};
+    for (const t of this.tools.values()) {
+      out[t.meta.name] = toolToAISDK(t);
+    }
+    return out;
+  }
+}

--- a/src/framework/tools/types.ts
+++ b/src/framework/tools/types.ts
@@ -12,12 +12,7 @@ export interface ToolMeta {
   category?: string;
 }
 
-export type ToolErrorType =
-  | 'invalid_args'
-  | 'exec_failed'
-  | 'timeout'
-  | 'cancelled'
-  | 'unknown';
+export type ToolErrorType = 'invalid_args' | 'exec_failed' | 'timeout' | 'cancelled' | 'unknown';
 
 export interface ToolError {
   type: ToolErrorType;
@@ -32,9 +27,7 @@ export interface ToolError {
  * Discriminated union the agent reads internally. `status` mirrors the shape
  * the codebase already uses in `tool_wrapper_run`.
  */
-export type ToolResult<T> =
-  | { status: 'ok'; result: T }
-  | { status: 'error'; error: ToolError };
+export type ToolResult<T> = { status: 'ok'; result: T } | { status: 'error'; error: ToolError };
 
 export function ok<T>(result: T): ToolResult<T> {
   return { status: 'ok', result };

--- a/src/framework/tools/types.ts
+++ b/src/framework/tools/types.ts
@@ -1,0 +1,78 @@
+import type { z } from 'zod';
+
+/**
+ * Standard tool metadata. `name` is the registry key; `kind` enables capability
+ * filtering (e.g. `byMetadata({kind: 'read'})` for the reference-resolver lookup
+ * pass). `category` mirrors today's `classifyShellCommand` grouping for
+ * tool-profile organization.
+ */
+export interface ToolMeta {
+  name: string;
+  kind: 'read' | 'write' | 'dangerous' | 'inert';
+  category?: string;
+}
+
+export type ToolErrorType =
+  | 'invalid_args'
+  | 'exec_failed'
+  | 'timeout'
+  | 'cancelled'
+  | 'unknown';
+
+export interface ToolError {
+  type: ToolErrorType;
+  message: string;
+  /** Short excerpt for tool-profile bad-example storage. */
+  snippet?: string;
+  /** Hint that another attempt is worth trying. */
+  retryable?: boolean;
+}
+
+/**
+ * Discriminated union the agent reads internally. `status` mirrors the shape
+ * the codebase already uses in `tool_wrapper_run`.
+ */
+export type ToolResult<T> =
+  | { status: 'ok'; result: T }
+  | { status: 'error'; error: ToolError };
+
+export function ok<T>(result: T): ToolResult<T> {
+  return { status: 'ok', result };
+}
+
+export function err<T = never>(error: ToolError): ToolResult<T> {
+  return { status: 'error', error };
+}
+
+/**
+ * Type guard for the `ToolResult` envelope. Used by `augment.ts` to skip
+ * heuristic error detection for migrated tools.
+ */
+export function isToolResult(value: unknown): value is ToolResult<unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as { status?: unknown };
+  return v.status === 'ok' || v.status === 'error';
+}
+
+/**
+ * Options passed to `execute`. Mirrors what the AI SDK supplies via its own
+ * `ToolExecutionOptions`, narrowed to the fields tool implementations use.
+ */
+export interface ToolExecOptions {
+  toolCallId?: string;
+  abortSignal?: AbortSignal;
+  messages?: unknown[];
+}
+
+/**
+ * Native Bernard tool contract. `execute` returns the envelope; the AI SDK
+ * never sees it directly — `serializeForModel` translates back to whatever
+ * shape the tool has historically exposed to the model.
+ */
+export interface BernardTool<TArgs, TData> {
+  meta: ToolMeta;
+  description: string;
+  parameters: z.ZodType<TArgs>;
+  execute: (args: TArgs, opts: ToolExecOptions) => Promise<ToolResult<TData>>;
+  serializeForModel: (result: ToolResult<TData>) => unknown;
+}

--- a/src/reference-tool-lookup.test.ts
+++ b/src/reference-tool-lookup.test.ts
@@ -209,6 +209,36 @@ describe('runReferenceLookup', () => {
     expect(result).toEqual({ status: 'none' });
   });
 
+  it('accepts a tool flagged kind:read via __bernardMeta even when not in the allowlist', async () => {
+    const tool = makeTool(() => ({ id: 'r1' }));
+    Object.defineProperty(tool, '__bernardMeta', {
+      value: { name: 'lookup_thing', kind: 'read' },
+      enumerable: false,
+    });
+    generateTextMock
+      .mockResolvedValueOnce({
+        text: '{"status":"call","toolName":"lookup_thing","args":{"q":"brother"}}',
+      })
+      .mockResolvedValueOnce({ text: '{"status":"found","resolvedTo":"r1"}' });
+    const result = await runReferenceLookup('my brother', { lookup_thing: tool }, makeConfig());
+    expect(result).toEqual({
+      status: 'found',
+      resolvedTo: 'r1',
+      toolName: 'lookup_thing',
+    });
+  });
+
+  it('rejects a tool flagged kind:write via __bernardMeta when not in the allowlist', async () => {
+    const tool = makeTool(() => ({ id: 'r1' }));
+    Object.defineProperty(tool, '__bernardMeta', {
+      value: { name: 'lookup_thing', kind: 'write' },
+      enumerable: false,
+    });
+    const result = await runReferenceLookup('my brother', { lookup_thing: tool }, makeConfig());
+    expect(result).toEqual({ status: 'none' });
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
   it('honors the BERNARD_LOOKUP_TOOLS extension', async () => {
     generateTextMock
       .mockResolvedValueOnce({

--- a/src/reference-tool-lookup.ts
+++ b/src/reference-tool-lookup.ts
@@ -1,5 +1,6 @@
 import { generateText } from 'ai';
 import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { readToolMeta } from './framework/tools/adapter.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
 
@@ -84,11 +85,21 @@ function describeTool(name: string, tool: any): ToolDescriptor {
   return { name, description, schema };
 }
 
+/**
+ * Returns true when the tool carries `meta.kind === 'read'` via the framework
+ * adapter. This is the canonical signal once tools are migrated to
+ * `BernardTool`; on day one only `task` qualifies, so the behavior change is
+ * additive (the suffix allowlist still covers MCP + legacy tools).
+ */
+function isReadKindTool(tool: unknown): boolean {
+  return readToolMeta(tool)?.kind === 'read';
+}
+
 function collectAllowedTools(tools: Record<string, any>, extraAllowed: string[]): ToolDescriptor[] {
   const out: ToolDescriptor[] = [];
   for (const [name, tool] of Object.entries(tools)) {
     if (!tool || typeof tool.execute !== 'function') continue;
-    if (!isAllowedLookupTool(name, extraAllowed)) continue;
+    if (!isAllowedLookupTool(name, extraAllowed) && !isReadKindTool(tool)) continue;
     out.push(describeTool(name, tool));
   }
   return out;

--- a/src/tools/augment.test.ts
+++ b/src/tools/augment.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
 import { augmentTools } from './augment.js';
+import { toolToAISDK } from '../framework/tools/adapter.js';
+import { ok, err, type BernardTool } from '../framework/tools/types.js';
 
 vi.mock('../tool-profiles.js', () => ({
   classifyShellCommand: vi.fn((cmd: string) => {
@@ -562,6 +565,67 @@ describe('augmentTools', () => {
       const calledArgs = store.recordBadExample.mock.calls[0][1] as string;
       expect(typeof calledArgs).toBe('string');
       expect(calledArgs.length).toBeLessThanOrEqual(300);
+    });
+  });
+
+  describe('envelope-aware path (migrated BernardTools)', () => {
+    function makeBernardTool(opts: {
+      name: string;
+      result: 'ok' | 'error';
+      message?: string;
+    }): BernardTool<{ x: number }, { val: number }> {
+      return {
+        meta: { name: opts.name, kind: 'read' },
+        description: opts.name,
+        parameters: z.object({ x: z.number() }),
+        execute: async () =>
+          opts.result === 'ok'
+            ? ok({ val: 1 })
+            : err({ type: 'exec_failed', message: opts.message ?? 'boom', snippet: 'boom-snip' }),
+        serializeForModel: (r) => (r.status === 'ok' ? r.result : `Error: ${r.error.message}`),
+      };
+    }
+
+    it('records error envelope WITHOUT calling detectToolError heuristic', async () => {
+      const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'error', message: 'fail' }));
+      const augmented = augmentTools({ demo: aisdk }, store);
+      await augmented.demo.execute({ x: 1 }, {});
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(store.recordBadExample).toHaveBeenCalledTimes(1);
+      // Heuristic detector must not be consulted for migrated tools.
+      expect(detectToolError).not.toHaveBeenCalled();
+    });
+
+    it('records nothing on ok envelope', async () => {
+      const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools({ demo: aisdk }, store);
+      await augmented.demo.execute({ x: 1 }, {});
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(store.recordBadExample).not.toHaveBeenCalled();
+      expect(detectToolError).not.toHaveBeenCalled();
+    });
+
+    it('returns the model-facing serialized form, not the raw envelope', async () => {
+      const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'error', message: 'oops' }));
+      const augmented = augmentTools({ demo: aisdk }, store);
+      const out = await augmented.demo.execute({ x: 1 }, {});
+      expect(out).toBe('Error: oops');
+    });
+
+    it('patches the most recent unfixed bad example on success (envelope path)', async () => {
+      store.get.mockReturnValue({
+        badExamples: [
+          { args: '{"x":2}', errorSnippet: 'old', fix: '(awaiting successful retry)' },
+        ],
+      });
+      const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools({ demo: aisdk }, store);
+      await augmented.demo.execute({ x: 1 }, {});
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(store.patchLastBadWithFix).toHaveBeenCalledWith('demo', JSON.stringify({ x: 1 }));
     });
   });
 

--- a/src/tools/augment.test.ts
+++ b/src/tools/augment.test.ts
@@ -587,7 +587,9 @@ describe('augmentTools', () => {
     }
 
     it('records error envelope WITHOUT calling detectToolError heuristic', async () => {
-      const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'error', message: 'fail' }));
+      const aisdk = toolToAISDK(
+        makeBernardTool({ name: 'demo', result: 'error', message: 'fail' }),
+      );
       const augmented = augmentTools({ demo: aisdk }, store);
       await augmented.demo.execute({ x: 1 }, {});
       await new Promise((resolve) => setImmediate(resolve));
@@ -608,7 +610,9 @@ describe('augmentTools', () => {
     });
 
     it('returns the model-facing serialized form, not the raw envelope', async () => {
-      const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'error', message: 'oops' }));
+      const aisdk = toolToAISDK(
+        makeBernardTool({ name: 'demo', result: 'error', message: 'oops' }),
+      );
       const augmented = augmentTools({ demo: aisdk }, store);
       const out = await augmented.demo.execute({ x: 1 }, {});
       expect(out).toBe('Error: oops');
@@ -616,9 +620,7 @@ describe('augmentTools', () => {
 
     it('patches the most recent unfixed bad example on success (envelope path)', async () => {
       store.get.mockReturnValue({
-        badExamples: [
-          { args: '{"x":2}', errorSnippet: 'old', fix: '(awaiting successful retry)' },
-        ],
+        badExamples: [{ args: '{"x":2}', errorSnippet: 'old', fix: '(awaiting successful retry)' }],
       });
       const aisdk = toolToAISDK(makeBernardTool({ name: 'demo', result: 'ok' }));
       const augmented = augmentTools({ demo: aisdk }, store);

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -1,6 +1,8 @@
 import { type ToolProfileStore, classifyShellCommand, detectToolError } from '../tool-profiles.js';
 import { debugLog } from '../logger.js';
 import { printInfo } from '../output.js';
+import { readBernardSource } from '../framework/tools/adapter.js';
+import type { ToolResult } from '../framework/tools/types.js';
 
 /**
  * Returns the profile key for a given tool invocation. Shell commands are
@@ -29,14 +31,54 @@ function safeSerialize(args: unknown): string {
 }
 
 /**
+ * Fires the profile-recording side-effect for a given outcome. `errorSnippet`
+ * is undefined on success. Wrapped in setImmediate by the caller so it never
+ * adds latency to tool execution.
+ */
+function recordOutcome(
+  profileStore: ToolProfileStore,
+  toolName: string,
+  profileKey: string,
+  argsSnippet: string,
+  errorSnippet: string | undefined,
+): void {
+  try {
+    if (errorSnippet !== undefined) {
+      profileStore.recordBadExample(profileKey, argsSnippet, errorSnippet);
+      debugLog(`augment:${toolName}:error`, { profileKey, snippet: errorSnippet });
+      printInfo(`  ~ profile ${profileKey} — recorded error`);
+      return;
+    }
+    // On success, patch the most recent unfixed bad example if there is one.
+    const profile = profileStore.get(profileKey);
+    if (
+      profile?.badExamples.length &&
+      profile.badExamples[profile.badExamples.length - 1].fix ===
+        '(awaiting successful retry)'
+    ) {
+      profileStore.patchLastBadWithFix(profileKey, argsSnippet);
+      debugLog(`augment:${toolName}:patched`, { profileKey });
+      printInfo(`  ~ profile ${profileKey} — learned fix`);
+    }
+  } catch {
+    // Recording must never propagate errors.
+  }
+}
+
+/**
  * Wraps every tool's `execute` function to observe results and record
  * error examples to the profile store, and patch fixes when the model
  * retries successfully. The recording is fire-and-forget via `setImmediate`
  * so it never adds latency to tool execution.
  *
+ * For tools that originated as {@link import('../framework/tools/types.js').BernardTool}
+ * (detected via the `__bernardSource` side-channel attached by `toolToAISDK`),
+ * error detection reads the envelope discriminator directly — no heuristics.
+ * For legacy AI-SDK tools and MCP-wrapped tools, the historical
+ * `detectToolError` heuristic path still applies.
+ *
  * Does NOT modify tool descriptions, parameters, or any other field.
- */
-/**
+ *
  * Uses `Record<string, any>` intentionally — this is a generic wrapper across
  * heterogeneous tool types (built-in, MCP, dispatch) whose parameter types are
  * erased at this boundary. The SDK's `ToolSet` type is `Record<string, Tool>`
@@ -55,8 +97,48 @@ export function augmentTools(
       continue;
     }
 
-    const originalExecute = toolDef.execute;
+    const source = readBernardSource(toolDef);
 
+    if (source) {
+      // Envelope-aware path for migrated BernardTools. We run the source
+      // execute (which returns a ToolResult envelope), record based on the
+      // discriminator, then call serializeForModel to produce the bytes the
+      // model sees — exactly what toolToAISDK would have done.
+      augmented[toolName] = {
+        ...toolDef,
+        execute: async (args: unknown, execOptions: unknown) => {
+          let envelope: ToolResult<unknown>;
+          try {
+            envelope = await source.execute(args, execOptions as never);
+          } catch (thrown: unknown) {
+            // Infrastructure-level throws (reconnect, network, etc.) are not
+            // usage errors — don't record them as bad examples.
+            debugLog(
+              `augment:${toolName}:threw`,
+              thrown instanceof Error ? thrown.message : String(thrown),
+            );
+            throw thrown;
+          }
+
+          const profileKey = resolveProfileKey(toolName, args);
+          const argsSnippet = safeSerialize(args);
+          const errSnippet =
+            envelope.status === 'error'
+              ? `${envelope.error.message}${envelope.error.snippet ? `\n${envelope.error.snippet}` : ''}`.slice(0, 200)
+              : undefined;
+          setImmediate(() =>
+            recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet),
+          );
+
+          return source.serializeForModel(envelope);
+        },
+      };
+      continue;
+    }
+
+    // Legacy heuristic path for AI-SDK / MCP / dispatch tools that have not
+    // been migrated. Behavior is unchanged from pre-Phase-B.
+    const originalExecute = toolDef.execute;
     augmented[toolName] = {
       ...toolDef,
       execute: async (args: unknown, execOptions: unknown) => {
@@ -64,8 +146,6 @@ export function augmentTools(
         try {
           result = await originalExecute(args, execOptions);
         } catch (thrown: unknown) {
-          // Infrastructure-level throws (MCP reconnect, network, etc.) are not
-          // usage errors — don't record them as bad examples.
           debugLog(
             `augment:${toolName}:threw`,
             thrown instanceof Error ? thrown.message : String(thrown),
@@ -73,33 +153,16 @@ export function augmentTools(
           throw thrown;
         }
 
-        // Non-blocking observation: record error/success in the next event loop tick
         const profileKey = resolveProfileKey(toolName, args);
+        const argsSnippet = safeSerialize(args);
         const capturedResult = result;
         setImmediate(() => {
           try {
             const errorInfo = detectToolError(toolName, capturedResult);
-            const argsSnippet = safeSerialize(args);
-
-            if (errorInfo.isError) {
-              profileStore.recordBadExample(profileKey, argsSnippet, errorInfo.snippet);
-              debugLog(`augment:${toolName}:error`, { profileKey, snippet: errorInfo.snippet });
-              printInfo(`  ~ profile ${profileKey} — recorded error`);
-            } else {
-              // On success, check if we should patch the last unfixed bad example
-              const profile = profileStore.get(profileKey);
-              if (
-                profile?.badExamples.length &&
-                profile.badExamples[profile.badExamples.length - 1].fix ===
-                  '(awaiting successful retry)'
-              ) {
-                profileStore.patchLastBadWithFix(profileKey, argsSnippet);
-                debugLog(`augment:${toolName}:patched`, { profileKey });
-                printInfo(`  ~ profile ${profileKey} — learned fix`);
-              }
-            }
+            const errSnippet = errorInfo.isError ? errorInfo.snippet : undefined;
+            recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet);
           } catch {
-            // Recording must never propagate errors
+            // detectToolError throws are swallowed; recording must never propagate.
           }
         });
 

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -53,8 +53,7 @@ function recordOutcome(
     const profile = profileStore.get(profileKey);
     if (
       profile?.badExamples.length &&
-      profile.badExamples[profile.badExamples.length - 1].fix ===
-        '(awaiting successful retry)'
+      profile.badExamples[profile.badExamples.length - 1].fix === '(awaiting successful retry)'
     ) {
       profileStore.patchLastBadWithFix(profileKey, argsSnippet);
       debugLog(`augment:${toolName}:patched`, { profileKey });
@@ -124,7 +123,10 @@ export function augmentTools(
           const argsSnippet = safeSerialize(args);
           const errSnippet =
             envelope.status === 'error'
-              ? `${envelope.error.message}${envelope.error.snippet ? `\n${envelope.error.snippet}` : ''}`.slice(0, 200)
+              ? `${envelope.error.message}${envelope.error.snippet ? `\n${envelope.error.snippet}` : ''}`.slice(
+                  0,
+                  200,
+                )
               : undefined;
           setImmediate(() =>
             recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import { createWaitTool } from './wait.js';
 import { createFileTools } from './file.js';
 import { createRoutineTool } from './routine.js';
 import { createSpecialistTool } from './specialist.js';
+import { toolToAISDK } from '../framework/tools/adapter.js';
 import type { ToolOptions } from './types.js';
 import type { MemoryStore } from '../memory.js';
 import type { RoutineStore } from '../routines.js';
@@ -41,9 +42,13 @@ export function createTools(
   config?: BernardConfig,
 ): Record<string, any> {
   return {
-    shell: createShellTool(options),
-    memory: createMemoryTool(memoryStore),
-    scratch: createScratchTool(memoryStore),
+    // Migrated to BernardTool (Phase B). `toolToAISDK` preserves model-facing
+    // bytes via each tool's `serializeForModel`; the source BernardTool is
+    // attached via `__bernardSource` so `augmentTools` can detect errors
+    // deterministically from the envelope.
+    shell: toolToAISDK(createShellTool(options)),
+    memory: toolToAISDK(createMemoryTool(memoryStore)),
+    scratch: toolToAISDK(createScratchTool(memoryStore)),
     routine: createRoutineTool(routineStore),
     specialist: createSpecialistTool(specialistStore, candidateStore, config),
     datetime: createDateTimeTool(),

--- a/src/tools/memory.test.ts
+++ b/src/tools/memory.test.ts
@@ -13,6 +13,15 @@ vi.mock('node:fs', () => ({
 
 const fs = await import('node:fs');
 
+/** Invokes the tool and returns the model-facing serialized value. */
+async function runSerialized(
+  tool: ReturnType<typeof createMemoryTool>,
+  args: Parameters<typeof tool.execute>[0],
+): Promise<unknown> {
+  const envelope = await tool.execute(args, {});
+  return tool.serializeForModel(envelope);
+}
+
 describe('createMemoryTool', () => {
   let store: MemoryStore;
   let memoryTool: ReturnType<typeof createMemoryTool>;
@@ -32,66 +41,76 @@ describe('createMemoryTool', () => {
   });
 
   it('list returns empty message when no memories', async () => {
-    const result = await memoryTool.execute({ action: 'list' }, {} as any);
+    const result = await runSerialized(memoryTool, { action: 'list' });
     expect(result).toContain('No persistent memories');
   });
 
   it('list returns stored keys', async () => {
     store.writeMemory('prefs', 'dark mode');
     vi.mocked(fs.readdirSync).mockReturnValue(['prefs.md'] as any);
-    const result = await memoryTool.execute({ action: 'list' }, {} as any);
+    const result = await runSerialized(memoryTool, { action: 'list' });
     expect(result).toContain('prefs');
   });
 
   it('read requires key', async () => {
-    const result = await memoryTool.execute({ action: 'read' }, {} as any);
-    expect(result).toContain('key is required');
+    const result = await runSerialized(memoryTool, { action: 'read' });
+    expect(result).toBe('Error: key is required for read action.');
   });
 
   it('read returns content when found', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('memory content');
-    const result = await memoryTool.execute({ action: 'read', key: 'prefs' }, {} as any);
+    const result = await runSerialized(memoryTool, { action: 'read', key: 'prefs' });
     expect(result).toBe('memory content');
   });
 
   it('read returns not-found message when missing', async () => {
-    const result = await memoryTool.execute({ action: 'read', key: 'nope' }, {} as any);
+    const result = await runSerialized(memoryTool, { action: 'read', key: 'nope' });
     expect(result).toContain('No memory found');
   });
 
   it('write requires key', async () => {
-    const result = await memoryTool.execute({ action: 'write', content: 'data' }, {} as any);
-    expect(result).toContain('key is required');
+    const result = await runSerialized(memoryTool, { action: 'write', content: 'data' });
+    expect(result).toBe('Error: key is required for write action.');
   });
 
   it('write requires content', async () => {
-    const result = await memoryTool.execute({ action: 'write', key: 'k' }, {} as any);
-    expect(result).toContain('content is required');
+    const result = await runSerialized(memoryTool, { action: 'write', key: 'k' });
+    expect(result).toBe('Error: content is required for write action.');
   });
 
   it('write saves and confirms', async () => {
-    const result = await memoryTool.execute(
-      { action: 'write', key: 'prefs', content: 'dark mode' },
-      {} as any,
-    );
+    const result = await runSerialized(memoryTool, {
+      action: 'write',
+      key: 'prefs',
+      content: 'dark mode',
+    });
     expect(result).toContain('saved');
   });
 
   it('delete requires key', async () => {
-    const result = await memoryTool.execute({ action: 'delete' }, {} as any);
-    expect(result).toContain('key is required');
+    const result = await runSerialized(memoryTool, { action: 'delete' });
+    expect(result).toBe('Error: key is required for delete action.');
   });
 
   it('delete returns not-found when missing', async () => {
-    const result = await memoryTool.execute({ action: 'delete', key: 'nope' }, {} as any);
+    const result = await runSerialized(memoryTool, { action: 'delete', key: 'nope' });
     expect(result).toContain('No memory found');
   });
 
   it('delete removes and confirms', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    const result = await memoryTool.execute({ action: 'delete', key: 'prefs' }, {} as any);
+    const result = await runSerialized(memoryTool, { action: 'delete', key: 'prefs' });
     expect(result).toContain('deleted');
+  });
+
+  it('returns error envelope on validation failure', async () => {
+    const envelope = await memoryTool.execute({ action: 'read' }, {});
+    expect(envelope.status).toBe('error');
+    if (envelope.status === 'error') {
+      expect(envelope.error.type).toBe('invalid_args');
+      expect(envelope.error.message).toBe('key is required for read action.');
+    }
   });
 });
 
@@ -106,63 +125,64 @@ describe('createScratchTool', () => {
   });
 
   it('list returns empty message when no notes', async () => {
-    const result = await scratchTool.execute({ action: 'list' }, {} as any);
+    const result = await runSerialized(scratchTool, { action: 'list' });
     expect(result).toContain('No scratch notes');
   });
 
   it('list returns stored keys', async () => {
     store.writeScratch('todo', 'step 1');
-    const result = await scratchTool.execute({ action: 'list' }, {} as any);
+    const result = await runSerialized(scratchTool, { action: 'list' });
     expect(result).toContain('todo');
   });
 
   it('read requires key', async () => {
-    const result = await scratchTool.execute({ action: 'read' }, {} as any);
-    expect(result).toContain('key is required');
+    const result = await runSerialized(scratchTool, { action: 'read' });
+    expect(result).toBe('Error: key is required for read action.');
   });
 
   it('read returns content when found', async () => {
     store.writeScratch('todo', 'step 1');
-    const result = await scratchTool.execute({ action: 'read', key: 'todo' }, {} as any);
+    const result = await runSerialized(scratchTool, { action: 'read', key: 'todo' });
     expect(result).toBe('step 1');
   });
 
   it('read returns not-found message when missing', async () => {
-    const result = await scratchTool.execute({ action: 'read', key: 'nope' }, {} as any);
+    const result = await runSerialized(scratchTool, { action: 'read', key: 'nope' });
     expect(result).toContain('No scratch note found');
   });
 
   it('write requires key', async () => {
-    const result = await scratchTool.execute({ action: 'write', content: 'data' }, {} as any);
-    expect(result).toContain('key is required');
+    const result = await runSerialized(scratchTool, { action: 'write', content: 'data' });
+    expect(result).toBe('Error: key is required for write action.');
   });
 
   it('write requires content', async () => {
-    const result = await scratchTool.execute({ action: 'write', key: 'k' }, {} as any);
-    expect(result).toContain('content is required');
+    const result = await runSerialized(scratchTool, { action: 'write', key: 'k' });
+    expect(result).toBe('Error: content is required for write action.');
   });
 
   it('write saves and confirms', async () => {
-    const result = await scratchTool.execute(
-      { action: 'write', key: 'todo', content: 'step 1' },
-      {} as any,
-    );
+    const result = await runSerialized(scratchTool, {
+      action: 'write',
+      key: 'todo',
+      content: 'step 1',
+    });
     expect(result).toContain('saved');
   });
 
   it('delete requires key', async () => {
-    const result = await scratchTool.execute({ action: 'delete' }, {} as any);
-    expect(result).toContain('key is required');
+    const result = await runSerialized(scratchTool, { action: 'delete' });
+    expect(result).toBe('Error: key is required for delete action.');
   });
 
   it('delete returns not-found when missing', async () => {
-    const result = await scratchTool.execute({ action: 'delete', key: 'nope' }, {} as any);
+    const result = await runSerialized(scratchTool, { action: 'delete', key: 'nope' });
     expect(result).toContain('No scratch note found');
   });
 
   it('delete removes and confirms', async () => {
     store.writeScratch('todo', 'step 1');
-    const result = await scratchTool.execute({ action: 'delete', key: 'todo' }, {} as any);
+    const result = await runSerialized(scratchTool, { action: 'delete', key: 'todo' });
     expect(result).toContain('deleted');
   });
 });

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -34,20 +34,23 @@ export function createMemoryTool(memoryStore: MemoryStore): BernardTool<MemoryAr
           return ok(`Stored memories:\n${keys.map((k) => `  - ${k}`).join('\n')}`);
         }
         case 'read': {
-          if (!key) return err({ type: 'invalid_args', message: 'key is required for read action.' });
+          if (!key)
+            return err({ type: 'invalid_args', message: 'key is required for read action.' });
           const value = memoryStore.readMemory(key);
           if (value === null) return ok(`No memory found for key "${key}".`);
           return ok(value);
         }
         case 'write': {
-          if (!key) return err({ type: 'invalid_args', message: 'key is required for write action.' });
+          if (!key)
+            return err({ type: 'invalid_args', message: 'key is required for write action.' });
           if (!content)
             return err({ type: 'invalid_args', message: 'content is required for write action.' });
           memoryStore.writeMemory(key, content);
           return ok(`Memory "${key}" saved.`);
         }
         case 'delete': {
-          if (!key) return err({ type: 'invalid_args', message: 'key is required for delete action.' });
+          if (!key)
+            return err({ type: 'invalid_args', message: 'key is required for delete action.' });
           const deleted = memoryStore.deleteMemory(key);
           if (!deleted) return ok(`No memory found for key "${key}".`);
           return ok(`Memory "${key}" deleted.`);
@@ -81,20 +84,23 @@ export function createScratchTool(memoryStore: MemoryStore): BernardTool<MemoryA
           return ok(`Scratch notes:\n${keys.map((k) => `  - ${k}`).join('\n')}`);
         }
         case 'read': {
-          if (!key) return err({ type: 'invalid_args', message: 'key is required for read action.' });
+          if (!key)
+            return err({ type: 'invalid_args', message: 'key is required for read action.' });
           const value = memoryStore.readScratch(key);
           if (value === null) return ok(`No scratch note found for key "${key}".`);
           return ok(value);
         }
         case 'write': {
-          if (!key) return err({ type: 'invalid_args', message: 'key is required for write action.' });
+          if (!key)
+            return err({ type: 'invalid_args', message: 'key is required for write action.' });
           if (!content)
             return err({ type: 'invalid_args', message: 'content is required for write action.' });
           memoryStore.writeScratch(key, content);
           return ok(`Scratch note "${key}" saved.`);
         }
         case 'delete': {
-          if (!key) return err({ type: 'invalid_args', message: 'key is required for delete action.' });
+          if (!key)
+            return err({ type: 'invalid_args', message: 'key is required for delete action.' });
           const deleted = memoryStore.deleteScratch(key);
           if (!deleted) return ok(`No scratch note found for key "${key}".`);
           return ok(`Scratch note "${key}" deleted.`);

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -1,53 +1,63 @@
-import { tool } from 'ai';
 import { z } from 'zod';
 import type { MemoryStore } from '../memory.js';
 import { MEMORY_DIR } from '../paths.js';
+import type { BernardTool } from '../framework/tools/types.js';
+import { ok, err } from '../framework/tools/types.js';
+
+const MEMORY_PARAMETERS = z.object({
+  action: z.enum(['list', 'read', 'write', 'delete']).describe('The action to perform'),
+  key: z.string().optional().describe('The memory key (required for read/write/delete)'),
+  content: z.string().optional().describe('The content to write (required for write)'),
+});
+
+type MemoryArgs = z.infer<typeof MEMORY_PARAMETERS>;
 
 /**
  * Creates the persistent memory tool backed by on-disk markdown files.
  *
  * Supports list, read, write, and delete actions for cross-session recall.
+ * Returns a {@link BernardTool}; `serializeForModel` reproduces the historical
+ * plain-string output (including the `"Error: "` prefix on validation errors).
  *
  * @param memoryStore - The backing MemoryStore instance.
  */
-export function createMemoryTool(memoryStore: MemoryStore) {
-  return tool({
+export function createMemoryTool(memoryStore: MemoryStore): BernardTool<MemoryArgs, string> {
+  return {
+    meta: { name: 'memory', kind: 'write' },
     description: `Persistent memory that survives across sessions. Use this to remember user preferences, project knowledge, or anything worth recalling later. Stored as files on disk at ${MEMORY_DIR}.`,
-    parameters: z.object({
-      action: z.enum(['list', 'read', 'write', 'delete']).describe('The action to perform'),
-      key: z.string().optional().describe('The memory key (required for read/write/delete)'),
-      content: z.string().optional().describe('The content to write (required for write)'),
-    }),
-    execute: async ({ action, key, content }): Promise<string> => {
+    parameters: MEMORY_PARAMETERS,
+    execute: async ({ action, key, content }) => {
       switch (action) {
         case 'list': {
           const keys = memoryStore.listMemory();
-          if (keys.length === 0) return 'No persistent memories stored.';
-          return `Stored memories:\n${keys.map((k) => `  - ${k}`).join('\n')}`;
+          if (keys.length === 0) return ok('No persistent memories stored.');
+          return ok(`Stored memories:\n${keys.map((k) => `  - ${k}`).join('\n')}`);
         }
         case 'read': {
-          if (!key) return 'Error: key is required for read action.';
+          if (!key) return err({ type: 'invalid_args', message: 'key is required for read action.' });
           const value = memoryStore.readMemory(key);
-          if (value === null) return `No memory found for key "${key}".`;
-          return value;
+          if (value === null) return ok(`No memory found for key "${key}".`);
+          return ok(value);
         }
         case 'write': {
-          if (!key) return 'Error: key is required for write action.';
-          if (!content) return 'Error: content is required for write action.';
+          if (!key) return err({ type: 'invalid_args', message: 'key is required for write action.' });
+          if (!content)
+            return err({ type: 'invalid_args', message: 'content is required for write action.' });
           memoryStore.writeMemory(key, content);
-          return `Memory "${key}" saved.`;
+          return ok(`Memory "${key}" saved.`);
         }
         case 'delete': {
-          if (!key) return 'Error: key is required for delete action.';
+          if (!key) return err({ type: 'invalid_args', message: 'key is required for delete action.' });
           const deleted = memoryStore.deleteMemory(key);
-          if (!deleted) return `No memory found for key "${key}".`;
-          return `Memory "${key}" deleted.`;
+          if (!deleted) return ok(`No memory found for key "${key}".`);
+          return ok(`Memory "${key}" deleted.`);
         }
         default:
-          return `Unknown action: ${action}`;
+          return err({ type: 'invalid_args', message: `Unknown action: ${action}` });
       }
     },
-  });
+    serializeForModel: (r) => (r.status === 'ok' ? r.result : `Error: ${r.error.message}`),
+  };
 }
 
 /**
@@ -57,43 +67,42 @@ export function createMemoryTool(memoryStore: MemoryStore) {
  *
  * @param memoryStore - The backing MemoryStore instance.
  */
-export function createScratchTool(memoryStore: MemoryStore) {
-  return tool({
+export function createScratchTool(memoryStore: MemoryStore): BernardTool<MemoryArgs, string> {
+  return {
+    meta: { name: 'scratch', kind: 'write' },
     description:
       'Session scratch notes for tracking complex task progress, intermediate findings, and working plans. These notes survive context compression but are discarded when the session ends. Use this to keep track of multi-step work within a single session.',
-    parameters: z.object({
-      action: z.enum(['list', 'read', 'write', 'delete']).describe('The action to perform'),
-      key: z.string().optional().describe('The scratch note key (required for read/write/delete)'),
-      content: z.string().optional().describe('The content to write (required for write)'),
-    }),
-    execute: async ({ action, key, content }): Promise<string> => {
+    parameters: MEMORY_PARAMETERS,
+    execute: async ({ action, key, content }) => {
       switch (action) {
         case 'list': {
           const keys = memoryStore.listScratch();
-          if (keys.length === 0) return 'No scratch notes in this session.';
-          return `Scratch notes:\n${keys.map((k) => `  - ${k}`).join('\n')}`;
+          if (keys.length === 0) return ok('No scratch notes in this session.');
+          return ok(`Scratch notes:\n${keys.map((k) => `  - ${k}`).join('\n')}`);
         }
         case 'read': {
-          if (!key) return 'Error: key is required for read action.';
+          if (!key) return err({ type: 'invalid_args', message: 'key is required for read action.' });
           const value = memoryStore.readScratch(key);
-          if (value === null) return `No scratch note found for key "${key}".`;
-          return value;
+          if (value === null) return ok(`No scratch note found for key "${key}".`);
+          return ok(value);
         }
         case 'write': {
-          if (!key) return 'Error: key is required for write action.';
-          if (!content) return 'Error: content is required for write action.';
+          if (!key) return err({ type: 'invalid_args', message: 'key is required for write action.' });
+          if (!content)
+            return err({ type: 'invalid_args', message: 'content is required for write action.' });
           memoryStore.writeScratch(key, content);
-          return `Scratch note "${key}" saved.`;
+          return ok(`Scratch note "${key}" saved.`);
         }
         case 'delete': {
-          if (!key) return 'Error: key is required for delete action.';
+          if (!key) return err({ type: 'invalid_args', message: 'key is required for delete action.' });
           const deleted = memoryStore.deleteScratch(key);
-          if (!deleted) return `No scratch note found for key "${key}".`;
-          return `Scratch note "${key}" deleted.`;
+          if (!deleted) return ok(`No scratch note found for key "${key}".`);
+          return ok(`Scratch note "${key}" deleted.`);
         }
         default:
-          return `Unknown action: ${action}`;
+          return err({ type: 'invalid_args', message: `Unknown action: ${action}` });
       }
     },
-  });
+    serializeForModel: (r) => (r.status === 'ok' ? r.result : `Error: ${r.error.message}`),
+  };
 }

--- a/src/tools/shell.test.ts
+++ b/src/tools/shell.test.ts
@@ -115,28 +115,37 @@ describe('createShellTool', () => {
     confirmDangerous = vi.fn();
   });
 
-  it('executes a safe command and returns output', async () => {
+  it('executes a safe command and returns ok envelope', async () => {
     vi.mocked(execSync).mockReturnValue('hello world');
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    const result = await shellTool.execute({ command: 'echo hello' }, {} as any);
-    expect(result).toEqual({ output: 'hello world', is_error: false });
+    const result = await shellTool.execute({ command: 'echo hello' }, {});
+    expect(result).toEqual({
+      status: 'ok',
+      result: { output: 'hello world', is_error: false },
+    });
     expect(confirmDangerous).not.toHaveBeenCalled();
   });
 
   it('returns "(no output)" for empty stdout', async () => {
     vi.mocked(execSync).mockReturnValue('');
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    const result = await shellTool.execute({ command: 'true' }, {} as any);
-    expect(result).toEqual({ output: '(no output)', is_error: false });
+    const result = await shellTool.execute({ command: 'true' }, {});
+    expect(result).toEqual({
+      status: 'ok',
+      result: { output: '(no output)', is_error: false },
+    });
   });
 
   it('calls confirmDangerous for dangerous commands', async () => {
     confirmDangerous.mockResolvedValue(true);
     vi.mocked(execSync).mockReturnValue('done');
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    const result = await shellTool.execute({ command: 'rm -rf /tmp/test' }, {} as any);
+    const result = await shellTool.execute({ command: 'rm -rf /tmp/test' }, {});
     expect(confirmDangerous).toHaveBeenCalledWith('rm -rf /tmp/test', undefined);
-    expect(result).toEqual({ output: 'done', is_error: false });
+    expect(result).toEqual({
+      status: 'ok',
+      result: { output: 'done', is_error: false },
+    });
   });
 
   it('forwards the abort signal to confirmDangerous', async () => {
@@ -146,7 +155,7 @@ describe('createShellTool', () => {
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
     await shellTool.execute({ command: 'rm -rf /tmp/test' }, {
       abortSignal: controller.signal,
-    } as any);
+    });
     expect(confirmDangerous).toHaveBeenCalledWith('rm -rf /tmp/test', controller.signal);
   });
 
@@ -154,30 +163,52 @@ describe('createShellTool', () => {
     vi.mocked(execSync).mockReturnValue('');
     const tmpFile = `${BERNARD_TMP_PREFIX}task.sh`;
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    const result = await shellTool.execute({ command: `rm -f ${tmpFile}` }, {} as any);
+    const result = await shellTool.execute({ command: `rm -f ${tmpFile}` }, {});
     expect(confirmDangerous).not.toHaveBeenCalled();
     expect(execSync).toHaveBeenCalled();
-    expect(result.is_error).toBe(false);
+    expect(result.status).toBe('ok');
   });
 
-  it('cancels command when user declines', async () => {
+  it('cancels command when user declines (ok envelope, not error)', async () => {
     confirmDangerous.mockResolvedValue(false);
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    const result = await shellTool.execute({ command: 'rm -rf /tmp/test' }, {} as any);
-    expect(result).toEqual({ output: 'Command cancelled by user.', is_error: false });
+    const result = await shellTool.execute({ command: 'rm -rf /tmp/test' }, {});
+    expect(result).toEqual({
+      status: 'ok',
+      result: { output: 'Command cancelled by user.', is_error: false },
+    });
     expect(execSync).not.toHaveBeenCalled();
   });
 
-  it('returns error on command failure', async () => {
+  it('returns error envelope on command failure', async () => {
     vi.mocked(execSync).mockImplementation(() => {
-      const err = new Error('Command failed') as any;
-      err.stderr = 'permission denied';
-      err.stdout = '';
-      throw err;
+      const e = new Error('Command failed') as any;
+      e.stderr = 'permission denied';
+      e.stdout = '';
+      throw e;
     });
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    const result = await shellTool.execute({ command: 'cat /root/secret' }, {} as any);
-    expect(result.is_error).toBe(true);
-    expect(result.output).toContain('permission denied');
+    const result = await shellTool.execute({ command: 'cat /root/secret' }, {});
+    expect(result.status).toBe('error');
+    if (result.status === 'error') {
+      expect(result.error.type).toBe('exec_failed');
+      expect(result.error.message).toContain('permission denied');
+      expect(result.error.snippet).toContain('permission denied');
+    }
+  });
+
+  it('serializeForModel preserves {output, is_error} bytes on ok and error', async () => {
+    const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
+    const okOut = shellTool.serializeForModel({
+      status: 'ok',
+      result: { output: 'hello', is_error: false },
+    });
+    expect(okOut).toEqual({ output: 'hello', is_error: false });
+
+    const errOut = shellTool.serializeForModel({
+      status: 'error',
+      error: { type: 'exec_failed', message: 'permission denied' },
+    });
+    expect(errOut).toEqual({ output: 'permission denied', is_error: true });
   });
 });

--- a/src/tools/shell.test.ts
+++ b/src/tools/shell.test.ts
@@ -153,9 +153,12 @@ describe('createShellTool', () => {
     vi.mocked(execSync).mockReturnValue('done');
     const controller = new AbortController();
     const shellTool = createShellTool({ shellTimeout: 30000, confirmDangerous });
-    await shellTool.execute({ command: 'rm -rf /tmp/test' }, {
-      abortSignal: controller.signal,
-    });
+    await shellTool.execute(
+      { command: 'rm -rf /tmp/test' },
+      {
+        abortSignal: controller.signal,
+      },
+    );
     expect(confirmDangerous).toHaveBeenCalledWith('rm -rf /tmp/test', controller.signal);
   });
 

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,9 +1,10 @@
-import { tool } from 'ai';
 import { z } from 'zod';
 import { execSync } from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ToolOptions, ShellResult } from './types.js';
+import type { BernardTool } from '../framework/tools/types.js';
+import { ok, err } from '../framework/tools/types.js';
 
 const DANGEROUS_PATTERNS = [
   /\brm\s+(-[^\s]*\s+)*-[^\s]*r/, // rm with -r flag
@@ -79,26 +80,36 @@ export function isSafelisted(command: string): boolean {
   });
 }
 
+const SHELL_DESCRIPTION =
+  'Execute a shell command in the current working directory and return its output. Use this for git commands, running scripts, and any terminal task. For reading and editing files, prefer file_read_lines and file_edit_lines.';
+
+const SHELL_PARAMETERS = z.object({
+  command: z.string().describe('The shell command to execute'),
+});
+
+type ShellArgs = z.infer<typeof SHELL_PARAMETERS>;
+
 /**
  * Creates the shell execution tool that runs commands in the user's terminal.
  *
  * Dangerous commands are intercepted and require explicit user confirmation
  * before execution, unless they match a safelist of Bernard-owned operations.
  *
+ * Returns a {@link BernardTool}; the AI-SDK adapter preserves the historical
+ * `{output, is_error}` shape via `serializeForModel`.
+ *
  * @param options - Shell timeout and dangerous-command confirmation callback.
  */
-export function createShellTool(options: ToolOptions) {
-  return tool({
-    description:
-      'Execute a shell command in the current working directory and return its output. Use this for git commands, running scripts, and any terminal task. For reading and editing files, prefer file_read_lines and file_edit_lines.',
-    parameters: z.object({
-      command: z.string().describe('The shell command to execute'),
-    }),
-    execute: async ({ command }, execOptions): Promise<ShellResult> => {
+export function createShellTool(options: ToolOptions): BernardTool<ShellArgs, ShellResult> {
+  return {
+    meta: { name: 'shell', kind: 'dangerous', category: 'shell' },
+    description: SHELL_DESCRIPTION,
+    parameters: SHELL_PARAMETERS,
+    execute: async ({ command }, execOptions) => {
       if (isDangerous(command) && !isSafelisted(command)) {
         const confirmed = await options.confirmDangerous(command, execOptions?.abortSignal);
         if (!confirmed) {
-          return { output: 'Command cancelled by user.', is_error: false };
+          return ok({ output: 'Command cancelled by user.', is_error: false });
         }
       }
 
@@ -109,15 +120,17 @@ export function createShellTool(options: ToolOptions) {
           maxBuffer: 1024 * 1024 * 10, // 10MB
           stdio: ['pipe', 'pipe', 'pipe'],
         });
-        return { output: stdout || '(no output)', is_error: false };
-      } catch (err: unknown) {
-        const execError = err as { stderr?: string; stdout?: string; message?: string };
+        return ok({ output: stdout || '(no output)', is_error: false });
+      } catch (e: unknown) {
+        const execError = e as { stderr?: string; stdout?: string; message?: string };
         const stderr = execError.stderr || '';
         const stdout = execError.stdout || '';
         const output =
           [stdout, stderr].filter(Boolean).join('\n') || execError.message || 'Command failed';
-        return { output, is_error: true };
+        return err({ type: 'exec_failed', message: output, snippet: output.slice(0, 200) });
       }
     },
-  });
+    serializeForModel: (r) =>
+      r.status === 'ok' ? r.result : { output: r.error.message, is_error: true },
+  };
 }

--- a/src/tools/task.test.ts
+++ b/src/tools/task.test.ts
@@ -257,11 +257,11 @@ describe('task tool', () => {
   it('returns structured JSON on success', async () => {
     mockGenerateText.mockResolvedValue({ text: '{"status":"success","output":"found 3 files"}' });
     const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
-    const result = await taskTool.execute!(
+    const envelope = await taskTool.execute(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
     );
-    const parsed = JSON.parse(result);
+    const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
     expect(parsed.status).toBe('success');
     expect(parsed.output).toBe('found 3 files');
   });
@@ -269,11 +269,11 @@ describe('task tool', () => {
   it('returns error for non-JSON output', async () => {
     mockGenerateText.mockResolvedValue({ text: 'Just some plain text response' });
     const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
-    const result = await taskTool.execute!(
+    const envelope = await taskTool.execute(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
     );
-    const parsed = JSON.parse(result);
+    const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
     expect(parsed.status).toBe('error');
     expect(parsed.output).toBe('Task did not produce valid structured output');
     expect(parsed.details).toBe('Just some plain text response');
@@ -282,11 +282,11 @@ describe('task tool', () => {
   it('returns error JSON on API failure (does not throw)', async () => {
     mockGenerateText.mockRejectedValue(new Error('API rate limit'));
     const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
-    const result = await taskTool.execute!(
+    const envelope = await taskTool.execute(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
     );
-    const parsed = JSON.parse(result);
+    const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
     expect(parsed.status).toBe('error');
     expect(parsed.output).toContain('API rate limit');
   });
@@ -309,8 +309,8 @@ describe('task tool', () => {
     );
 
     // 5th should hit the limit
-    const result = await taskTool.execute!({ task: 'overflow' }, execOptions);
-    const parsed = JSON.parse(result);
+    const envelope = await taskTool.execute({ task: 'overflow' }, execOptions);
+    const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
     expect(parsed.status).toBe('error');
     expect(parsed.output).toContain('Maximum concurrent agents');
 
@@ -456,12 +456,12 @@ describe('task tool', () => {
     const taskTool = createTaskTool(
       makeCtx(makeConfig(), toolOptions, memoryStore, { rag: mockRagStore as any }),
     );
-    const result = await taskTool.execute!(
+    const envelope = await taskTool.execute(
       { task: 'test' },
       { toolCallId: '1', messages: [], abortSignal: undefined as any },
     );
 
-    const parsed = JSON.parse(result);
+    const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
     expect(parsed.status).toBe('success');
     expect(parsed.output).toBe('done');
   });
@@ -522,12 +522,12 @@ describe('task tool', () => {
 
     it('returns error JSON when override provider has no API key', async () => {
       const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
-      const result = await taskTool.execute!(
+      const envelope = await taskTool.execute(
         { task: 'test', provider: 'xai' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      const parsed = JSON.parse(result);
+      const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
       expect(parsed.status).toBe('error');
       expect(parsed.output).toContain('No API key found');
       expect(parsed.output).toContain('xai');
@@ -565,12 +565,12 @@ describe('task tool', () => {
       const taskTool = createTaskTool(
         makeCtx(makeConfig(), toolOptions, memoryStore, { routines: routineStore }),
       );
-      const result = await taskTool.execute!(
+      const envelope = await taskTool.execute(
         { task: 'task-nonexistent', taskId: 'task-nonexistent' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      const parsed = JSON.parse(result);
+      const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
       expect(parsed.status).toBe('error');
       expect(parsed.output).toContain('not found');
       expect(mockGenerateText).not.toHaveBeenCalled();
@@ -600,12 +600,12 @@ describe('task tool', () => {
 
     it('returns error when taskId references a routine that does not exist', async () => {
       const taskTool = createTaskTool(makeCtx(makeConfig(), toolOptions, memoryStore));
-      const result = await taskTool.execute!(
+      const envelope = await taskTool.execute(
         { taskId: 'task-check-issues' },
         { toolCallId: '1', messages: [], abortSignal: undefined as any },
       );
 
-      const parsed = JSON.parse(result);
+      const parsed = JSON.parse(taskTool.serializeForModel(envelope) as string);
       expect(parsed.status).toBe('error');
       expect(parsed.output).toContain('not found');
       expect(mockGenerateText).not.toHaveBeenCalled();

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -184,7 +184,9 @@ function serializeTaskForModel(r: ToolResult<TaskPayload>): string {
   if (r.status === 'ok') {
     const { innerStatus, output, details } = r.result;
     return JSON.stringify(
-      details !== undefined ? { status: innerStatus, output, details } : { status: innerStatus, output },
+      details !== undefined
+        ? { status: innerStatus, output, details }
+        : { status: innerStatus, output },
     );
   }
   return JSON.stringify({ status: 'error', output: r.error.message });

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -1,4 +1,4 @@
-import { generateText, tool } from 'ai';
+import { generateText } from 'ai';
 import { z } from 'zod';
 import { getModelForConfig, getProviderOptionsForConfig } from '../providers/index.js';
 import { createTools } from './index.js';
@@ -15,6 +15,8 @@ import { buildMemoryContext } from '../memory-context.js';
 import { acquireSlot, releaseSlot, MAX_CONCURRENT_AGENTS } from './agent-pool.js';
 import { type BernardConfig, resolveProviderAndModel } from '../config.js';
 import type { AgentContext } from '../framework/context.js';
+import type { BernardTool, ToolResult } from '../framework/tools/types.js';
+import { ok, err } from '../framework/tools/types.js';
 
 export const TASK_SYSTEM_PROMPT = `You are a task executor for Bernard, a CLI AI assistant. You have been given a focused, isolated task.
 
@@ -122,54 +124,91 @@ export function wrapTaskResult(text: string): TaskResult {
  * agent/task tools (preventing recursion). The final step forces text-only output
  * via `experimental_prepareStep` to ensure structured JSON is produced.
  */
-export function createTaskTool(ctx: AgentContext) {
+/**
+ * Internal payload carried inside the {@link ToolResult} envelope. The
+ * model-facing serializer reshapes this into the historical
+ * `{status: 'success'|'error', output, details?}` JSON.
+ *
+ * Important: the task tool returns an `ok` envelope even when `innerStatus`
+ * is `'error'`. That distinction (the *task* reported failure vs. the *tool*
+ * itself failed to run) keeps tool-execution errors (slot exhausted, API
+ * failure) on the envelope-error path while preserving today's full bytes
+ * (`{status:"error",output:...,details:...}`) for the model.
+ */
+export interface TaskPayload {
+  innerStatus: 'success' | 'error';
+  output: any;
+  details?: string;
+}
+
+const TASK_PARAMETERS = z
+  .object({
+    task: z
+      .string()
+      .optional()
+      .describe(
+        'A self-contained task description. Include specific objective, expected output, exact file paths or commands, and success criteria. The task executor has zero prior context.',
+      ),
+    taskId: z
+      .string()
+      .optional()
+      .describe(
+        'ID of a saved task (task-prefixed routine) to execute. Loads stored task content as the primary description.',
+      ),
+    context: z.string().optional().describe('Optional additional context for the task'),
+    provider: z
+      .string()
+      .optional()
+      .describe(
+        'Optional provider override for this task (e.g. "xai"). Falls back to global config.',
+      ),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        'Optional model override for this task (e.g. "grok-code-fast-1"). Falls back to global config.',
+      ),
+  })
+  .refine((data) => data.task || data.taskId, {
+    message: 'Either task or taskId must be provided',
+  });
+
+type TaskArgs = z.infer<typeof TASK_PARAMETERS>;
+
+/**
+ * Serializes a task envelope back to the historical JSON bytes the model has
+ * seen since the tool was introduced: `{"status":"success"|"error","output":...,"details"?:...}`.
+ * The envelope is internal-only; the model never sees `{status:"ok",result:{...}}`.
+ */
+function serializeTaskForModel(r: ToolResult<TaskPayload>): string {
+  if (r.status === 'ok') {
+    const { innerStatus, output, details } = r.result;
+    return JSON.stringify(
+      details !== undefined ? { status: innerStatus, output, details } : { status: innerStatus, output },
+    );
+  }
+  return JSON.stringify({ status: 'error', output: r.error.message });
+}
+
+export function createTaskTool(ctx: AgentContext): BernardTool<TaskArgs, TaskPayload> {
   const { config } = ctx;
   const options = ctx.toolOptions;
   const memoryStore = ctx.stores.memory;
   const mcpTools = ctx.mcp.tools;
   const ragStore = ctx.rag;
   const routineStore = ctx.stores.routines;
-  return tool({
+  return {
+    meta: { name: 'task', kind: 'read' },
     description:
       'Execute a focused, isolated task with structured JSON output {status, output, details?}. Tasks have no conversation history and a limited step budget. Use when you need a discrete, machine-readable result — especially during routine execution for chaining outcomes.',
-    parameters: z
-      .object({
-        task: z
-          .string()
-          .optional()
-          .describe(
-            'A self-contained task description. Include specific objective, expected output, exact file paths or commands, and success criteria. The task executor has zero prior context.',
-          ),
-        taskId: z
-          .string()
-          .optional()
-          .describe(
-            'ID of a saved task (task-prefixed routine) to execute. Loads stored task content as the primary description.',
-          ),
-        context: z.string().optional().describe('Optional additional context for the task'),
-        provider: z
-          .string()
-          .optional()
-          .describe(
-            'Optional provider override for this task (e.g. "xai"). Falls back to global config.',
-          ),
-        model: z
-          .string()
-          .optional()
-          .describe(
-            'Optional model override for this task (e.g. "grok-code-fast-1"). Falls back to global config.',
-          ),
-      })
-      .refine((data) => data.task || data.taskId, {
-        message: 'Either task or taskId must be provided',
-      }),
+    parameters: TASK_PARAMETERS,
     execute: async ({ task, taskId, context, provider, model }, execOptions) => {
       const resolution = resolveProviderAndModel({ provider, model, config });
       if (!resolution.ok) {
         const envHint = resolution.isCustom ? '' : ` or set ${resolution.envVar}`;
-        return JSON.stringify({
-          status: 'error',
-          output: `No API key found for provider "${resolution.provider}". Run: bernard add-key ${resolution.provider} <your-api-key>${envHint}.`,
+        return err({
+          type: 'invalid_args',
+          message: `No API key found for provider "${resolution.provider}". Run: bernard add-key ${resolution.provider} <your-api-key>${envHint}.`,
         });
       }
       const { provider: resolvedProvider, model: resolvedModel } = resolution;
@@ -178,9 +217,9 @@ export function createTaskTool(ctx: AgentContext) {
       let resolvedTask = task ?? '';
       if (taskId) {
         if (!routineStore) {
-          return JSON.stringify({
-            status: 'error',
-            output: 'taskId provided but routine store is not available.',
+          return err({
+            type: 'invalid_args',
+            message: 'taskId provided but routine store is not available.',
           });
         }
         const routine = routineStore.get(taskId);
@@ -191,18 +230,15 @@ export function createTaskTool(ctx: AgentContext) {
             resolvedTask += `\n\nAdditional context: ${task}`;
           }
         } else {
-          return JSON.stringify({
-            status: 'error',
-            output: `Saved task "${taskId}" not found.`,
-          });
+          return err({ type: 'invalid_args', message: `Saved task "${taskId}" not found.` });
         }
       }
 
       const slot = acquireSlot();
       if (!slot) {
-        return JSON.stringify({
-          status: 'error',
-          output: `Maximum concurrent agents (${MAX_CONCURRENT_AGENTS}) reached. Wait for existing agents to finish.`,
+        return err({
+          type: 'exec_failed',
+          message: `Maximum concurrent agents (${MAX_CONCURRENT_AGENTS}) reached. Wait for existing agents to finish.`,
         });
       }
 
@@ -230,8 +266,8 @@ export function createTaskTool(ctx: AgentContext) {
                 results: ragResults.length,
               });
             }
-          } catch (err) {
-            debugLog('task:rag:error', err instanceof Error ? err.message : String(err));
+          } catch (e) {
+            debugLog('task:rag:error', e instanceof Error ? e.message : String(e));
           }
         }
 
@@ -271,16 +307,30 @@ export function createTaskTool(ctx: AgentContext) {
         });
 
         const taskResult = wrapTaskResult(result.text);
-        printTaskEnd(JSON.stringify(taskResult));
-        return JSON.stringify(taskResult);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        const errorResult: TaskResult = { status: 'error', output: message };
-        printTaskEnd(JSON.stringify(errorResult));
-        return JSON.stringify(errorResult);
+        // The task reported success or error — both are carried inside an
+        // `ok` envelope; the inner status is preserved for the model via
+        // serializeForModel. Envelope-level error is reserved for genuine
+        // tool-execution failures (slot, API, missing routine, etc.).
+        const envelope = ok<TaskPayload>(
+          taskResult.details !== undefined
+            ? {
+                innerStatus: taskResult.status,
+                output: taskResult.output,
+                details: taskResult.details,
+              }
+            : { innerStatus: taskResult.status, output: taskResult.output },
+        );
+        printTaskEnd(serializeTaskForModel(envelope));
+        return envelope;
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        const errEnvelope = err<TaskPayload>({ type: 'exec_failed', message });
+        printTaskEnd(serializeTaskForModel(errEnvelope));
+        return errEnvelope;
       } finally {
         releaseSlot();
       }
     },
-  });
+    serializeForModel: serializeTaskForModel,
+  };
 }

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -4,6 +4,7 @@ import { getModelForConfig, getProviderOptionsForConfig } from '../providers/ind
 import { createTools, type ToolOptions } from './index.js';
 import { createSubAgentTool } from './subagent.js';
 import { createTaskTool } from './task.js';
+import { toolToAISDK } from '../framework/tools/adapter.js';
 import { createSpecialistRunTool } from './specialist-run.js';
 import { makeLastStepTextOnly } from './task.js';
 import {
@@ -282,7 +283,7 @@ export async function dispatchToolWrapper(
     const fullRegistry: Record<string, any> = {
       ...baseTools,
       agent: createSubAgentTool(innerCtx),
-      task: createTaskTool(innerCtx),
+      task: toolToAISDK(createTaskTool(innerCtx)),
       specialist_run: createSpecialistRunTool(innerCtx),
       tool_wrapper_run: createToolWrapperRunTool(innerCtx),
     };


### PR DESCRIPTION
## Summary

Phase B of the framework refactor epic (#155). Introduces the `BernardTool<TArgs, TData>` interface and `ToolResult<T>` discriminated union envelope, migrates 3 pilots (shell, memory, task), and rewrites `augment.ts` to use the envelope discriminator for native tools. Zero observable change to the model — each migrated tool's `serializeForModel` reproduces today's exact bytes.

## What's new

- **`src/framework/tools/`**: `types.ts` (envelope + `ToolMeta` + `ToolError`), `adapter.ts` (`toolToAISDK`, `legacyTool`, `readToolMeta`, `readBernardSource`), `registry.ts` (`ToolRegistry.byMetadata`), `mcp.ts` (`wrapMCPTool` — the one place that retains heuristic error detection at the MCP boundary).
- **Pilots migrated**: `shell` (`kind: 'dangerous'`), `memory` + `scratch` (`kind: 'write'`), `task` (`kind: 'read'`). Side-channel `__bernardMeta` + `__bernardSource` attached to the AI-SDK `Tool` so the augmentation layer and the registry can read metadata without holding a separate reference.
- **`augment.ts`**: Migrated tools now use the envelope discriminator directly (no `detectToolError` call). Legacy / MCP tools keep the heuristic path. Bad-example recording remains in `setImmediate` with a try/catch so a thrown detector never breaks tool execution.
- **`reference-tool-lookup.ts`**: Candidate selection now unions the existing suffix-pattern allowlist with `readToolMeta(tool)?.kind === 'read'`. Day-one behavior change is additive — only `task` carries `kind: 'read'` today.

## Byte identity

The model sees the same bytes as before for every migrated tool:
- shell: `{output, is_error}` (was `ShellResult`)
- memory: plain string success, `Error: ...` prefix on failure
- task: `JSON.stringify({status, output, details?})`

Verified by the new `src/framework/tools/__tests__/adapter.test.ts` and the updated per-tool tests.

## Out of scope (deferred)

- Migrating the other 12 tools — staged in subsequent PRs after the standard proves out.
- Deleting the suffix-pattern allowlist in `reference-tool-lookup.ts` — deferred until ≥80% of tools carry `meta.kind`.
- Flipping the model-facing shape to the canonical envelope (single-scoped future PR once all serializers degenerate to `JSON.stringify(envelope)`).
- Phases C–E (AgentRunner, ExecutionStrategy, AgentDefinition) — separate PRs.

## Test plan

- [x] `npm test` — 2188/2188 pass
- [x] `npm run lint` — 0 errors (138 pre-existing warnings unchanged)
- [x] `npm run build` — clean
- [ ] REPL smoke walk: `shell ls`, missing memory key (verify `Error:` prefix), `task` dispatch (verify JSON shape), wrapper-routed `shell` (verify `{output, is_error}` survives the shim → augment composition)
- [ ] MCP smoke walk: connect a real MCP server and call one read tool through `wrapMCPTool`

Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)