### PR TITLE
Cap plan step strings at 400 chars and add repair hint (#150)

### DIFF
--- a/src/tool-call-repair.test.ts
+++ b/src/tool-call-repair.test.ts
@@ -183,6 +183,31 @@ describe('makeRepairHook', () => {
     expect(result).not.toBeNull();
   });
 
+  it('hints at single-line short entries when the plan tool fails to parse', async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      toolCalls: [{ toolName: 'plan', args: { action: 'view' } }],
+    } as any);
+
+    const ctx = makeRepairContext({
+      toolCall: { toolCallId: 'tc-plan', toolName: 'plan', args: 'broken' },
+      tools: { plan: { description: 'plan' } },
+      error: new (InvalidToolArgumentsError as any)(
+        "Invalid arguments for tool plan: JSON parsing failed: Expected ',' or '}' after property value in JSON at position 14399",
+      ),
+    });
+
+    const hook = makeRepairHook({ config: makeConfig(), label: 'main' });
+    await hook(ctx as any);
+
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as any;
+    const userMessage = callArgs.messages[callArgs.messages.length - 1];
+    expect(userMessage.content).toMatch(/single line/i);
+    expect(userMessage.content).toMatch(/newlines/i);
+    expect(userMessage.content).toMatch(/split/i);
+    // Should not fall through to the generic file_write truncation hint.
+    expect(userMessage.content).not.toMatch(/file_write/);
+  });
+
   it('only invokes generateText once per failed tool call (no looping)', async () => {
     vi.mocked(generateText).mockResolvedValue({
       toolCalls: [{ toolName: 'shell', args: { command: 'ls' } }],

--- a/src/tool-call-repair.ts
+++ b/src/tool-call-repair.ts
@@ -66,7 +66,10 @@ export function makeRepairHook<TOOLS extends ToolSet>(
       const isNoSuchTool = NoSuchToolError.isInstance(error);
 
       let hint = '';
-      if (isInvalidArgs && looksLikeTruncationError(errorMessage)) {
+      if (isInvalidArgs && toolCall.toolName === 'plan') {
+        hint =
+          "\n\nThe `plan` tool requires each step's `description` and `verification` to be a single line of plain text with no embedded newlines (JSON forbids literal newlines inside string values — they must be escaped as `\\n`). Re-emit the call with short, single-line entries (under ~400 characters each). If a step needs more detail, split it into multiple smaller steps rather than packing a multi-line blob into one entry.";
+      } else if (isInvalidArgs && looksLikeTruncationError(errorMessage)) {
         hint =
           '\n\nThe arguments appear to have been truncated mid-string. For payloads larger than ~1 KB (file contents, scripts, JSON bodies), write the content to a file using `file_write` (or save a script with `file_write` and execute it with `shell`) instead of inlining it as a tool-call argument.';
       } else if (isNoSuchTool) {

--- a/src/tool-call-repair.ts
+++ b/src/tool-call-repair.ts
@@ -68,7 +68,7 @@ export function makeRepairHook<TOOLS extends ToolSet>(
       let hint = '';
       if (isInvalidArgs && toolCall.toolName === 'plan') {
         hint =
-          "\n\nThe `plan` tool requires each step's `description` and `verification` to be a single line of plain text with no embedded newlines (JSON forbids literal newlines inside string values — they must be escaped as `\\n`). Re-emit the call with short, single-line entries (under ~400 characters each). If a step needs more detail, split it into multiple smaller steps rather than packing a multi-line blob into one entry.";
+          "\n\nThe `plan` tool requires each step's `description` and `verification` to be a single line of plain text with NO newlines of any kind — neither literal line breaks (which JSON forbids inside string values) nor escaped `\\n` sequences. Re-emit the call with short, single-line entries (under ~400 characters each). If a step needs more detail, split it into multiple smaller steps rather than packing a multi-line blob into one entry.";
       } else if (isInvalidArgs && looksLikeTruncationError(errorMessage)) {
         hint =
           '\n\nThe arguments appear to have been truncated mid-string. For payloads larger than ~1 KB (file contents, scripts, JSON bodies), write the content to a file using `file_write` (or save a script with `file_write` and execute it with `shell`) instead of inlining it as a tool-call argument.';

--- a/src/tools/plan.test.ts
+++ b/src/tools/plan.test.ts
@@ -148,6 +148,47 @@ describe('plan tool', () => {
     expect(parsed.success).toBe(false);
   });
 
+  it('rejects create with description exceeding 400 chars at the schema layer', () => {
+    const tooLong = 'x'.repeat(401);
+    const parsed = tool.parameters.safeParse({
+      action: 'create',
+      steps: [{ description: tooLong, verification: 'check it' }],
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(
+        parsed.error.issues.some((i) =>
+          /description must be at most 400 characters/.test(i.message),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('rejects create with verification exceeding 400 chars at the schema layer', () => {
+    const tooLong = 'y'.repeat(401);
+    const parsed = tool.parameters.safeParse({
+      action: 'create',
+      steps: [{ description: 'do a thing', verification: tooLong }],
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(
+        parsed.error.issues.some((i) =>
+          /verification must be at most 400 characters/.test(i.message),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('accepts description and verification exactly at the 400-char limit', () => {
+    const atLimit = 'z'.repeat(400);
+    const parsed = tool.parameters.safeParse({
+      action: 'create',
+      steps: [{ description: atLimit, verification: atLimit }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
   it('skips re-printing when repeated view actions yield identical render', async () => {
     await run({ action: 'create', steps: [s('a'), s('b')] });
     expect(printPlan).toHaveBeenCalledTimes(1);

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -11,14 +11,14 @@ const stepInputSchema = z.object({
     .min(1, 'description must not be empty')
     .max(STEP_FIELD_MAX, `description must be at most ${STEP_FIELD_MAX} characters`)
     .describe(
-      `What this step accomplishes. Single line of plain text — no embedded newlines, no code blocks. Keep under ${STEP_FIELD_MAX} characters; split long steps into multiple smaller steps.`,
+      `What this step accomplishes. Single line of plain text — no newlines (neither literal nor escaped as \\n), no code blocks. Keep under ${STEP_FIELD_MAX} characters; split long steps into multiple smaller steps.`,
     ),
   verification: z
     .string()
     .min(1, 'verification must not be empty')
     .max(STEP_FIELD_MAX, `verification must be at most ${STEP_FIELD_MAX} characters`)
     .describe(
-      `Concrete check that proves the step succeeded — a command to run, a file to read, a URL to GET, an output substring to look for. Must be observable, not subjective. Single line of plain text — no embedded newlines, no code blocks. Keep under ${STEP_FIELD_MAX} characters.`,
+      `Concrete check that proves the step succeeded — a command to run, a file to read, a URL to GET, an output substring to look for. Must be observable, not subjective. Single line of plain text — no newlines (neither literal nor escaped as \\n), no code blocks. Keep under ${STEP_FIELD_MAX} characters.`,
     ),
 });
 
@@ -43,8 +43,7 @@ export function createPlanTool(planStore: PlanStore) {
   };
 
   return tool({
-    description:
-      "Track and manage a structured plan for the current turn. Required in coordinator mode. Each step has a `verification` criterion (set at creation) describing how you'll prove it succeeded. Actions: 'create' seeds a plan with step objects {description, verification}; 'add' appends one such step; 'update' transitions a step's status; 'view' shows the plan. Marking 'done' requires `signoff` (attesting verification was performed). Marking 'cancelled' or 'error' requires `note` (the reason). The plan is visible to the user. Each `description` and `verification` must be a single line of plain text — no embedded newlines, no code blocks, no multi-paragraph prose. Keep each entry under ~400 characters; if a step needs more context, split it into multiple smaller steps.",
+    description: `Track and manage a structured plan for the current turn. Required in coordinator mode. Each step has a \`verification\` criterion (set at creation) describing how you'll prove it succeeded. Actions: 'create' seeds a plan with step objects {description, verification}; 'add' appends one such step; 'update' transitions a step's status; 'view' shows the plan. Marking 'done' requires \`signoff\` (attesting verification was performed). Marking 'cancelled' or 'error' requires \`note\` (the reason). The plan is visible to the user. Each \`description\` and \`verification\` must be a single line of plain text — no newlines (neither literal nor escaped as \\n), no code blocks, no multi-paragraph prose. Keep each entry under ${STEP_FIELD_MAX} characters; if a step needs more context, split it into multiple smaller steps.`,
     parameters: z.object({
       action: z.enum(['create', 'update', 'add', 'view']).describe('The action to perform'),
       steps: z

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -3,16 +3,22 @@ import { z } from 'zod';
 import type { PlanStore } from '../plan-store.js';
 import { printPlan } from '../output.js';
 
+const STEP_FIELD_MAX = 400;
+
 const stepInputSchema = z.object({
   description: z
     .string()
     .min(1, 'description must not be empty')
-    .describe('What this step accomplishes.'),
+    .max(STEP_FIELD_MAX, `description must be at most ${STEP_FIELD_MAX} characters`)
+    .describe(
+      `What this step accomplishes. Single line of plain text — no embedded newlines, no code blocks. Keep under ${STEP_FIELD_MAX} characters; split long steps into multiple smaller steps.`,
+    ),
   verification: z
     .string()
     .min(1, 'verification must not be empty')
+    .max(STEP_FIELD_MAX, `verification must be at most ${STEP_FIELD_MAX} characters`)
     .describe(
-      'Concrete check that proves the step succeeded — a command to run, a file to read, a URL to GET, an output substring to look for. Must be observable, not subjective.',
+      `Concrete check that proves the step succeeded — a command to run, a file to read, a URL to GET, an output substring to look for. Must be observable, not subjective. Single line of plain text — no embedded newlines, no code blocks. Keep under ${STEP_FIELD_MAX} characters.`,
     ),
 });
 
@@ -38,7 +44,7 @@ export function createPlanTool(planStore: PlanStore) {
 
   return tool({
     description:
-      "Track and manage a structured plan for the current turn. Required in coordinator mode. Each step has a `verification` criterion (set at creation) describing how you'll prove it succeeded. Actions: 'create' seeds a plan with step objects {description, verification}; 'add' appends one such step; 'update' transitions a step's status; 'view' shows the plan. Marking 'done' requires `signoff` (attesting verification was performed). Marking 'cancelled' or 'error' requires `note` (the reason). The plan is visible to the user.",
+      "Track and manage a structured plan for the current turn. Required in coordinator mode. Each step has a `verification` criterion (set at creation) describing how you'll prove it succeeded. Actions: 'create' seeds a plan with step objects {description, verification}; 'add' appends one such step; 'update' transitions a step's status; 'view' shows the plan. Marking 'done' requires `signoff` (attesting verification was performed). Marking 'cancelled' or 'error' requires `note` (the reason). The plan is visible to the user. Each `description` and `verification` must be a single line of plain text — no embedded newlines, no code blocks, no multi-paragraph prose. Keep each entry under ~400 characters; if a step needs more context, split it into multiple smaller steps.",
     parameters: z.object({
       action: z.enum(['create', 'update', 'add', 'view']).describe('The action to perform'),
       steps: z


### PR DESCRIPTION
## Summary

- Adds `.max(400)` to the `plan` tool's step `description` and `verification` fields and tightens their `.describe()` / tool-level description with explicit "single line, no embedded newlines, split long steps" guidance, so the model is steered away from emitting the multi-thousand-character single-string blobs that triggered the `JSON parsing failed` death in #150.
- Adds a `plan`-specific branch to `makeRepairHook` (ordered before the generic truncation/`file_write` hint), so when the SDK throws `InvalidToolArgumentsError` on a `plan` call the recovery prompt tells the model to re-emit short, single-line steps rather than (incorrectly) suggesting it write the plan to a file.
- Backs both changes with unit tests: schema accepts at the 400-char boundary, rejects 401+ for both fields, and the repair hook emits the new hint (and NOT the `file_write` fallback) for plan parse failures.

Fixes #150.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run src/tools/plan.test.ts src/tool-call-repair.test.ts` — 31 passing
- [x] `npm run format` — no diff
- [ ] Manual REPL repro with `BERNARD_REACT_MODE=true` and the bug-report prompt, confirming the turn completes without `Agent error: Invalid arguments for tool plan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)