### PR TITLE
feat(provider): opt-in --provider-base-url override for built-ins (closes #151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ When the active provider is custom, the welcome banner prints an extra `Endpoint
 
 Reserved names: `anthropic`, `openai`, `xai` (these are the built-ins). Custom-provider keys are stored in `keys.json` and are **not** read from environment variables.
 
+### One-shot Base URL Override
+
+For ephemeral routing — testing an OpenAI-compatible gateway, a staging endpoint, or an internal proxy without registering a custom provider — you can override a built-in provider's base URL for a single session:
+
+```bash
+bernard -p openai \
+  --allow-provider-base-url \
+  --provider-base-url https://proxy.company.internal/v1
+```
+
+Rules:
+
+- Both flags are required. Passing `--provider-base-url` without `--allow-provider-base-url` is rejected with a clear error. The opt-in guard exists so a stray flag (e.g. left in shell history) cannot silently re-route your traffic.
+- The URL must be `http://` or `https://`.
+- The override only applies to built-in providers (`anthropic`, `openai`, `xai`). Combining it with a custom provider is rejected — custom providers already define their own base URL, edit them with `bernard add-provider`.
+- The override is **not** persisted to preferences or env. It is in effect only for the process started with that command. For a durable named endpoint, use `bernard add-provider` instead.
+
+The welcome banner shows the overridden URL on the `Endpoint:` line so it's obvious which endpoint the session is talking to.
+
 ### Environment Variables
 
 Bernard loads `.env` from the current directory first, then falls back to `~/.bernard/.env`.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -467,6 +467,111 @@ describe('loadConfig', () => {
   });
 });
 
+describe('loadConfig providerBaseUrl override', () => {
+  beforeEach(() => {
+    fsMock.existsSync.mockReturnValue(false);
+    fsMock.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai-test');
+    vi.stubEnv('XAI_API_KEY', '');
+    vi.stubEnv('BERNARD_PROVIDER', '');
+    vi.stubEnv('BERNARD_MODEL', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when neither flag is supplied', () => {
+    const config = loadConfig({ provider: 'openai' });
+    expect(config.providerBaseUrl).toBeUndefined();
+  });
+
+  it('is a no-op when only --allow-provider-base-url is supplied (no URL)', () => {
+    const config = loadConfig({ provider: 'openai', allowProviderBaseUrl: true });
+    expect(config.providerBaseUrl).toBeUndefined();
+  });
+
+  it('rejects --provider-base-url without --allow-provider-base-url', () => {
+    expect(() =>
+      loadConfig({ provider: 'openai', providerBaseUrl: 'https://proxy.example/v1' }),
+    ).toThrow(/--allow-provider-base-url/);
+  });
+
+  it('rejects an empty URL even with opt-in', () => {
+    expect(() =>
+      loadConfig({
+        provider: 'openai',
+        providerBaseUrl: '',
+        allowProviderBaseUrl: true,
+      }),
+    ).toThrow(/--provider-base-url:/);
+  });
+
+  it('rejects a non-URL string', () => {
+    expect(() =>
+      loadConfig({
+        provider: 'openai',
+        providerBaseUrl: 'not-a-url',
+        allowProviderBaseUrl: true,
+      }),
+    ).toThrow(/not a valid URL/);
+  });
+
+  it('rejects a non-http(s) URL', () => {
+    expect(() =>
+      loadConfig({
+        provider: 'openai',
+        providerBaseUrl: 'ftp://proxy.example/v1',
+        allowProviderBaseUrl: true,
+      }),
+    ).toThrow(/http or https/);
+  });
+
+  it('accepts a valid URL and trims whitespace', () => {
+    const config = loadConfig({
+      provider: 'openai',
+      providerBaseUrl: '  https://proxy.example/v1  ',
+      allowProviderBaseUrl: true,
+    });
+    expect(config.providerBaseUrl).toBe('https://proxy.example/v1');
+  });
+
+  it('rejects the override when the active provider is custom', () => {
+    fsMock.readFileSync.mockImplementation((p: unknown) => {
+      if (typeof p === 'string' && p.endsWith('custom-providers.json')) {
+        return JSON.stringify({
+          providers: {
+            mygw: {
+              name: 'mygw',
+              sdk: 'openai',
+              baseURL: 'https://gw.example/v1',
+              defaultModel: 'gpt-4o',
+              models: ['gpt-4o'],
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        });
+      }
+      if (typeof p === 'string' && p.endsWith('keys.json')) {
+        return JSON.stringify({ mygw: 'dummy' });
+      }
+      throw new Error('ENOENT');
+    });
+    expect(() =>
+      loadConfig({
+        provider: 'mygw',
+        providerBaseUrl: 'https://x.example/v1',
+        allowProviderBaseUrl: true,
+      }),
+    ).toThrow(/cannot be combined with custom provider/);
+  });
+});
+
 describe('saveOption', () => {
   beforeEach(() => {
     fsMock.existsSync.mockReturnValue(true);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import * as dotenv from 'dotenv';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { PREFS_PATH, KEYS_PATH, ENV_PATH, LEGACY_DIR } from './paths.js';
-import { loadCustomProviders, type CustomProvider } from './custom-providers.js';
+import { loadCustomProviders, validateBaseURL, type CustomProvider } from './custom-providers.js';
 
 /** Resolved runtime configuration for a Bernard session. */
 export interface BernardConfig {
@@ -54,6 +54,13 @@ export interface BernardConfig {
   apiKeys?: Record<string, string>;
   /** Loaded snapshot of user-defined custom providers from `custom-providers.json`. */
   customProviders: Record<string, CustomProvider>;
+  /**
+   * One-shot override for the active built-in provider's endpoint URL.
+   * Only set when the user passes `--allow-provider-base-url` together with
+   * `--provider-base-url <url>` on the CLI. Never persisted; never read from
+   * env or preferences. See `bernard add-provider` for the persistent path.
+   */
+  providerBaseUrl?: string;
 }
 
 const DEFAULT_PROVIDER = 'anthropic';
@@ -640,7 +647,12 @@ export function defaultProviderErrorMessage(
  * @param overrides - Optional CLI-supplied provider/model that take highest priority.
  * @throws {Error} If the selected provider has no API key configured.
  */
-export function loadConfig(overrides?: { provider?: string; model?: string }): BernardConfig {
+export function loadConfig(overrides?: {
+  provider?: string;
+  model?: string;
+  providerBaseUrl?: string;
+  allowProviderBaseUrl?: boolean;
+}): BernardConfig {
   // Load .env from cwd first, then XDG config dir, then legacy ~/.bernard/
   const cwdEnv = path.join(process.cwd(), '.env');
   const legacyEnv = path.join(LEGACY_DIR, '.env');
@@ -765,6 +777,13 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
+  const providerBaseUrl = resolveProviderBaseUrl(
+    overrides?.providerBaseUrl,
+    overrides?.allowProviderBaseUrl,
+    provider,
+    customProviders,
+  );
+
   const config: BernardConfig = {
     provider,
     model,
@@ -788,10 +807,44 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     xaiApiKey: process.env.XAI_API_KEY,
     apiKeys: { ...storedKeys },
     customProviders,
+    providerBaseUrl,
   };
 
   validateConfig(config);
   return config;
+}
+
+/**
+ * Validates and resolves the provider base URL override.
+ *
+ * Returns the URL string when the override is active and valid, or `undefined`
+ * when no override is in play. Throws on misuse so the user sees the error at
+ * startup rather than encountering a surprise routing change mid-session.
+ */
+function resolveProviderBaseUrl(
+  url: string | undefined,
+  allow: boolean | undefined,
+  provider: string,
+  customProviders: Record<string, CustomProvider>,
+): string | undefined {
+  if (url === undefined) return undefined;
+  if (!allow) {
+    throw new Error(
+      '--provider-base-url requires the explicit opt-in flag --allow-provider-base-url. ' +
+        'This guard exists so a stray flag cannot silently re-route your provider traffic.',
+    );
+  }
+  const trimmed = url.trim();
+  const err = validateBaseURL(trimmed);
+  if (err) throw new Error(`--provider-base-url: ${err}`);
+  if (Object.hasOwn(customProviders, provider)) {
+    throw new Error(
+      `--provider-base-url cannot be combined with custom provider "${provider}" — ` +
+        `that provider already defines its own base URL. Either pick a built-in provider ` +
+        `(anthropic, openai, xai) or edit the custom provider with \`bernard add-provider\`.`,
+    );
+  }
+  return trimmed;
 }
 
 function validateConfig(config: BernardConfig): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,14 @@ program
   .option('-r, --resume', 'Resume the previous conversation')
   .option('--alert <id>', 'Open with cron alert context')
   .option('--tool-details', 'Show full tool call args and result output (default: hidden)')
+  .option(
+    '--allow-provider-base-url',
+    'Opt-in flag required to enable --provider-base-url for this session',
+  )
+  .option(
+    '--provider-base-url <url>',
+    "Override the active built-in provider's endpoint URL for this session (requires --allow-provider-base-url)",
+  )
   .action(async (opts) => {
     try {
       await runFirstTimeSetup();
@@ -58,6 +66,8 @@ program
       const config = loadConfig({
         provider: opts.provider,
         model: opts.model,
+        providerBaseUrl: opts.providerBaseUrl,
+        allowProviderBaseUrl: opts.allowProviderBaseUrl,
       });
 
       if (opts.toolDetails) config.toolDetails = true;
@@ -98,7 +108,7 @@ The user has been notified and this session is open for them to review and act o
         config.provider,
         config.model,
         getLocalVersion(),
-        config.customProviders?.[config.provider]?.baseURL,
+        config.providerBaseUrl ?? config.customProviders?.[config.provider]?.baseURL,
       );
       const prefs = loadPreferences();
       startupUpdateCheck(!!prefs.autoUpdate);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -100,7 +100,22 @@ export function getModelForConfig(
       apiKey,
     });
   }
+  // Built-in providers map 1:1 to SDK names; route through the factory path
+  // when the user has supplied a session-scoped base-URL override so the
+  // request actually hits the new endpoint instead of the vendor default.
+  if (config.providerBaseUrl && isBuiltinSdk(provider)) {
+    const apiKey = getProviderApiKey(config, provider) ?? '';
+    return getModel(provider, model, {
+      sdk: provider,
+      baseURL: config.providerBaseUrl,
+      apiKey,
+    });
+  }
   return getModel(provider, model);
+}
+
+function isBuiltinSdk(provider: string): provider is SupportedSdk {
+  return provider === 'anthropic' || provider === 'openai' || provider === 'xai';
 }
 
 // Disable OpenAI strict-schemas: MCP tools commonly emit JSON Schema features

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1345,7 +1345,7 @@ export async function startRepl(
           config.provider,
           config.model,
           getLocalVersion(),
-          config.customProviders?.[config.provider]?.baseURL,
+          config.providerBaseUrl ?? config.customProviders?.[config.provider]?.baseURL,
         );
         printInfo('Conversation history and scratch notes cleared.');
         void prompt();
@@ -1583,6 +1583,10 @@ export async function startRepl(
                 config.apiKeys = { ...(config.apiKeys ?? {}), [added.entry.name]: added.apiKey };
                 config.provider = added.entry.name;
                 config.model = added.entry.defaultModel;
+                // Drop any session-scoped --provider-base-url override: a custom
+                // provider already defines its own baseURL, and re-applying the
+                // CLI override to a different provider would mis-route traffic.
+                config.providerBaseUrl = undefined;
                 savePreferences({
                   provider: config.provider,
                   model: config.model,
@@ -1598,6 +1602,11 @@ export async function startRepl(
             } else {
               config.provider = value;
               config.model = getDefaultModel(config.provider, customProviders);
+              // Drop the session-scoped --provider-base-url override. It was tied
+              // to whichever provider was active at launch; silently re-applying
+              // it to a different built-in (e.g. openai gateway → anthropic)
+              // would route Anthropic traffic through an OpenAI endpoint.
+              config.providerBaseUrl = undefined;
               savePreferences({
                 provider: config.provider,
                 model: config.model,


### PR DESCRIPTION
## Summary
- Adds two CLI flags: `--allow-provider-base-url` (opt-in guard) and `--provider-base-url <url>` (the override). Both are required together; passing the URL without the guard errors out.
- Routes built-in providers (`anthropic` / `openai` / `xai`) through the existing custom-provider SDK factory when the override is active, so the request actually hits the override URL instead of the vendor default. Custom providers are rejected at load time — they already own a `baseURL`.
- URL validation reuses `validateBaseURL` from `src/custom-providers.ts` (http/https only, non-empty after trim).
- Welcome banner (both startup and `/clear`) shows the override on the `Endpoint:` line, so the user can see at a glance which URL the session is using.
- `/provider` switch (existing-provider branch and the in-REPL "+ Add custom provider…" wizard) clears the override so it cannot silently re-apply to a different built-in.

Closes #151.

## Acceptance Criteria
- [x] User can supply a provider base URL override
- [x] Override is rejected unless `--allow-provider-base-url` is present
- [x] Clear UX/error messaging on misuse (missing opt-in, invalid URL, non-http(s), combined with a custom provider)
- [x] Works end-to-end for at least one provider — verified by pointing an OpenAI session at `http://127.0.0.1:1/v1` and observing the SDK error mention that host
- [x] Docs updated (CLI help + new README "One-shot Base URL Override" section)

## Test plan
- [x] `npm run build` clean
- [x] `npm run format` clean
- [x] `bernard --provider-base-url … ` without opt-in → rejected
- [x] `--allow-provider-base-url --provider-base-url ""` / `not-a-url` / `ftp://…` → rejected with specific message
- [x] `--allow-provider-base-url` alone → no-op, REPL starts normally
- [x] `-p <custom-provider> --allow-provider-base-url --provider-base-url …` → rejected (custom provider already has a baseURL)
- [x] Welcome banner shows the override on the `Endpoint:` line
- [x] Smoke: with `--provider-base-url http://127.0.0.1:1/v1`, an actual `generateText` call fails with a connect error naming that host (confirms routing)
- [x] Switching `/provider` mid-session clears `config.providerBaseUrl` (verified by exercising `loadConfig` + the mutation pattern from `repl.ts`)

## Follow-ups (not blocking)
- `validateBaseURL` does not currently reject URLs with embedded credentials (`http://user:pass@host`). Pre-existing in `custom-providers.ts`; worth tightening separately.
- RAG worker subprocess re-runs `loadConfig({ provider, model })` and does not inherit `providerBaseUrl`. Documented as non-persistent, but split-brain traffic could surprise users running a session against a staging endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)