### PR TITLE
feat(tools): tool determinism/side-effect metadata + redaction (closes #176)

### DIFF
--- a/src/cron/scoped-notes-tools.ts
+++ b/src/cron/scoped-notes-tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { CronNotesStore, MAX_NOTE_LENGTH } from './notes-store.js';
 import { formatEntryCompact } from '../tools/cron-notes.js';
 import { debugLog } from '../logger.js';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /**
  * Builds `cron_notes_read` and `cron_notes_write` tools pre-scoped to a single
@@ -15,38 +16,56 @@ export function createScopedCronNotesTools(
   jobId: string,
   runId: string,
 ) {
-  const scopedNotesRead = tool({
-    description:
-      'Read notes previously written for this cron job by prior runs. Call this before acting to avoid duplicate work.',
-    parameters: z.object({}),
-    execute: async (): Promise<string> => {
-      debugLog('cron_notes_read:scoped:execute', { jobId });
-      const notes = notesStore.read(jobId);
-      if (notes.entries.length === 0) {
-        return `No prior notes for this job.`;
-      }
-      const label = notes.entries.length === 1 ? 'entry' : 'entries';
-      const lines = notes.entries.map(formatEntryCompact);
-      return `Prior notes (${notes.entries.length} ${label}):\n${lines.join('\n')}`;
-    },
-  });
-
-  const scopedNotesWrite = tool({
-    description:
-      "Append a short factual note recording a significant action this run took (e.g. 'Sent email to user@example.com', 'Created issue #123'). Keep it to one line.",
-    parameters: z.object({
-      text: z
-        .string()
-        .min(1)
-        .max(MAX_NOTE_LENGTH)
-        .describe('Short factual description of the action'),
+  const scopedNotesRead = attachMeta(
+    tool({
+      description:
+        'Read notes previously written for this cron job by prior runs. Call this before acting to avoid duplicate work.',
+      parameters: z.object({}),
+      execute: async (): Promise<string> => {
+        debugLog('cron_notes_read:scoped:execute', { jobId });
+        const notes = notesStore.read(jobId);
+        if (notes.entries.length === 0) {
+          return `No prior notes for this job.`;
+        }
+        const label = notes.entries.length === 1 ? 'entry' : 'entries';
+        const lines = notes.entries.map(formatEntryCompact);
+        return `Prior notes (${notes.entries.length} ${label}):\n${lines.join('\n')}`;
+      },
     }),
-    execute: async ({ text }): Promise<string> => {
-      debugLog('cron_notes_write:scoped:execute', { jobId, runId, text });
-      notesStore.append(jobId, text, runId);
-      return `Note appended (run ${runId.slice(0, 8)}).`;
+    {
+      name: 'cron_notes_read',
+      kind: 'read',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
     },
-  });
+  );
+
+  const scopedNotesWrite = attachMeta(
+    tool({
+      description:
+        "Append a short factual note recording a significant action this run took (e.g. 'Sent email to user@example.com', 'Created issue #123'). Keep it to one line.",
+      parameters: z.object({
+        text: z
+          .string()
+          .min(1)
+          .max(MAX_NOTE_LENGTH)
+          .describe('Short factual description of the action'),
+      }),
+      execute: async ({ text }): Promise<string> => {
+        debugLog('cron_notes_write:scoped:execute', { jobId, runId, text });
+        notesStore.append(jobId, text, runId);
+        return `Note appended (run ${runId.slice(0, 8)}).`;
+      },
+    }),
+    {
+      name: 'cron_notes_write',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
+    },
+  );
 
   return {
     cron_notes_read: scopedNotesRead,

--- a/src/framework/agents/cron.ts
+++ b/src/framework/agents/cron.ts
@@ -7,7 +7,7 @@ import { createDateTimeTool, formatCurrentDateTime } from '../../tools/datetime.
 import { createWebReadTool } from '../../tools/web.js';
 import { createWaitTool } from '../../tools/wait.js';
 import { createTimeTools } from '../../tools/time.js';
-import { toolToAISDK } from '../tools/adapter.js';
+import { toolToAISDK, attachMeta } from '../tools/adapter.js';
 import { CronStore } from '../../cron/store.js';
 import { type CronLogStep } from '../../cron/log-store.js';
 import { CronNotesStore } from '../../cron/notes-store.js';
@@ -127,46 +127,64 @@ export const cronDefinition: AgentDefinition<CronInput, string> = {
     const memoryStore = ctx.stores.memory;
     const config = ctx.config;
 
-    const notifyTool = tool({
-      description:
-        'Send a desktop notification to alert the user. Use this when you find something that requires user attention. Clicking the notification will open a terminal with the alert context.',
-      parameters: z.object({
-        message: z.string().describe('The alert message to show the user'),
-        severity: z
-          .enum(['low', 'normal', 'critical'])
-          .describe('Urgency level of the notification'),
+    const notifyTool = attachMeta(
+      tool({
+        description:
+          'Send a desktop notification to alert the user. Use this when you find something that requires user attention. Clicking the notification will open a terminal with the alert context.',
+        parameters: z.object({
+          message: z.string().describe('The alert message to show the user'),
+          severity: z
+            .enum(['low', 'normal', 'critical'])
+            .describe('Urgency level of the notification'),
+        }),
+        execute: async ({ message, severity }): Promise<string> => {
+          const alert = store.createAlert({
+            jobId: job.id,
+            jobName: job.name,
+            message,
+            prompt: job.prompt,
+            response: '',
+          });
+          sendNotification({
+            title: `Bernard: ${job.name}`,
+            message,
+            severity,
+            alertId: alert.id,
+            log,
+          });
+          return `Notification sent for alert ${alert.id}. Terminal will open when the user clicks the notification.`;
+        },
       }),
-      execute: async ({ message, severity }): Promise<string> => {
-        const alert = store.createAlert({
-          jobId: job.id,
-          jobName: job.name,
-          message,
-          prompt: job.prompt,
-          response: '',
-        });
-        sendNotification({
-          title: `Bernard: ${job.name}`,
-          message,
-          severity,
-          alertId: alert.id,
-          log,
-        });
-        return `Notification sent for alert ${alert.id}. Terminal will open when the user clicks the notification.`;
+      {
+        name: 'notify',
+        kind: 'write',
+        deterministic: false,
+        sideEffect: 'local',
+        cacheable: false,
       },
-    });
+    );
 
-    const selfDisableTool = tool({
-      description:
-        "Disable this cron job so it will not run again. Use when the job's task is complete and no further executions are needed.",
-      parameters: z.object({
-        reason: z.string().describe('Brief reason for disabling (logged for the user)'),
+    const selfDisableTool = attachMeta(
+      tool({
+        description:
+          "Disable this cron job so it will not run again. Use when the job's task is complete and no further executions are needed.",
+        parameters: z.object({
+          reason: z.string().describe('Brief reason for disabling (logged for the user)'),
+        }),
+        execute: async ({ reason }): Promise<string> => {
+          const updated = store.updateJob(job.id, { enabled: false });
+          if (!updated) return `Error: could not disable job ${job.id}.`;
+          return `Job "${job.name}" disabled. Reason: ${reason}`;
+        },
       }),
-      execute: async ({ reason }): Promise<string> => {
-        const updated = store.updateJob(job.id, { enabled: false });
-        if (!updated) return `Error: could not disable job ${job.id}.`;
-        return `Job "${job.name}" disabled. Reason: ${reason}`;
+      {
+        name: 'cron_self_disable',
+        kind: 'write',
+        deterministic: false,
+        sideEffect: 'local',
+        cacheable: false,
       },
-    });
+    );
 
     const shellTool = createShellTool({
       shellTimeout: config.shellTimeout,

--- a/src/framework/agents/cron.ts
+++ b/src/framework/agents/cron.ts
@@ -85,6 +85,13 @@ export interface CronInput {
   serverNames: string[];
   mcpTools: Record<string, Tool>;
   ragResults?: RAGSearchResult[];
+  /**
+   * Mutable slot populated inside `tools()` so `hooks()` (which the framework
+   * invokes immediately after) can hand the same registry to
+   * `cronStepRecorderHook` for sensitive-arg redaction. The runner doesn't
+   * need to set this — `tools()` will.
+   */
+  toolRegistry?: Record<string, Tool>;
 }
 
 /**
@@ -166,7 +173,7 @@ export const cronDefinition: AgentDefinition<CronInput, string> = {
       confirmDangerous: async () => false,
     });
 
-    return {
+    const registry: Record<string, Tool> = {
       shell: toolToAISDK(shellTool),
       memory: toolToAISDK(createMemoryTool(memoryStore)),
       scratch: toolToAISDK(createScratchTool(memoryStore)),
@@ -179,6 +186,8 @@ export const cronDefinition: AgentDefinition<CronInput, string> = {
       ...createScopedCronNotesTools(notesStore, job.id, runId),
       ...mcpTools,
     };
+    input.toolRegistry = registry;
+    return registry;
   },
 
   strategy() {
@@ -194,7 +203,7 @@ export const cronDefinition: AgentDefinition<CronInput, string> = {
   },
 
   hooks(_ctx, input) {
-    return [cronStepRecorderHook(input.steps)];
+    return [cronStepRecorderHook(input.steps, input.toolRegistry)];
   },
 
   resolveModel(ctx): ResolvedModel {

--- a/src/framework/hooks/cron-step-recorder.ts
+++ b/src/framework/hooks/cron-step-recorder.ts
@@ -1,5 +1,7 @@
 import type { CronLogStep } from '../../cron/log-store.js';
 import type { AgentHook } from './types.js';
+import { readToolMeta } from '../tools/adapter.js';
+import { redactArgs, REDACTED } from '../tools/redact.js';
 
 /**
  * Maximum chars to keep per tool-result string before truncating in the log.
@@ -23,25 +25,41 @@ function truncateResult(result: unknown, maxLen: number): unknown {
  *
  * The hook owns its own monotonically-increasing `stepIndex`; callers should
  * create a fresh hook (and a fresh `steps` array) per cron run.
+ *
+ * When `toolRegistry` is supplied, each tool call's args and result are scrubbed
+ * against the tool's `ToolMeta.sensitiveArgs` / `sensitiveResult` fields before
+ * persistence.
  */
-export function cronStepRecorderHook(steps: CronLogStep[]): AgentHook {
+export function cronStepRecorderHook(
+  steps: CronLogStep[],
+  toolRegistry?: Record<string, unknown>,
+): AgentHook {
   let stepIndex = 0;
   return {
     onStepFinish: ({ text, toolCalls, toolResults, usage, finishReason }) => {
-      const truncatedResults = (toolResults ?? []).map((tr) => ({
-        toolName: tr.toolName,
-        toolCallId: tr.toolCallId,
-        result: truncateResult(tr.result, CRON_RESULT_MAX_LEN),
-      }));
+      const truncatedResults = (toolResults ?? []).map((tr) => {
+        const meta = toolRegistry ? readToolMeta(toolRegistry[tr.toolName]) : undefined;
+        return {
+          toolName: tr.toolName,
+          toolCallId: tr.toolCallId,
+          result: meta?.sensitiveResult ? REDACTED : truncateResult(tr.result, CRON_RESULT_MAX_LEN),
+        };
+      });
       steps.push({
         stepIndex: stepIndex++,
         timestamp: new Date().toISOString(),
         text: text || '',
-        toolCalls: (toolCalls ?? []).map((tc) => ({
-          toolName: tc.toolName,
-          toolCallId: tc.toolCallId,
-          args: tc.args as Record<string, unknown>,
-        })),
+        toolCalls: (toolCalls ?? []).map((tc) => {
+          const meta = toolRegistry ? readToolMeta(toolRegistry[tc.toolName]) : undefined;
+          const args = meta
+            ? (redactArgs(tc.args, meta.sensitiveArgs) as Record<string, unknown>)
+            : (tc.args as Record<string, unknown>);
+          return {
+            toolName: tc.toolName,
+            toolCallId: tc.toolCallId,
+            args,
+          };
+        }),
         toolResults: truncatedResults,
         usage: {
           promptTokens: usage?.promptTokens ?? 0,

--- a/src/framework/tools/adapter.ts
+++ b/src/framework/tools/adapter.ts
@@ -21,18 +21,20 @@ export function toolToAISDK<TArgs, TData>(t: BernardTool<TArgs, TData>): Tool {
       return t.serializeForModel(envelope);
     },
   });
+  // `configurable: true` lets later passes (augment, shim) re-attach the same
+  // meta onto a spread copy without throwing. The property is still
+  // non-enumerable so object spread keeps stripping it — re-attachment is the
+  // explicit contract.
   Object.defineProperty(aisdk, '__bernardMeta', {
     value: t.meta,
     enumerable: false,
-    configurable: false,
+    configurable: true,
     writable: false,
   });
-  // Stash the source BernardTool so augmentation can re-run execute and
-  // inspect the raw envelope without rebuilding the adapter chain.
   Object.defineProperty(aisdk, '__bernardSource', {
     value: t,
     enumerable: false,
-    configurable: false,
+    configurable: true,
     writable: false,
   });
   return aisdk;
@@ -106,10 +108,23 @@ export function attachMeta<T extends Tool>(t: T, meta: ToolMeta): T {
   Object.defineProperty(t, '__bernardMeta', {
     value: meta,
     enumerable: false,
-    configurable: false,
+    configurable: true,
     writable: false,
   });
   return t;
+}
+
+/**
+ * Re-attaches Bernard meta to a spread copy of a tool. Object spread (e.g.
+ * `{ ...tool, execute: wrapped }`) silently drops `__bernardMeta` because the
+ * property is non-enumerable; passes that rebuild a tool's `execute` (the
+ * augmentation layer, the wrap-with-specialist shim) must call this on the
+ * copy so downstream `readToolMeta` keeps working.
+ */
+export function preserveMeta<T extends Tool>(copy: T, source: unknown): T {
+  const meta = readToolMeta(source);
+  if (meta) attachMeta(copy, meta);
+  return copy;
 }
 
 /**

--- a/src/framework/tools/adapter.ts
+++ b/src/framework/tools/adapter.ts
@@ -95,8 +95,29 @@ export function legacyTool(t: Tool, meta: ToolMeta): BernardTool<unknown, unknow
 }
 
 /**
- * Reads the metadata attached to a `Tool` by `toolToAISDK`. Returns
- * `undefined` for tools that did not pass through the adapter (legacy or MCP).
+ * Attaches Bernard meta to an existing AI-SDK `Tool` without wrapping its
+ * `execute` function. Use this to declare meta on tools whose factories
+ * already return a plain `tool({...})` from the AI SDK — cheaper than going
+ * through `legacyTool` + `toolToAISDK` when the envelope shape is irrelevant.
+ *
+ * Returns the same tool reference for fluent chaining.
+ */
+export function attachMeta<T extends Tool>(t: T, meta: ToolMeta): T {
+  Object.defineProperty(t, '__bernardMeta', {
+    value: meta,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return t;
+}
+
+/**
+ * Reads the metadata attached to a `Tool` by `toolToAISDK` or `attachMeta`.
+ * Returns `undefined` for tools that did not pass through either helper.
+ * Surfaces all `ToolMeta` fields verbatim — including the newer
+ * `deterministic`, `sideEffect`, `cacheable`, `cacheTtlMs`, `sensitiveArgs`,
+ * and `sensitiveResult` properties when present.
  */
 export function readToolMeta(t: unknown): ToolMeta | undefined {
   if (!t || typeof t !== 'object') return undefined;

--- a/src/framework/tools/mcp.ts
+++ b/src/framework/tools/mcp.ts
@@ -25,6 +25,8 @@ export function wrapMCPTool(
     name,
     kind: 'inert',
     category: `mcp.${serverName}`,
+    deterministic: false,
+    sideEffect: 'external-api',
     ...metaOverride,
   };
 

--- a/src/framework/tools/meta-coverage.test.ts
+++ b/src/framework/tools/meta-coverage.test.ts
@@ -150,7 +150,9 @@ function checkMetaCoverage(tools: Record<string, unknown>): {
       missing.push(name);
       continue;
     }
-    if (meta.deterministic === undefined && meta.sideEffect === undefined) {
+    // Both fields are required so the cache layer and policy decisions can
+    // reason about the tool without falling back to "unknown" defaults.
+    if (meta.deterministic === undefined || meta.sideEffect === undefined) {
       incomplete.push(name);
     }
   }

--- a/src/framework/tools/meta-coverage.test.ts
+++ b/src/framework/tools/meta-coverage.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readToolMeta } from './adapter.js';
+
+// Mock heavyweight stores so createTools() can run without touching disk or
+// spawning subprocesses. Each mock matches the minimal surface area used by
+// the corresponding tool factory at construction time.
+vi.mock('../../memory.js', () => ({
+  MemoryStore: class {
+    list() {
+      return [];
+    }
+    get() {
+      return undefined;
+    }
+    set() {}
+    delete() {}
+    listScratch() {
+      return [];
+    }
+    getScratch() {
+      return undefined;
+    }
+    setScratch() {}
+    deleteScratch() {}
+    clearScratch() {}
+  },
+}));
+
+vi.mock('../../routines.js', () => ({
+  RoutineStore: class {
+    list() {
+      return [];
+    }
+    get() {
+      return undefined;
+    }
+  },
+}));
+
+vi.mock('../../specialists.js', () => ({
+  SpecialistStore: class {
+    list() {
+      return [];
+    }
+    get() {
+      return undefined;
+    }
+  },
+}));
+
+vi.mock('../../specialist-candidates.js', () => ({
+  CandidateStore: class {
+    listPending() {
+      return [];
+    }
+  },
+}));
+
+vi.mock('../../cron/store.js', () => ({
+  CronStore: class {
+    loadJobs() {
+      return [];
+    }
+    listAlerts() {
+      return [];
+    }
+    getJob() {
+      return undefined;
+    }
+  },
+}));
+
+vi.mock('../../cron/log-store.js', () => ({
+  CronLogStore: class {
+    getEntries() {
+      return [];
+    }
+    getEntryCount() {
+      return 0;
+    }
+    getEntry() {
+      return undefined;
+    }
+    deleteJobLogs() {
+      return false;
+    }
+    rotate() {}
+  },
+}));
+
+vi.mock('../../cron/notes-store.js', () => ({
+  CronNotesStore: class {
+    read() {
+      return { entries: [] };
+    }
+    listJobIds() {
+      return [];
+    }
+    append() {
+      return { total: 0 };
+    }
+    entriesForRun() {
+      return [];
+    }
+  },
+  MAX_NOTE_LENGTH: 2000,
+}));
+
+vi.mock('../../cron/client.js', () => ({
+  isDaemonRunning: () => false,
+  startDaemon: vi.fn(),
+  stopDaemon: vi.fn(),
+}));
+
+vi.mock('../../cron/runner.js', () => ({
+  runJob: vi.fn(),
+}));
+
+vi.mock('../../mcp.js', () => ({
+  listMCPServers: () => [],
+  addMCPServer: vi.fn(),
+  removeMCPServer: vi.fn(),
+  getMCPServer: () => undefined,
+  addMCPUrlServer: vi.fn(),
+}));
+
+vi.mock('../../logger.js', () => ({
+  debugLog: vi.fn(),
+}));
+
+describe('tool meta coverage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('every tool returned by createTools() declares the required meta fields', async () => {
+    const { createTools } = await import('../../tools/index.js');
+    const tools = createTools(
+      { shellTimeout: 10_000, confirmDangerous: async () => false },
+      // Cast: the mocked MemoryStore satisfies the structural shape used here.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      new (await import('../../memory.js')).MemoryStore() as any,
+    );
+
+    const missing: string[] = [];
+    const incomplete: string[] = [];
+    for (const [name, tool] of Object.entries(tools)) {
+      if (!tool || typeof tool !== 'object') continue;
+      const meta = readToolMeta(tool);
+      if (!meta) {
+        missing.push(name);
+        continue;
+      }
+      // Every tool must classify itself by determinism and side effect so the
+      // cache layer and policy decisions can reason about it.
+      if (meta.deterministic === undefined && meta.sideEffect === undefined) {
+        incomplete.push(name);
+      }
+    }
+
+    expect(missing, `Tools missing __bernardMeta: ${missing.join(', ')}`).toEqual([]);
+    expect(incomplete, `Tools missing deterministic/sideEffect: ${incomplete.join(', ')}`).toEqual(
+      [],
+    );
+  });
+});

--- a/src/framework/tools/meta-coverage.test.ts
+++ b/src/framework/tools/meta-coverage.test.ts
@@ -128,6 +128,35 @@ vi.mock('../../logger.js', () => ({
   debugLog: vi.fn(),
 }));
 
+// Minimal ToolProfileStore stand-in for `augmentTools`. The wrapper only
+// touches the store on tool execution; meta inspection at registry
+// construction time doesn't read it, so an inert shape suffices.
+const fakeProfileStore = {
+  get: () => undefined,
+  recordBadExample: () => {},
+  patchLastBadWithFix: () => {},
+};
+
+function checkMetaCoverage(tools: Record<string, unknown>): {
+  missing: string[];
+  incomplete: string[];
+} {
+  const missing: string[] = [];
+  const incomplete: string[] = [];
+  for (const [name, tool] of Object.entries(tools)) {
+    if (!tool || typeof tool !== 'object') continue;
+    const meta = readToolMeta(tool);
+    if (!meta) {
+      missing.push(name);
+      continue;
+    }
+    if (meta.deterministic === undefined && meta.sideEffect === undefined) {
+      incomplete.push(name);
+    }
+  }
+  return { missing, incomplete };
+}
+
 describe('tool meta coverage', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -142,25 +171,59 @@ describe('tool meta coverage', () => {
       new (await import('../../memory.js')).MemoryStore() as any,
     );
 
-    const missing: string[] = [];
-    const incomplete: string[] = [];
-    for (const [name, tool] of Object.entries(tools)) {
-      if (!tool || typeof tool !== 'object') continue;
-      const meta = readToolMeta(tool);
-      if (!meta) {
-        missing.push(name);
-        continue;
-      }
-      // Every tool must classify itself by determinism and side effect so the
-      // cache layer and policy decisions can reason about it.
-      if (meta.deterministic === undefined && meta.sideEffect === undefined) {
-        incomplete.push(name);
-      }
-    }
-
+    const { missing, incomplete } = checkMetaCoverage(tools);
     expect(missing, `Tools missing __bernardMeta: ${missing.join(', ')}`).toEqual([]);
     expect(incomplete, `Tools missing deterministic/sideEffect: ${incomplete.join(', ')}`).toEqual(
       [],
     );
+  });
+
+  it('meta survives augmentTools — non-enumerable __bernardMeta is re-attached after the spread', async () => {
+    const { createTools } = await import('../../tools/index.js');
+    const { augmentTools } = await import('../../tools/augment.js');
+    const tools = createTools(
+      { shellTimeout: 10_000, confirmDangerous: async () => false },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      new (await import('../../memory.js')).MemoryStore() as any,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const augmented = augmentTools(tools, fakeProfileStore as any);
+
+    const { missing } = checkMetaCoverage(augmented);
+    expect(
+      missing,
+      `Tools that lost __bernardMeta during augmentTools spread: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every tool the cron agent registers declares the required meta fields', async () => {
+    const { cronDefinition } = await import('../agents/cron.js');
+    const memory = new (await import('../../memory.js')).MemoryStore();
+    const cronStore = new (await import('../../cron/store.js')).CronStore();
+    const notesStore = new (await import('../../cron/notes-store.js')).CronNotesStore();
+    const ctx = {
+      stores: { memory },
+      config: { shellTimeout: 10_000, maxSteps: 20 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const input = {
+      job: { id: 'j1', name: 'test', prompt: 'noop', enabled: true },
+      runId: 'r1',
+      steps: [],
+      store: cronStore,
+      notesStore,
+      log: () => {},
+      serverNames: [],
+      mcpTools: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const tools = cronDefinition.tools(ctx, input);
+
+    const { missing, incomplete } = checkMetaCoverage(tools);
+    expect(missing, `Cron tools missing __bernardMeta: ${missing.join(', ')}`).toEqual([]);
+    expect(
+      incomplete,
+      `Cron tools missing deterministic/sideEffect: ${incomplete.join(', ')}`,
+    ).toEqual([]);
   });
 });

--- a/src/framework/tools/redact.ts
+++ b/src/framework/tools/redact.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns a shallow copy of `args` with any keys listed in `sensitiveArgs`
+ * replaced by the string `'[REDACTED]'`. Used to scrub sensitive values out
+ * of reasoning logs, cron step logs, and cache keys before they are persisted.
+ *
+ * Returns `args` unchanged when `sensitiveArgs` is empty/undefined or when
+ * `args` is not a plain object.
+ */
+export const REDACTED = '[REDACTED]' as const;
+
+export function redactArgs(args: unknown, sensitiveArgs: string[] | undefined): unknown {
+  if (!sensitiveArgs || sensitiveArgs.length === 0) return args;
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return args;
+  const copy: Record<string, unknown> = { ...(args as Record<string, unknown>) };
+  for (const key of sensitiveArgs) {
+    if (key in copy) copy[key] = REDACTED;
+  }
+  return copy;
+}

--- a/src/framework/tools/result-cache.test.ts
+++ b/src/framework/tools/result-cache.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  getCachedResult,
+  setCachedResult,
+  clearCache,
+  DEFAULT_CACHE_TTL_MS,
+} from './result-cache.js';
+import type { ToolMeta } from './types.js';
+
+const cacheableMeta: ToolMeta = {
+  name: 'time_range',
+  kind: 'read',
+  deterministic: true,
+  sideEffect: 'none',
+  cacheable: true,
+  cacheTtlMs: 0,
+};
+
+const nonCacheableMeta: ToolMeta = {
+  name: 'web_read',
+  kind: 'read',
+  deterministic: false,
+  sideEffect: 'network',
+  cacheable: false,
+};
+
+describe('result-cache', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stores and retrieves a result for a cacheable tool', () => {
+    setCachedResult(cacheableMeta, { start: 800, end: 1000 }, '2 hours');
+    expect(getCachedResult(cacheableMeta, { start: 800, end: 1000 })).toBe('2 hours');
+  });
+
+  it('returns null for a non-cacheable tool even after setCachedResult', () => {
+    setCachedResult(nonCacheableMeta, { url: 'https://example.com' }, '<html/>');
+    expect(getCachedResult(nonCacheableMeta, { url: 'https://example.com' })).toBeNull();
+  });
+
+  it('evicts an expired entry on read', () => {
+    const ttlMeta: ToolMeta = { ...cacheableMeta, cacheTtlMs: 1000 };
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(now);
+    setCachedResult(ttlMeta, { x: 1 }, 'cached');
+    nowSpy.mockReturnValue(now + 2000);
+    expect(getCachedResult(ttlMeta, { x: 1 })).toBeNull();
+  });
+
+  it('redacts sensitive args from the cache key so values do not leak', () => {
+    const sensitiveMeta: ToolMeta = {
+      ...cacheableMeta,
+      name: 'sensitive_tool',
+      sensitiveArgs: ['token'],
+    };
+    setCachedResult(sensitiveMeta, { token: 'alpha', x: 1 }, 'first');
+    // A different `token` value with the same `x` hits the same redacted key.
+    expect(getCachedResult(sensitiveMeta, { token: 'beta', x: 1 })).toBe('first');
+  });
+
+  it('uses DEFAULT_CACHE_TTL_MS when cacheTtlMs is unset', () => {
+    const meta: ToolMeta = {
+      name: 'default_ttl_tool',
+      kind: 'read',
+      deterministic: true,
+      sideEffect: 'none',
+      cacheable: true,
+    };
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(now);
+    setCachedResult(meta, { a: 1 }, 'val');
+    nowSpy.mockReturnValue(now + DEFAULT_CACHE_TTL_MS - 100);
+    expect(getCachedResult(meta, { a: 1 })).toBe('val');
+    nowSpy.mockReturnValue(now + DEFAULT_CACHE_TTL_MS + 100);
+    expect(getCachedResult(meta, { a: 1 })).toBeNull();
+  });
+});

--- a/src/framework/tools/result-cache.test.ts
+++ b/src/framework/tools/result-cache.test.ts
@@ -83,6 +83,14 @@ describe('result-cache', () => {
     expect(getCachedResult(cacheableMeta, { b: 1 })).toBe('without');
   });
 
+  it('returns CACHE_MISS without throwing when args are not JSON-serializable', () => {
+    // Circular reference would make JSON.stringify throw.
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    expect(() => setCachedResult(cacheableMeta, circular, 'unused')).not.toThrow();
+    expect(getCachedResult(cacheableMeta, circular)).toBe(CACHE_MISS);
+  });
+
   it('uses DEFAULT_CACHE_TTL_MS when cacheTtlMs is unset', () => {
     const meta: ToolMeta = {
       name: 'default_ttl_tool',

--- a/src/framework/tools/result-cache.test.ts
+++ b/src/framework/tools/result-cache.test.ts
@@ -3,6 +3,7 @@ import {
   getCachedResult,
   setCachedResult,
   clearCache,
+  CACHE_MISS,
   DEFAULT_CACHE_TTL_MS,
 } from './result-cache.js';
 import type { ToolMeta } from './types.js';
@@ -38,9 +39,17 @@ describe('result-cache', () => {
     expect(getCachedResult(cacheableMeta, { start: 800, end: 1000 })).toBe('2 hours');
   });
 
-  it('returns null for a non-cacheable tool even after setCachedResult', () => {
+  it('returns CACHE_MISS for a non-cacheable tool even after setCachedResult', () => {
     setCachedResult(nonCacheableMeta, { url: 'https://example.com' }, '<html/>');
-    expect(getCachedResult(nonCacheableMeta, { url: 'https://example.com' })).toBeNull();
+    expect(getCachedResult(nonCacheableMeta, { url: 'https://example.com' })).toBe(CACHE_MISS);
+  });
+
+  it('distinguishes a cached null/undefined from a miss', () => {
+    setCachedResult(cacheableMeta, { start: 0, end: 0 }, null);
+    expect(getCachedResult(cacheableMeta, { start: 0, end: 0 })).toBeNull();
+    setCachedResult(cacheableMeta, { start: 1, end: 1 }, undefined);
+    expect(getCachedResult(cacheableMeta, { start: 1, end: 1 })).toBeUndefined();
+    expect(getCachedResult(cacheableMeta, { start: 2, end: 2 })).toBe(CACHE_MISS);
   });
 
   it('evicts an expired entry on read', () => {
@@ -50,7 +59,7 @@ describe('result-cache', () => {
     nowSpy.mockReturnValue(now);
     setCachedResult(ttlMeta, { x: 1 }, 'cached');
     nowSpy.mockReturnValue(now + 2000);
-    expect(getCachedResult(ttlMeta, { x: 1 })).toBeNull();
+    expect(getCachedResult(ttlMeta, { x: 1 })).toBe(CACHE_MISS);
   });
 
   it('redacts sensitive args from the cache key so values do not leak', () => {
@@ -62,6 +71,16 @@ describe('result-cache', () => {
     setCachedResult(sensitiveMeta, { token: 'alpha', x: 1 }, 'first');
     // A different `token` value with the same `x` hits the same redacted key.
     expect(getCachedResult(sensitiveMeta, { token: 'beta', x: 1 })).toBe('first');
+  });
+
+  it('does not collide an undefined-valued arg with an absent arg', () => {
+    // JSON.stringify drops undefined-valued properties — `{a:undefined,b:1}`
+    // and `{b:1}` would otherwise hash to the same key. The replacer must
+    // distinguish them.
+    setCachedResult(cacheableMeta, { a: undefined, b: 1 }, 'with-undef');
+    setCachedResult(cacheableMeta, { b: 1 }, 'without');
+    expect(getCachedResult(cacheableMeta, { a: undefined, b: 1 })).toBe('with-undef');
+    expect(getCachedResult(cacheableMeta, { b: 1 })).toBe('without');
   });
 
   it('uses DEFAULT_CACHE_TTL_MS when cacheTtlMs is unset', () => {
@@ -79,6 +98,6 @@ describe('result-cache', () => {
     nowSpy.mockReturnValue(now + DEFAULT_CACHE_TTL_MS - 100);
     expect(getCachedResult(meta, { a: 1 })).toBe('val');
     nowSpy.mockReturnValue(now + DEFAULT_CACHE_TTL_MS + 100);
-    expect(getCachedResult(meta, { a: 1 })).toBeNull();
+    expect(getCachedResult(meta, { a: 1 })).toBe(CACHE_MISS);
   });
 });

--- a/src/framework/tools/result-cache.ts
+++ b/src/framework/tools/result-cache.ts
@@ -8,6 +8,15 @@ import { redactArgs } from './redact.js';
 /** Default TTL when a tool's `cacheTtlMs` is unset. 5 minutes. */
 export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Sentinel returned by {@link getCachedResult} to signal "no cached value"
+ * (non-cacheable tool, no entry, or expired entry). A unique symbol so it
+ * cannot collide with a legitimate cached value — including `null` or
+ * `undefined`, both of which are valid cached results.
+ */
+export const CACHE_MISS: unique symbol = Symbol('bernard.cache.miss');
+export type CacheMiss = typeof CACHE_MISS;
+
 interface CacheEntry {
   result: unknown;
   /** Expiry time in epoch ms. `0` means never expires. */
@@ -16,24 +25,36 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 
+/**
+ * `JSON.stringify` silently omits object properties whose value is `undefined`,
+ * so `{a: undefined, b: 1}` and `{b: 1}` collide on the cache key even though
+ * Zod's `.optional()` preserves the distinction at the object level. Replace
+ * `undefined` with an explicit sentinel so the two shapes hash distinctly.
+ */
+const UNDEF_SENTINEL = '__bernard.cache.undef__';
+function stringifyArgs(args: unknown): string {
+  return JSON.stringify(args, (_k, v) => (v === undefined ? UNDEF_SENTINEL : v));
+}
+
 function cacheKey(meta: ToolMeta, args: unknown): string {
   const safeArgs = redactArgs(args, meta.sensitiveArgs);
-  return `${meta.name}::${JSON.stringify(safeArgs)}`;
+  return `${meta.name}::${stringifyArgs(safeArgs)}`;
 }
 
 /**
- * Returns the cached result for `(meta, args)` or `null` when the tool is not
- * cacheable, there is no entry, or the entry has expired. Expired entries are
- * evicted on read.
+ * Returns the cached result for `(meta, args)` or {@link CACHE_MISS} when the
+ * tool is not cacheable, there is no entry, or the entry has expired. Expired
+ * entries are evicted on read. Callers must check `=== CACHE_MISS` rather than
+ * comparing to `null`/`undefined`, since both are valid cached values.
  */
-export function getCachedResult(meta: ToolMeta, args: unknown): unknown | null {
-  if (!isCacheable(meta)) return null;
+export function getCachedResult(meta: ToolMeta, args: unknown): unknown | CacheMiss {
+  if (!isCacheable(meta)) return CACHE_MISS;
   const key = cacheKey(meta, args);
   const entry = cache.get(key);
-  if (!entry) return null;
+  if (!entry) return CACHE_MISS;
   if (entry.expiresAt !== 0 && Date.now() > entry.expiresAt) {
     cache.delete(key);
-    return null;
+    return CACHE_MISS;
   }
   return entry.result;
 }

--- a/src/framework/tools/result-cache.ts
+++ b/src/framework/tools/result-cache.ts
@@ -30,15 +30,34 @@ const cache = new Map<string, CacheEntry>();
  * so `{a: undefined, b: 1}` and `{b: 1}` collide on the cache key even though
  * Zod's `.optional()` preserves the distinction at the object level. Replace
  * `undefined` with an explicit sentinel so the two shapes hash distinctly.
+ *
+ * Also serialize BigInt explicitly (JSON.stringify throws on it) so a tool
+ * that legitimately uses BigInt args doesn't crash the cache layer.
  */
 const UNDEF_SENTINEL = '__bernard.cache.undef__';
+const BIGINT_SENTINEL_PREFIX = '__bernard.cache.bigint:';
 function stringifyArgs(args: unknown): string {
-  return JSON.stringify(args, (_k, v) => (v === undefined ? UNDEF_SENTINEL : v));
+  return JSON.stringify(args, (_k, v) => {
+    if (v === undefined) return UNDEF_SENTINEL;
+    if (typeof v === 'bigint') return `${BIGINT_SENTINEL_PREFIX}${v.toString()}`;
+    return v;
+  });
 }
 
-function cacheKey(meta: ToolMeta, args: unknown): string {
+/**
+ * Returns a stable cache key for `(meta, args)`, or `null` when `args` cannot
+ * be safely keyed (circular references, exotic class instances that throw in
+ * `toJSON`, etc.). A `null` return signals the caller to treat the call as a
+ * cache miss without storing anything — the alternative (throwing) would
+ * propagate into every read/write site.
+ */
+function cacheKey(meta: ToolMeta, args: unknown): string | null {
   const safeArgs = redactArgs(args, meta.sensitiveArgs);
-  return `${meta.name}::${stringifyArgs(safeArgs)}`;
+  try {
+    return `${meta.name}::${stringifyArgs(safeArgs)}`;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -50,6 +69,7 @@ function cacheKey(meta: ToolMeta, args: unknown): string {
 export function getCachedResult(meta: ToolMeta, args: unknown): unknown | CacheMiss {
   if (!isCacheable(meta)) return CACHE_MISS;
   const key = cacheKey(meta, args);
+  if (key === null) return CACHE_MISS;
   const entry = cache.get(key);
   if (!entry) return CACHE_MISS;
   if (entry.expiresAt !== 0 && Date.now() > entry.expiresAt) {
@@ -66,9 +86,11 @@ export function getCachedResult(meta: ToolMeta, args: unknown): unknown | CacheM
  */
 export function setCachedResult(meta: ToolMeta, args: unknown, result: unknown): void {
   if (!isCacheable(meta)) return;
+  const key = cacheKey(meta, args);
+  if (key === null) return;
   const ttl = meta.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   const expiresAt = ttl === 0 ? 0 : Date.now() + ttl;
-  cache.set(cacheKey(meta, args), { result, expiresAt });
+  cache.set(key, { result, expiresAt });
 }
 
 /** Clears all cached entries. Exposed for tests. */

--- a/src/framework/tools/result-cache.ts
+++ b/src/framework/tools/result-cache.ts
@@ -1,0 +1,56 @@
+// TODO(#171): wire `getCachedResult` / `setCachedResult` into `augmentTools`
+// so deterministic, side-effect-free tools transparently hit the cache. Until
+// then the cache is exposed for future use and exercised by unit tests only.
+
+import { isCacheable, type ToolMeta } from './types.js';
+import { redactArgs } from './redact.js';
+
+/** Default TTL when a tool's `cacheTtlMs` is unset. 5 minutes. */
+export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  result: unknown;
+  /** Expiry time in epoch ms. `0` means never expires. */
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(meta: ToolMeta, args: unknown): string {
+  const safeArgs = redactArgs(args, meta.sensitiveArgs);
+  return `${meta.name}::${JSON.stringify(safeArgs)}`;
+}
+
+/**
+ * Returns the cached result for `(meta, args)` or `null` when the tool is not
+ * cacheable, there is no entry, or the entry has expired. Expired entries are
+ * evicted on read.
+ */
+export function getCachedResult(meta: ToolMeta, args: unknown): unknown | null {
+  if (!isCacheable(meta)) return null;
+  const key = cacheKey(meta, args);
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt !== 0 && Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.result;
+}
+
+/**
+ * Stores `result` for `(meta, args)`. No-op for non-cacheable tools.
+ * Honors `meta.cacheTtlMs` (default {@link DEFAULT_CACHE_TTL_MS}; `0` means
+ * indefinite).
+ */
+export function setCachedResult(meta: ToolMeta, args: unknown, result: unknown): void {
+  if (!isCacheable(meta)) return;
+  const ttl = meta.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const expiresAt = ttl === 0 ? 0 : Date.now() + ttl;
+  cache.set(cacheKey(meta, args), { result, expiresAt });
+}
+
+/** Clears all cached entries. Exposed for tests. */
+export function clearCache(): void {
+  cache.clear();
+}

--- a/src/framework/tools/types.ts
+++ b/src/framework/tools/types.ts
@@ -1,15 +1,50 @@
 import type { z } from 'zod';
 
 /**
+ * Side-effect classification for a tool invocation. Used together with
+ * `deterministic` to decide whether a tool's results are safe to cache.
+ *
+ * - `none`         — pure computation, no observable side effects.
+ * - `local`        — affects local filesystem, in-process state, or local services.
+ * - `network`      — issues network requests, but only to fetch data.
+ * - `external-api` — mutates state on a third-party service.
+ */
+export type ToolSideEffect = 'none' | 'local' | 'network' | 'external-api';
+
+/**
  * Standard tool metadata. `name` is the registry key; `kind` enables capability
  * filtering (e.g. `byMetadata({kind: 'read'})` for the reference-resolver lookup
  * pass). `category` mirrors today's `classifyShellCommand` grouping for
  * tool-profile organization.
+ *
+ * The remaining fields classify a tool by determinism, side effects, and
+ * sensitivity. They are all optional so legacy declarations continue to
+ * compile; the meta-coverage test enforces presence at runtime.
  */
 export interface ToolMeta {
   name: string;
   kind: 'read' | 'write' | 'dangerous' | 'inert';
   category?: string;
+  /** Same args always produce the same result. Required for caching. */
+  deterministic?: boolean;
+  /** What the tool touches when it runs. */
+  sideEffect?: ToolSideEffect;
+  /** Explicit opt-in for caching when sideEffect != 'none'. */
+  cacheable?: boolean;
+  /** Cache TTL in ms. 0 = indefinite. Defaults to 5 minutes when omitted. */
+  cacheTtlMs?: number;
+  /** Argument field names whose values should be redacted in logs/cache keys. */
+  sensitiveArgs?: string[];
+  /** When true, the tool's result is redacted in logs. */
+  sensitiveResult?: boolean;
+}
+
+/**
+ * A tool is cacheable iff it is deterministic AND either has no side effects
+ * or was explicitly opted in via `cacheable: true`.
+ */
+export function isCacheable(meta: ToolMeta): boolean {
+  return meta.deterministic === true && (meta.sideEffect === 'none' || meta.cacheable === true);
 }
 
 export type ToolErrorType = 'invalid_args' | 'exec_failed' | 'timeout' | 'cancelled' | 'unknown';

--- a/src/tools/ask-user.ts
+++ b/src/tools/ask-user.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import type { ToolOptions, AskUserQuestion } from './types.js';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /**
  * Creates the `ask_user` tool that pauses the agent loop to ask the user one
@@ -9,53 +10,62 @@ import type { ToolOptions, AskUserQuestion } from './types.js';
  * coordinator mode trips the plan-enforcement loop and aborts the turn.
  */
 export function createAskUserTool(askUser: ToolOptions['askUser']) {
-  return tool({
-    description:
-      'Ask the user one or more clarifying questions and wait for their answers. Use this whenever you need information only the user can provide (intent, preferences, missing arguments) — do NOT write the question as prose in your reply, since that gets no response back. Provide each question as an entry in `questions`; supply `choices` per question when the answer is constrained, otherwise the user gets a free-form prompt. Batch related questions in one call (e.g. title + body + labels) — the user sees a tab strip showing progress. Returns JSON: {"answers": ["...", "..."]} aligned by index, {"cancelled": true, "answered": [...]} with whatever was answered before cancel, or {"unavailable": true} if running headless.',
-    parameters: z.object({
-      questions: z
-        .array(
-          z.object({
-            question: z.string().min(1).describe('The question to show the user'),
-            choices: z
-              .array(z.string())
-              .min(2)
-              .optional()
-              .describe(
-                'Optional list of answer labels. Provide 2+ entries; one-choice menus are rejected.',
-              ),
-            allow_other: z
-              .boolean()
-              .optional()
-              .describe(
-                'When choices are given, also append an escape-hatch option that lets the user type a custom answer. Set false when your choices already cover every case. Default true.',
-              ),
-            other_label: z
-              .string()
-              .optional()
-              .describe(
-                'Label for the appended escape-hatch option. Use this to make the wording specific to your question (e.g. "Other (I will specify title and body)"). Ignored when allow_other is false. Defaults to a generic "Other (type a custom answer)".',
-              ),
-          }),
-        )
-        .min(1)
-        .max(10)
-        .describe(
-          'One or more questions to ask in sequence. For batches of 2+, the user sees a tab strip with completed/current/upcoming markers.',
-        ),
+  return attachMeta(
+    tool({
+      description:
+        'Ask the user one or more clarifying questions and wait for their answers. Use this whenever you need information only the user can provide (intent, preferences, missing arguments) — do NOT write the question as prose in your reply, since that gets no response back. Provide each question as an entry in `questions`; supply `choices` per question when the answer is constrained, otherwise the user gets a free-form prompt. Batch related questions in one call (e.g. title + body + labels) — the user sees a tab strip showing progress. Returns JSON: {"answers": ["...", "..."]} aligned by index, {"cancelled": true, "answered": [...]} with whatever was answered before cancel, or {"unavailable": true} if running headless.',
+      parameters: z.object({
+        questions: z
+          .array(
+            z.object({
+              question: z.string().min(1).describe('The question to show the user'),
+              choices: z
+                .array(z.string())
+                .min(2)
+                .optional()
+                .describe(
+                  'Optional list of answer labels. Provide 2+ entries; one-choice menus are rejected.',
+                ),
+              allow_other: z
+                .boolean()
+                .optional()
+                .describe(
+                  'When choices are given, also append an escape-hatch option that lets the user type a custom answer. Set false when your choices already cover every case. Default true.',
+                ),
+              other_label: z
+                .string()
+                .optional()
+                .describe(
+                  'Label for the appended escape-hatch option. Use this to make the wording specific to your question (e.g. "Other (I will specify title and body)"). Ignored when allow_other is false. Defaults to a generic "Other (type a custom answer)".',
+                ),
+            }),
+          )
+          .min(1)
+          .max(10)
+          .describe(
+            'One or more questions to ask in sequence. For batches of 2+, the user sees a tab strip with completed/current/upcoming markers.',
+          ),
+      }),
+      execute: async ({ questions }, execOptions): Promise<string> => {
+        if (!askUser) {
+          return JSON.stringify({ unavailable: true, reason: 'no interactive user' });
+        }
+        const normalised: AskUserQuestion[] = questions.map((q) => ({
+          question: q.question,
+          choices: q.choices,
+          allowOther: q.choices && q.choices.length > 0 ? q.allow_other !== false : true,
+          otherLabel: q.other_label,
+        }));
+        const result = await askUser(normalised, execOptions?.abortSignal);
+        return JSON.stringify(result);
+      },
     }),
-    execute: async ({ questions }, execOptions): Promise<string> => {
-      if (!askUser) {
-        return JSON.stringify({ unavailable: true, reason: 'no interactive user' });
-      }
-      const normalised: AskUserQuestion[] = questions.map((q) => ({
-        question: q.question,
-        choices: q.choices,
-        allowOther: q.choices && q.choices.length > 0 ? q.allow_other !== false : true,
-        otherLabel: q.other_label,
-      }));
-      const result = await askUser(normalised, execOptions?.abortSignal);
-      return JSON.stringify(result);
+    {
+      name: 'ask_user',
+      kind: 'inert',
+      deterministic: false,
+      sideEffect: 'none',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -1,7 +1,7 @@
 import { type ToolProfileStore, classifyShellCommand, detectToolError } from '../tool-profiles.js';
 import { debugLog } from '../logger.js';
 import { printInfo } from '../output.js';
-import { readBernardSource } from '../framework/tools/adapter.js';
+import { readBernardSource, preserveMeta } from '../framework/tools/adapter.js';
 import type { ToolResult } from '../framework/tools/types.js';
 
 /**
@@ -103,15 +103,55 @@ export function augmentTools(
       // execute (which returns a ToolResult envelope), record based on the
       // discriminator, then call serializeForModel to produce the bytes the
       // model sees — exactly what toolToAISDK would have done.
-      augmented[toolName] = {
+      augmented[toolName] = preserveMeta(
+        {
+          ...toolDef,
+          execute: async (args: unknown, execOptions: unknown) => {
+            let envelope: ToolResult<unknown>;
+            try {
+              envelope = await source.execute(args, execOptions as never);
+            } catch (thrown: unknown) {
+              // Infrastructure-level throws (reconnect, network, etc.) are not
+              // usage errors — don't record them as bad examples.
+              debugLog(
+                `augment:${toolName}:threw`,
+                thrown instanceof Error ? thrown.message : String(thrown),
+              );
+              throw thrown;
+            }
+
+            const profileKey = resolveProfileKey(toolName, args);
+            const argsSnippet = safeSerialize(args);
+            const errSnippet =
+              envelope.status === 'error'
+                ? `${envelope.error.message}${envelope.error.snippet ? `\n${envelope.error.snippet}` : ''}`.slice(
+                    0,
+                    200,
+                  )
+                : undefined;
+            setImmediate(() =>
+              recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet),
+            );
+
+            return source.serializeForModel(envelope);
+          },
+        },
+        toolDef,
+      );
+      continue;
+    }
+
+    // Legacy heuristic path for AI-SDK / MCP / dispatch tools that have not
+    // been migrated. Behavior is unchanged from pre-Phase-B.
+    const originalExecute = toolDef.execute;
+    augmented[toolName] = preserveMeta(
+      {
         ...toolDef,
         execute: async (args: unknown, execOptions: unknown) => {
-          let envelope: ToolResult<unknown>;
+          let result: unknown;
           try {
-            envelope = await source.execute(args, execOptions as never);
+            result = await originalExecute(args, execOptions);
           } catch (thrown: unknown) {
-            // Infrastructure-level throws (reconnect, network, etc.) are not
-            // usage errors — don't record them as bad examples.
             debugLog(
               `augment:${toolName}:threw`,
               thrown instanceof Error ? thrown.message : String(thrown),
@@ -121,56 +161,22 @@ export function augmentTools(
 
           const profileKey = resolveProfileKey(toolName, args);
           const argsSnippet = safeSerialize(args);
-          const errSnippet =
-            envelope.status === 'error'
-              ? `${envelope.error.message}${envelope.error.snippet ? `\n${envelope.error.snippet}` : ''}`.slice(
-                  0,
-                  200,
-                )
-              : undefined;
-          setImmediate(() =>
-            recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet),
-          );
+          const capturedResult = result;
+          setImmediate(() => {
+            try {
+              const errorInfo = detectToolError(toolName, capturedResult);
+              const errSnippet = errorInfo.isError ? errorInfo.snippet : undefined;
+              recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet);
+            } catch {
+              // detectToolError throws are swallowed; recording must never propagate.
+            }
+          });
 
-          return source.serializeForModel(envelope);
+          return result;
         },
-      };
-      continue;
-    }
-
-    // Legacy heuristic path for AI-SDK / MCP / dispatch tools that have not
-    // been migrated. Behavior is unchanged from pre-Phase-B.
-    const originalExecute = toolDef.execute;
-    augmented[toolName] = {
-      ...toolDef,
-      execute: async (args: unknown, execOptions: unknown) => {
-        let result: unknown;
-        try {
-          result = await originalExecute(args, execOptions);
-        } catch (thrown: unknown) {
-          debugLog(
-            `augment:${toolName}:threw`,
-            thrown instanceof Error ? thrown.message : String(thrown),
-          );
-          throw thrown;
-        }
-
-        const profileKey = resolveProfileKey(toolName, args);
-        const argsSnippet = safeSerialize(args);
-        const capturedResult = result;
-        setImmediate(() => {
-          try {
-            const errorInfo = detectToolError(toolName, capturedResult);
-            const errSnippet = errorInfo.isError ? errorInfo.snippet : undefined;
-            recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet);
-          } catch {
-            // detectToolError throws are swallowed; recording must never propagate.
-          }
-        });
-
-        return result;
       },
-    };
+      toolDef,
+    );
   }
 
   return augmented;

--- a/src/tools/cron-logs.ts
+++ b/src/tools/cron-logs.ts
@@ -1,8 +1,20 @@
-import { tool } from 'ai';
+import { tool, type Tool } from 'ai';
 import { z } from 'zod';
 import { CronLogStore } from '../cron/log-store.js';
 import { CronNotesStore } from '../cron/notes-store.js';
 import { debugLog } from '../logger.js';
+import { attachMeta } from '../framework/tools/adapter.js';
+import type { ToolMeta } from '../framework/tools/types.js';
+
+function withLocalMeta(name: string, kind: ToolMeta['kind'], t: Tool): Tool {
+  return attachMeta(t, {
+    name,
+    kind,
+    deterministic: false,
+    sideEffect: 'local',
+    cacheable: false,
+  });
+}
 
 /**
  * Creates tools for inspecting and managing cron job execution logs.
@@ -15,158 +27,180 @@ export function createCronLogTools() {
   const notesStore = new CronNotesStore();
 
   return {
-    cron_logs_list: tool({
-      description:
-        'List recent cron job execution runs. Returns one-line summaries (no step details). Use cron_logs_get for full traces.',
-      parameters: z.object({
-        job_id: z.string().describe('Job ID to list runs for'),
-        limit: z.number().min(1).max(50).default(10).describe('Number of runs to return (max 50)'),
-        offset: z.number().min(0).default(0).describe('Offset for pagination'),
-      }),
-      execute: async ({ job_id, limit, offset }): Promise<string> => {
-        debugLog('cron_logs_list:execute', { job_id, limit, offset });
+    cron_logs_list: withLocalMeta(
+      'cron_logs_list',
+      'read',
+      tool({
+        description:
+          'List recent cron job execution runs. Returns one-line summaries (no step details). Use cron_logs_get for full traces.',
+        parameters: z.object({
+          job_id: z.string().describe('Job ID to list runs for'),
+          limit: z
+            .number()
+            .min(1)
+            .max(50)
+            .default(10)
+            .describe('Number of runs to return (max 50)'),
+          offset: z.number().min(0).default(0).describe('Offset for pagination'),
+        }),
+        execute: async ({ job_id, limit, offset }): Promise<string> => {
+          debugLog('cron_logs_list:execute', { job_id, limit, offset });
 
-        const entries = logStore.getEntries(job_id, limit, offset);
-        if (entries.length === 0) {
+          const entries = logStore.getEntries(job_id, limit, offset);
+          if (entries.length === 0) {
+            const total = logStore.getEntryCount(job_id);
+            if (total === 0) return `No execution logs found for job "${job_id}".`;
+            return `No more entries (total: ${total}, offset: ${offset}).`;
+          }
+
+          const total = logStore.getEntryCount(job_id);
+          const lines = entries.map((e) => {
+            const status = e.success ? 'OK' : 'ERR';
+            const dur = `${e.durationMs}ms`;
+            const stepCount = e.steps.length;
+            const toolCallCount = e.steps.reduce((n, s) => n + s.toolCalls.length, 0);
+            return `  [${status}] ${e.completedAt} | ${dur} | ${stepCount} steps, ${toolCallCount} tool calls | run:${e.runId}`;
+          });
+
+          return `Execution logs for job "${job_id}" (showing ${entries.length} of ${total}, offset ${offset}):\n${lines.join('\n')}`;
+        },
+      }),
+    ),
+
+    cron_logs_get: withLocalMeta(
+      'cron_logs_get',
+      'read',
+      tool({
+        description:
+          'Get the full execution trace for a specific cron job run, including all steps, tool calls, and results.',
+        parameters: z.object({
+          job_id: z.string().describe('Job ID'),
+          run_id: z.string().describe('Run ID (from cron_logs_list output)'),
+        }),
+        execute: async ({ job_id, run_id }): Promise<string> => {
+          debugLog('cron_logs_get:execute', { job_id, run_id });
+
+          const entry = logStore.getEntry(job_id, run_id);
+          if (!entry) return `No log entry found for job "${job_id}", run "${run_id}".`;
+
+          let result = `Run: ${entry.runId}\n`;
+          result += `Job: ${entry.jobName} (${entry.jobId})\n`;
+          result += `Status: ${entry.success ? 'success' : 'error'}\n`;
+          if (entry.error) result += `Error: ${entry.error}\n`;
+          result += `Started: ${entry.startedAt}\n`;
+          result += `Completed: ${entry.completedAt}\n`;
+          result += `Duration: ${entry.durationMs}ms\n`;
+          result += `Tokens: ${entry.totalUsage.promptTokens} prompt + ${entry.totalUsage.completionTokens} completion = ${entry.totalUsage.totalTokens} total\n`;
+          result += `Prompt: ${entry.prompt}\n`;
+          result += `\n--- Steps (${entry.steps.length}) ---\n`;
+
+          for (const step of entry.steps) {
+            result += `\nStep ${step.stepIndex} [${step.timestamp}] (${step.finishReason}):\n`;
+            if (step.text) {
+              result += `  Text: ${step.text}\n`;
+            }
+            for (const tc of step.toolCalls) {
+              result += `  Tool call: ${tc.toolName}(${JSON.stringify(tc.args)})\n`;
+            }
+            for (const tr of step.toolResults) {
+              const resultStr =
+                typeof tr.result === 'string' ? tr.result : JSON.stringify(tr.result);
+              const truncated =
+                resultStr.length > 500 ? resultStr.slice(0, 500) + '... (truncated)' : resultStr;
+              result += `  Tool result [${tr.toolName}]: ${truncated}\n`;
+            }
+          }
+
+          result += `\n--- Final Output ---\n${entry.finalOutput}`;
+
+          const notes = notesStore.entriesForRun(job_id, run_id);
+          if (notes.length > 0) {
+            result += `\n\n## Notes written during this run\n`;
+            result += notes.map((n) => `- ${n.timestamp} — ${n.text}`).join('\n');
+          }
+
+          return result;
+        },
+      }),
+    ),
+
+    cron_logs_summary: withLocalMeta(
+      'cron_logs_summary',
+      'read',
+      tool({
+        description:
+          'Get aggregate statistics for a cron job: success rate, average duration, total token usage, recent run count.',
+        parameters: z.object({
+          job_id: z.string().describe('Job ID to summarize'),
+        }),
+        execute: async ({ job_id }): Promise<string> => {
+          debugLog('cron_logs_summary:execute', { job_id });
+
           const total = logStore.getEntryCount(job_id);
           if (total === 0) return `No execution logs found for job "${job_id}".`;
-          return `No more entries (total: ${total}, offset: ${offset}).`;
-        }
 
-        const total = logStore.getEntryCount(job_id);
-        const lines = entries.map((e) => {
-          const status = e.success ? 'OK' : 'ERR';
-          const dur = `${e.durationMs}ms`;
-          const stepCount = e.steps.length;
-          const toolCallCount = e.steps.reduce((n, s) => n + s.toolCalls.length, 0);
-          return `  [${status}] ${e.completedAt} | ${dur} | ${stepCount} steps, ${toolCallCount} tool calls | run:${e.runId}`;
-        });
+          // Read all entries for summary (capped at most recent 500)
+          const entries = logStore.getEntries(job_id, 500, 0);
 
-        return `Execution logs for job "${job_id}" (showing ${entries.length} of ${total}, offset ${offset}):\n${lines.join('\n')}`;
-      },
-    }),
+          const successes = entries.filter((e) => e.success).length;
+          const failures = entries.length - successes;
+          const successRate = ((successes / entries.length) * 100).toFixed(1);
+          const avgDuration = Math.round(
+            entries.reduce((s, e) => s + e.durationMs, 0) / entries.length,
+          );
+          const totalTokens = entries.reduce((s, e) => s + e.totalUsage.totalTokens, 0);
+          const avgTokens = Math.round(totalTokens / entries.length);
 
-    cron_logs_get: tool({
-      description:
-        'Get the full execution trace for a specific cron job run, including all steps, tool calls, and results.',
-      parameters: z.object({
-        job_id: z.string().describe('Job ID'),
-        run_id: z.string().describe('Run ID (from cron_logs_list output)'),
-      }),
-      execute: async ({ job_id, run_id }): Promise<string> => {
-        debugLog('cron_logs_get:execute', { job_id, run_id });
+          let result = `Summary for job "${job_id}" (${entries.length} runs analyzed of ${total} total):\n`;
+          result += `  Success rate: ${successRate}% (${successes} ok, ${failures} errors)\n`;
+          result += `  Avg duration: ${avgDuration}ms\n`;
+          result += `  Total tokens: ${totalTokens} (avg ${avgTokens}/run)\n`;
 
-        const entry = logStore.getEntry(job_id, run_id);
-        if (!entry) return `No log entry found for job "${job_id}", run "${run_id}".`;
-
-        let result = `Run: ${entry.runId}\n`;
-        result += `Job: ${entry.jobName} (${entry.jobId})\n`;
-        result += `Status: ${entry.success ? 'success' : 'error'}\n`;
-        if (entry.error) result += `Error: ${entry.error}\n`;
-        result += `Started: ${entry.startedAt}\n`;
-        result += `Completed: ${entry.completedAt}\n`;
-        result += `Duration: ${entry.durationMs}ms\n`;
-        result += `Tokens: ${entry.totalUsage.promptTokens} prompt + ${entry.totalUsage.completionTokens} completion = ${entry.totalUsage.totalTokens} total\n`;
-        result += `Prompt: ${entry.prompt}\n`;
-        result += `\n--- Steps (${entry.steps.length}) ---\n`;
-
-        for (const step of entry.steps) {
-          result += `\nStep ${step.stepIndex} [${step.timestamp}] (${step.finishReason}):\n`;
-          if (step.text) {
-            result += `  Text: ${step.text}\n`;
+          if (entries.length > 0) {
+            result += `  Latest run: ${entries[0].completedAt} (${entries[0].success ? 'ok' : 'error'})`;
           }
-          for (const tc of step.toolCalls) {
-            result += `  Tool call: ${tc.toolName}(${JSON.stringify(tc.args)})\n`;
-          }
-          for (const tr of step.toolResults) {
-            const resultStr = typeof tr.result === 'string' ? tr.result : JSON.stringify(tr.result);
-            const truncated =
-              resultStr.length > 500 ? resultStr.slice(0, 500) + '... (truncated)' : resultStr;
-            result += `  Tool result [${tr.toolName}]: ${truncated}\n`;
-          }
-        }
 
-        result += `\n--- Final Output ---\n${entry.finalOutput}`;
-
-        const notes = notesStore.entriesForRun(job_id, run_id);
-        if (notes.length > 0) {
-          result += `\n\n## Notes written during this run\n`;
-          result += notes.map((n) => `- ${n.timestamp} — ${n.text}`).join('\n');
-        }
-
-        return result;
-      },
-    }),
-
-    cron_logs_summary: tool({
-      description:
-        'Get aggregate statistics for a cron job: success rate, average duration, total token usage, recent run count.',
-      parameters: z.object({
-        job_id: z.string().describe('Job ID to summarize'),
+          return result;
+        },
       }),
-      execute: async ({ job_id }): Promise<string> => {
-        debugLog('cron_logs_summary:execute', { job_id });
+    ),
 
-        const total = logStore.getEntryCount(job_id);
-        if (total === 0) return `No execution logs found for job "${job_id}".`;
+    cron_logs_cleanup: withLocalMeta(
+      'cron_logs_cleanup',
+      'write',
+      tool({
+        description:
+          'Rotate or delete cron job execution logs. Use "rotate" to keep only the most recent entries, or "delete" to remove all logs for a job.',
+        parameters: z.object({
+          job_id: z.string().describe('Job ID'),
+          action: z
+            .enum(['rotate', 'delete'])
+            .describe('Action: "rotate" keeps recent entries, "delete" removes all'),
+          keep: z
+            .number()
+            .min(1)
+            .max(10000)
+            .default(500)
+            .describe('Number of recent entries to keep (only for rotate)'),
+        }),
+        execute: async ({ job_id, action, keep }): Promise<string> => {
+          debugLog('cron_logs_cleanup:execute', { job_id, action, keep });
 
-        // Read all entries for summary (capped at most recent 500)
-        const entries = logStore.getEntries(job_id, 500, 0);
+          if (action === 'delete') {
+            const deleted = logStore.deleteJobLogs(job_id);
+            if (!deleted) return `No log file found for job "${job_id}".`;
+            return `All execution logs deleted for job "${job_id}".`;
+          }
 
-        const successes = entries.filter((e) => e.success).length;
-        const failures = entries.length - successes;
-        const successRate = ((successes / entries.length) * 100).toFixed(1);
-        const avgDuration = Math.round(
-          entries.reduce((s, e) => s + e.durationMs, 0) / entries.length,
-        );
-        const totalTokens = entries.reduce((s, e) => s + e.totalUsage.totalTokens, 0);
-        const avgTokens = Math.round(totalTokens / entries.length);
+          const countBefore = logStore.getEntryCount(job_id);
+          if (countBefore === 0) return `No execution logs found for job "${job_id}".`;
 
-        let result = `Summary for job "${job_id}" (${entries.length} runs analyzed of ${total} total):\n`;
-        result += `  Success rate: ${successRate}% (${successes} ok, ${failures} errors)\n`;
-        result += `  Avg duration: ${avgDuration}ms\n`;
-        result += `  Total tokens: ${totalTokens} (avg ${avgTokens}/run)\n`;
+          logStore.rotate(job_id, keep);
+          const countAfter = logStore.getEntryCount(job_id);
 
-        if (entries.length > 0) {
-          result += `  Latest run: ${entries[0].completedAt} (${entries[0].success ? 'ok' : 'error'})`;
-        }
-
-        return result;
-      },
-    }),
-
-    cron_logs_cleanup: tool({
-      description:
-        'Rotate or delete cron job execution logs. Use "rotate" to keep only the most recent entries, or "delete" to remove all logs for a job.',
-      parameters: z.object({
-        job_id: z.string().describe('Job ID'),
-        action: z
-          .enum(['rotate', 'delete'])
-          .describe('Action: "rotate" keeps recent entries, "delete" removes all'),
-        keep: z
-          .number()
-          .min(1)
-          .max(10000)
-          .default(500)
-          .describe('Number of recent entries to keep (only for rotate)'),
+          return `Rotated logs for job "${job_id}": ${countBefore} → ${countAfter} entries (kept last ${keep}).`;
+        },
       }),
-      execute: async ({ job_id, action, keep }): Promise<string> => {
-        debugLog('cron_logs_cleanup:execute', { job_id, action, keep });
-
-        if (action === 'delete') {
-          const deleted = logStore.deleteJobLogs(job_id);
-          if (!deleted) return `No log file found for job "${job_id}".`;
-          return `All execution logs deleted for job "${job_id}".`;
-        }
-
-        const countBefore = logStore.getEntryCount(job_id);
-        if (countBefore === 0) return `No execution logs found for job "${job_id}".`;
-
-        logStore.rotate(job_id, keep);
-        const countAfter = logStore.getEntryCount(job_id);
-
-        return `Rotated logs for job "${job_id}": ${countBefore} → ${countAfter} entries (kept last ${keep}).`;
-      },
-    }),
+    ),
   };
 }

--- a/src/tools/cron-notes.ts
+++ b/src/tools/cron-notes.ts
@@ -1,8 +1,20 @@
-import { tool } from 'ai';
+import { tool, type Tool } from 'ai';
 import { z } from 'zod';
 import { CronNotesStore, MAX_NOTE_LENGTH, type CronNoteEntry } from '../cron/notes-store.js';
 import { CronStore } from '../cron/store.js';
 import { debugLog } from '../logger.js';
+import { attachMeta } from '../framework/tools/adapter.js';
+import type { ToolMeta } from '../framework/tools/types.js';
+
+function withLocalMeta(name: string, kind: ToolMeta['kind'], t: Tool): Tool {
+  return attachMeta(t, {
+    name,
+    kind,
+    deterministic: false,
+    sideEffect: 'local',
+    cacheable: false,
+  });
+}
 
 function pluralizeEntries(n: number): string {
   return `${n} ${n === 1 ? 'entry' : 'entries'}`;
@@ -30,92 +42,108 @@ export function createCronNotesTools() {
   const cronStore = new CronStore();
 
   return {
-    cron_notes_read: tool({
-      description:
-        'Read all persistent notes for a cron job. Returns a human-readable formatted list of note entries including timestamp, optional runId, and text. Notes persist across daemon restarts and record actions prior runs took.',
-      parameters: z.object({
-        job_id: z.string().describe('Job ID to read notes for'),
+    cron_notes_read: withLocalMeta(
+      'cron_notes_read',
+      'read',
+      tool({
+        description:
+          'Read all persistent notes for a cron job. Returns a human-readable formatted list of note entries including timestamp, optional runId, and text. Notes persist across daemon restarts and record actions prior runs took.',
+        parameters: z.object({
+          job_id: z.string().describe('Job ID to read notes for'),
+        }),
+        execute: async ({ job_id }): Promise<string> => {
+          debugLog('cron_notes_read:execute', { job_id });
+
+          const notes = notesStore.read(job_id);
+          if (notes.entries.length === 0) {
+            return `No notes recorded for job "${job_id}".`;
+          }
+
+          const lines = notes.entries.map(formatEntryCompact);
+          return `Notes for job "${job_id}" (${pluralizeEntries(notes.entries.length)}):\n${lines.join('\n')}`;
+        },
       }),
-      execute: async ({ job_id }): Promise<string> => {
-        debugLog('cron_notes_read:execute', { job_id });
+    ),
 
-        const notes = notesStore.read(job_id);
-        if (notes.entries.length === 0) {
-          return `No notes recorded for job "${job_id}".`;
-        }
+    cron_notes_write: withLocalMeta(
+      'cron_notes_write',
+      'write',
+      tool({
+        description:
+          'Append a persistent note to a cron job. Use short factual entries recording significant actions (e.g. "Sent email to user@example.com", "Created issue #123"). Notes persist across daemon restarts.',
+        parameters: z.object({
+          job_id: z.string().describe('Job ID to attach the note to'),
+          text: z
+            .string()
+            .min(1)
+            .max(MAX_NOTE_LENGTH)
+            .describe('Short factual description of the action'),
+        }),
+        execute: async ({ job_id, text }): Promise<string> => {
+          debugLog('cron_notes_write:execute', { job_id, text });
 
-        const lines = notes.entries.map(formatEntryCompact);
-        return `Notes for job "${job_id}" (${pluralizeEntries(notes.entries.length)}):\n${lines.join('\n')}`;
-      },
-    }),
+          if (text.length > MAX_NOTE_LENGTH) {
+            return `Error: note text exceeds ${MAX_NOTE_LENGTH} characters (got ${text.length}). Summarize first.`;
+          }
 
-    cron_notes_write: tool({
-      description:
-        'Append a persistent note to a cron job. Use short factual entries recording significant actions (e.g. "Sent email to user@example.com", "Created issue #123"). Notes persist across daemon restarts.',
-      parameters: z.object({
-        job_id: z.string().describe('Job ID to attach the note to'),
-        text: z
-          .string()
-          .min(1)
-          .max(MAX_NOTE_LENGTH)
-          .describe('Short factual description of the action'),
+          const { total } = notesStore.append(job_id, text);
+          return `Appended note to job "${job_id}" (${pluralizeEntries(total)} total).`;
+        },
       }),
-      execute: async ({ job_id, text }): Promise<string> => {
-        debugLog('cron_notes_write:execute', { job_id, text });
+    ),
 
-        if (text.length > MAX_NOTE_LENGTH) {
-          return `Error: note text exceeds ${MAX_NOTE_LENGTH} characters (got ${text.length}). Summarize first.`;
-        }
+    cron_notes_list: withLocalMeta(
+      'cron_notes_list',
+      'read',
+      tool({
+        description:
+          'List all cron jobs that have persistent notes, with an entry count per job. Use to discover which jobs are tracking state.',
+        parameters: z.object({}),
+        execute: async (): Promise<string> => {
+          debugLog('cron_notes_list:execute', {});
 
-        const { total } = notesStore.append(job_id, text);
-        return `Appended note to job "${job_id}" (${pluralizeEntries(total)} total).`;
-      },
-    }),
+          const jobIds = notesStore.listJobIds();
+          if (jobIds.length === 0) {
+            return 'No cron jobs have notes yet.';
+          }
 
-    cron_notes_list: tool({
-      description:
-        'List all cron jobs that have persistent notes, with an entry count per job. Use to discover which jobs are tracking state.',
-      parameters: z.object({}),
-      execute: async (): Promise<string> => {
-        debugLog('cron_notes_list:execute', {});
+          const lines = jobIds.map((id) => {
+            const job = cronStore.getJob(id);
+            const label = job ? `${id} (${job.name})` : id;
+            const count = notesStore.read(id).entries.length;
+            return `  ${label}: ${pluralizeEntries(count)}`;
+          });
 
-        const jobIds = notesStore.listJobIds();
-        if (jobIds.length === 0) {
-          return 'No cron jobs have notes yet.';
-        }
-
-        const lines = jobIds.map((id) => {
-          const job = cronStore.getJob(id);
-          const label = job ? `${id} (${job.name})` : id;
-          const count = notesStore.read(id).entries.length;
-          return `  ${label}: ${pluralizeEntries(count)}`;
-        });
-
-        return `Jobs with notes:\n${lines.join('\n')}`;
-      },
-    }),
-
-    cron_notes_view: tool({
-      description:
-        "View a cron job's persistent notes formatted for human reading (one entry per block). Prefer cron_notes_read for programmatic consumption.",
-      parameters: z.object({
-        job_id: z.string().describe('Job ID to view notes for'),
+          return `Jobs with notes:\n${lines.join('\n')}`;
+        },
       }),
-      execute: async ({ job_id }): Promise<string> => {
-        debugLog('cron_notes_view:execute', { job_id });
+    ),
 
-        const notes = notesStore.read(job_id);
-        if (notes.entries.length === 0) {
-          return `No notes recorded for job "${job_id}".`;
-        }
+    cron_notes_view: withLocalMeta(
+      'cron_notes_view',
+      'read',
+      tool({
+        description:
+          "View a cron job's persistent notes formatted for human reading (one entry per block). Prefer cron_notes_read for programmatic consumption.",
+        parameters: z.object({
+          job_id: z.string().describe('Job ID to view notes for'),
+        }),
+        execute: async ({ job_id }): Promise<string> => {
+          debugLog('cron_notes_view:execute', { job_id });
 
-        const job = cronStore.getJob(job_id);
-        const header = job
-          ? `Notes for "${job.name}" (${job_id}) — ${pluralizeEntries(notes.entries.length)}`
-          : `Notes for job ${job_id} — ${pluralizeEntries(notes.entries.length)}`;
-        const body = notes.entries.map(formatEntryView).join('\n\n');
-        return `${header}\n\n${body}`;
-      },
-    }),
+          const notes = notesStore.read(job_id);
+          if (notes.entries.length === 0) {
+            return `No notes recorded for job "${job_id}".`;
+          }
+
+          const job = cronStore.getJob(job_id);
+          const header = job
+            ? `Notes for "${job.name}" (${job_id}) — ${pluralizeEntries(notes.entries.length)}`
+            : `Notes for job ${job_id} — ${pluralizeEntries(notes.entries.length)}`;
+          const body = notes.entries.map(formatEntryView).join('\n\n');
+          return `${header}\n\n${body}`;
+        },
+      }),
+    ),
   };
 }

--- a/src/tools/cron.ts
+++ b/src/tools/cron.ts
@@ -1,4 +1,4 @@
-import { tool } from 'ai';
+import { tool, type Tool } from 'ai';
 import { z } from 'zod';
 import cron from 'node-cron';
 import { CronStore } from '../cron/store.js';
@@ -6,6 +6,18 @@ import { CronLogStore } from '../cron/log-store.js';
 import { runJob } from '../cron/runner.js';
 import { isDaemonRunning, startDaemon, stopDaemon } from '../cron/client.js';
 import { debugLog } from '../logger.js';
+import { attachMeta } from '../framework/tools/adapter.js';
+import type { ToolMeta } from '../framework/tools/types.js';
+
+function withCronMeta(name: string, kind: ToolMeta['kind'], t: Tool): Tool {
+  return attachMeta(t, {
+    name,
+    kind,
+    deterministic: false,
+    sideEffect: 'local',
+    cacheable: false,
+  });
+}
 
 function ensureDaemon(): string | null {
   if (!isDaemonRunning()) {
@@ -40,299 +52,341 @@ export function createCronTools() {
   const logStore = new CronLogStore();
 
   return {
-    cron_create: tool({
-      description: 'Create a new scheduled cron job that runs an AI prompt on a schedule.',
-      parameters: z.object({
-        name: z.string().describe('Job name'),
-        schedule: z
-          .string()
-          .describe('Cron expression (e.g. "0 * * * *" for hourly, "*/5 * * * *" for every 5 min)'),
-        prompt: z.string().describe('The AI prompt to execute on each run'),
-      }),
-      execute: async ({ name, schedule, prompt }): Promise<string> => {
-        debugLog('cron_create:execute', { name, schedule, prompt });
+    cron_create: withCronMeta(
+      'cron_create',
+      'write',
+      tool({
+        description: 'Create a new scheduled cron job that runs an AI prompt on a schedule.',
+        parameters: z.object({
+          name: z.string().describe('Job name'),
+          schedule: z
+            .string()
+            .describe(
+              'Cron expression (e.g. "0 * * * *" for hourly, "*/5 * * * *" for every 5 min)',
+            ),
+          prompt: z.string().describe('The AI prompt to execute on each run'),
+        }),
+        execute: async ({ name, schedule, prompt }): Promise<string> => {
+          debugLog('cron_create:execute', { name, schedule, prompt });
 
-        if (!cron.validate(schedule)) {
-          return `Error: Invalid cron expression "${schedule}". Use standard cron format (e.g. "0 * * * *" for hourly, "*/5 * * * *" for every 5 minutes).`;
-        }
-
-        try {
-          const job = store.createJob(name, schedule, prompt);
-
-          const daemonErr = ensureDaemon();
-          if (daemonErr) {
-            return `Job "${job.name}" created (${job.id}) but daemon failed to start: ${daemonErr}`;
+          if (!cron.validate(schedule)) {
+            return `Error: Invalid cron expression "${schedule}". Use standard cron format (e.g. "0 * * * *" for hourly, "*/5 * * * *" for every 5 minutes).`;
           }
 
-          return `Cron job created:\n  ID: ${job.id}\n  Name: ${job.name}\n  Schedule: ${job.schedule}\n  Daemon: running`;
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return `Error creating job: ${msg}`;
-        }
-      },
-    }),
+          try {
+            const job = store.createJob(name, schedule, prompt);
 
-    cron_list: tool({
-      description: 'List all cron jobs with their status and last run info.',
-      parameters: z.object({}),
-      execute: async (): Promise<string> => {
-        debugLog('cron_list:execute', {});
+            const daemonErr = ensureDaemon();
+            if (daemonErr) {
+              return `Job "${job.name}" created (${job.id}) but daemon failed to start: ${daemonErr}`;
+            }
 
-        const jobs = store.loadJobs();
-        if (jobs.length === 0) return 'No cron jobs configured.';
-
-        const lines = jobs.map((j) => {
-          const status = j.enabled ? 'enabled' : 'disabled';
-          const lastRun = j.lastRun
-            ? `last run: ${j.lastRun} (${j.lastRunStatus || 'unknown'})`
-            : 'never run';
-          return `  - ${j.name} [${status}]\n    ID: ${j.id}\n    Schedule: ${j.schedule}\n    ${lastRun}`;
-        });
-
-        return `Cron jobs (${jobs.length}):\n${lines.join('\n')}`;
-      },
-    }),
-
-    cron_run: tool({
-      description:
-        "Manually run a cron job immediately. Executes the job's prompt through the AI agent and returns the result.",
-      parameters: z.object({
-        id: z.string().describe('Job ID to run'),
+            return `Cron job created:\n  ID: ${job.id}\n  Name: ${job.name}\n  Schedule: ${job.schedule}\n  Daemon: running`;
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return `Error creating job: ${msg}`;
+          }
+        },
       }),
-      execute: async ({ id }): Promise<string> => {
-        debugLog('cron_run:execute', { id });
+    ),
 
-        const job = store.getJob(id);
-        if (!job) return `Error: No job found with ID "${id}".`;
+    cron_list: withCronMeta(
+      'cron_list',
+      'read',
+      tool({
+        description: 'List all cron jobs with their status and last run info.',
+        parameters: z.object({}),
+        execute: async (): Promise<string> => {
+          debugLog('cron_list:execute', {});
 
-        if (job.lastRunStatus === 'running') {
-          return `Error: Job "${job.name}" is already running. Wait for it to finish before triggering another run.`;
-        }
+          const jobs = store.loadJobs();
+          if (jobs.length === 0) return 'No cron jobs configured.';
 
-        const disabledNote = job.enabled ? '' : '\nNote: this job is currently disabled.\n';
-
-        const startTime = new Date().toISOString();
-        store.updateJob(id, {
-          lastRun: startTime,
-          lastRunStatus: 'running',
-        });
-
-        try {
-          const logs: string[] = [];
-          const result = await runJob(job, (msg) => logs.push(msg));
-
-          store.updateJob(id, {
-            lastRunStatus: result.success ? 'success' : 'error',
-            lastResult: result.output.slice(0, 2000),
+          const lines = jobs.map((j) => {
+            const status = j.enabled ? 'enabled' : 'disabled';
+            const lastRun = j.lastRun
+              ? `last run: ${j.lastRun} (${j.lastRunStatus || 'unknown'})`
+              : 'never run';
+            return `  - ${j.name} [${status}]\n    ID: ${j.id}\n    Schedule: ${j.schedule}\n    ${lastRun}`;
           });
 
-          const status = result.success ? 'Success' : 'Error';
-          let response = `${disabledNote}Job "${job.name}" — ${status}\n\nOutput:\n${result.output}`;
-          if (logs.length > 0) {
-            response += `\n\nLogs:\n${logs.join('\n')}`;
-          }
-          return response;
-        } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
-          store.updateJob(id, {
-            lastRunStatus: 'error',
-            lastResult: message.slice(0, 2000),
-          });
-          return `${disabledNote}Job "${job.name}" — Error\n\nThrew: ${message}`;
-        }
-      },
-    }),
-
-    cron_get: tool({
-      description: 'Get full details of a cron job including prompt text and last result.',
-      parameters: z.object({
-        id: z.string().describe('Job ID'),
+          return `Cron jobs (${jobs.length}):\n${lines.join('\n')}`;
+        },
       }),
-      execute: async ({ id }): Promise<string> => {
-        debugLog('cron_get:execute', { id });
+    ),
 
-        const job = store.getJob(id);
-        if (!job) return `Error: No job found with ID "${id}".`;
+    cron_run: withCronMeta(
+      'cron_run',
+      'write',
+      tool({
+        description:
+          "Manually run a cron job immediately. Executes the job's prompt through the AI agent and returns the result.",
+        parameters: z.object({
+          id: z.string().describe('Job ID to run'),
+        }),
+        execute: async ({ id }): Promise<string> => {
+          debugLog('cron_run:execute', { id });
 
-        let result = `Job details:\n`;
-        result += `  ID: ${job.id}\n`;
-        result += `  Name: ${job.name}\n`;
-        result += `  Schedule: ${job.schedule}\n`;
-        result += `  Enabled: ${job.enabled}\n`;
-        result += `  Created: ${job.createdAt}\n`;
-        result += `  Prompt: ${job.prompt}`;
-        if (job.lastRun) {
-          result += `\n  Last run: ${job.lastRun}`;
-          result += `\n  Last status: ${job.lastRunStatus || 'unknown'}`;
-          if (job.lastResult) {
-            result += `\n  Last result: ${job.lastResult}`;
+          const job = store.getJob(id);
+          if (!job) return `Error: No job found with ID "${id}".`;
+
+          if (job.lastRunStatus === 'running') {
+            return `Error: Job "${job.name}" is already running. Wait for it to finish before triggering another run.`;
           }
-        }
 
-        return result;
-      },
-    }),
+          const disabledNote = job.enabled ? '' : '\nNote: this job is currently disabled.\n';
 
-    cron_update: tool({
-      description: `Update a cron job's name, schedule, or prompt. You MUST include the new values as parameters.
+          const startTime = new Date().toISOString();
+          store.updateJob(id, {
+            lastRun: startTime,
+            lastRunStatus: 'running',
+          });
+
+          try {
+            const logs: string[] = [];
+            const result = await runJob(job, (msg) => logs.push(msg));
+
+            store.updateJob(id, {
+              lastRunStatus: result.success ? 'success' : 'error',
+              lastResult: result.output.slice(0, 2000),
+            });
+
+            const status = result.success ? 'Success' : 'Error';
+            let response = `${disabledNote}Job "${job.name}" — ${status}\n\nOutput:\n${result.output}`;
+            if (logs.length > 0) {
+              response += `\n\nLogs:\n${logs.join('\n')}`;
+            }
+            return response;
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            store.updateJob(id, {
+              lastRunStatus: 'error',
+              lastResult: message.slice(0, 2000),
+            });
+            return `${disabledNote}Job "${job.name}" — Error\n\nThrew: ${message}`;
+          }
+        },
+      }),
+    ),
+
+    cron_get: withCronMeta(
+      'cron_get',
+      'read',
+      tool({
+        description: 'Get full details of a cron job including prompt text and last result.',
+        parameters: z.object({
+          id: z.string().describe('Job ID'),
+        }),
+        execute: async ({ id }): Promise<string> => {
+          debugLog('cron_get:execute', { id });
+
+          const job = store.getJob(id);
+          if (!job) return `Error: No job found with ID "${id}".`;
+
+          let result = `Job details:\n`;
+          result += `  ID: ${job.id}\n`;
+          result += `  Name: ${job.name}\n`;
+          result += `  Schedule: ${job.schedule}\n`;
+          result += `  Enabled: ${job.enabled}\n`;
+          result += `  Created: ${job.createdAt}\n`;
+          result += `  Prompt: ${job.prompt}`;
+          if (job.lastRun) {
+            result += `\n  Last run: ${job.lastRun}`;
+            result += `\n  Last status: ${job.lastRunStatus || 'unknown'}`;
+            if (job.lastResult) {
+              result += `\n  Last result: ${job.lastResult}`;
+            }
+          }
+
+          return result;
+        },
+      }),
+    ),
+
+    cron_update: withCronMeta(
+      'cron_update',
+      'write',
+      tool({
+        description: `Update a cron job's name, schedule, or prompt. You MUST include the new values as parameters.
 Examples:
   Change prompt: { "id": "<id>", "prompt": "new prompt text" }
   Change schedule: { "id": "<id>", "schedule": "*/30 * * * *" }
   Change multiple: { "id": "<id>", "name": "New name", "prompt": "new prompt" }`,
-      parameters: z.object({
-        id: z.string().describe('Job ID'),
-        name: z.string().optional().describe('New job name'),
-        schedule: z.string().optional().describe('New cron expression'),
-        prompt: z
-          .string()
-          .optional()
-          .describe('New AI prompt text — replaces the existing prompt entirely'),
-      }),
-      execute: async ({ id, name, schedule, prompt }): Promise<string> => {
-        debugLog('cron_update:execute', { id, name, schedule, prompt });
+        parameters: z.object({
+          id: z.string().describe('Job ID'),
+          name: z.string().optional().describe('New job name'),
+          schedule: z.string().optional().describe('New cron expression'),
+          prompt: z
+            .string()
+            .optional()
+            .describe('New AI prompt text — replaces the existing prompt entirely'),
+        }),
+        execute: async ({ id, name, schedule, prompt }): Promise<string> => {
+          debugLog('cron_update:execute', { id, name, schedule, prompt });
 
-        if (!name && !schedule && !prompt) {
-          const received = Object.entries({ id, name, schedule, prompt })
-            .filter(([, v]) => v !== undefined)
-            .map(([k]) => k)
-            .join(', ');
-          return (
-            'Error: update requires at least one field to change (name, schedule, prompt) as a parameter in this tool call. ' +
-            'Example: {"id":"...","prompt":"new prompt text"}. ' +
-            `Received parameters: ${received}.`
-          );
-        }
-
-        if (schedule && !cron.validate(schedule)) {
-          return `Error: Invalid cron expression "${schedule}". Use standard cron format (e.g. "0 * * * *" for hourly, "*/5 * * * *" for every 5 minutes).`;
-        }
-
-        const updates: Record<string, string> = {};
-        if (name) updates.name = name;
-        if (schedule) updates.schedule = schedule;
-        if (prompt) updates.prompt = prompt;
-
-        const job = store.updateJob(id, updates);
-        if (!job) return `Error: No job found with ID "${id}".`;
-
-        return `Job updated:\n  ID: ${job.id}\n  Name: ${job.name}\n  Schedule: ${job.schedule}\n  Enabled: ${job.enabled}`;
-      },
-    }),
-
-    cron_delete: tool({
-      description: 'Delete a cron job.',
-      parameters: z.object({
-        id: z.string().describe('Job ID'),
-      }),
-      execute: async ({ id }): Promise<string> => {
-        debugLog('cron_delete:execute', { id });
-
-        const deleted = store.deleteJob(id);
-        if (!deleted) return `Error: No job found with ID "${id}".`;
-
-        logStore.deleteJobLogs(id);
-
-        const suffix = stopIfNoEnabledJobs(store);
-        if (suffix) return `Job deleted.${suffix}`;
-
-        return `Job "${id}" deleted.`;
-      },
-    }),
-
-    cron_enable: tool({
-      description: 'Enable a disabled cron job.',
-      parameters: z.object({
-        id: z.string().describe('Job ID'),
-      }),
-      execute: async ({ id }): Promise<string> => {
-        debugLog('cron_enable:execute', { id });
-
-        const job = store.updateJob(id, { enabled: true });
-        if (!job) return `Error: No job found with ID "${id}".`;
-
-        const daemonErr = ensureDaemon();
-        if (daemonErr) {
-          return `Job "${job.name}" enabled but daemon failed to start: ${daemonErr}`;
-        }
-
-        return `Job "${job.name}" enabled. Daemon running.`;
-      },
-    }),
-
-    cron_disable: tool({
-      description: 'Disable an active cron job.',
-      parameters: z.object({
-        id: z.string().describe('Job ID'),
-      }),
-      execute: async ({ id }): Promise<string> => {
-        debugLog('cron_disable:execute', { id });
-
-        const job = store.updateJob(id, { enabled: false });
-        if (!job) return `Error: No job found with ID "${id}".`;
-
-        const suffix = stopIfNoEnabledJobs(store);
-        if (suffix) return `Job "${job.name}" disabled.${suffix}`;
-
-        return `Job "${job.name}" disabled.`;
-      },
-    }),
-
-    cron_status: tool({
-      description: 'Check cron daemon status and job counts.',
-      parameters: z.object({}),
-      execute: async (): Promise<string> => {
-        debugLog('cron_status:execute', {});
-
-        const running = isDaemonRunning();
-        const jobs = store.loadJobs();
-        const enabled = jobs.filter((j) => j.enabled).length;
-        const alerts = store.listAlerts().filter((a) => !a.acknowledged);
-
-        let result = `Daemon: ${running ? 'running' : 'stopped'}\n`;
-        result += `Jobs: ${jobs.length} total, ${enabled} enabled\n`;
-        result += `Unacknowledged alerts: ${alerts.length}`;
-
-        if (alerts.length > 0) {
-          result += '\n\nRecent alerts:';
-          for (const alert of alerts.slice(0, 5)) {
-            result += `\n  - [${alert.timestamp}] ${alert.jobName}: ${alert.message}`;
+          if (!name && !schedule && !prompt) {
+            const received = Object.entries({ id, name, schedule, prompt })
+              .filter(([, v]) => v !== undefined)
+              .map(([k]) => k)
+              .join(', ');
+            return (
+              'Error: update requires at least one field to change (name, schedule, prompt) as a parameter in this tool call. ' +
+              'Example: {"id":"...","prompt":"new prompt text"}. ' +
+              `Received parameters: ${received}.`
+            );
           }
-        }
 
-        return result;
-      },
-    }),
+          if (schedule && !cron.validate(schedule)) {
+            return `Error: Invalid cron expression "${schedule}". Use standard cron format (e.g. "0 * * * *" for hourly, "*/5 * * * *" for every 5 minutes).`;
+          }
 
-    cron_bounce: tool({
-      description:
-        'Restart the cron daemon. Useful after code updates or if the daemon is misbehaving.',
-      parameters: z.object({}),
-      execute: async (): Promise<string> => {
-        debugLog('cron_bounce:execute', {});
+          const updates: Record<string, string> = {};
+          if (name) updates.name = name;
+          if (schedule) updates.schedule = schedule;
+          if (prompt) updates.prompt = prompt;
 
-        const wasRunning = isDaemonRunning();
-        if (wasRunning) {
-          stopDaemon();
-          // Brief delay for process cleanup
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        }
+          const job = store.updateJob(id, updates);
+          if (!job) return `Error: No job found with ID "${id}".`;
 
-        const enabled = store.loadJobs().filter((j) => j.enabled);
-        if (enabled.length === 0) {
-          return wasRunning
-            ? 'Daemon stopped. No enabled jobs — not restarting.'
-            : 'Daemon was not running. No enabled jobs — nothing to do.';
-        }
+          return `Job updated:\n  ID: ${job.id}\n  Name: ${job.name}\n  Schedule: ${job.schedule}\n  Enabled: ${job.enabled}`;
+        },
+      }),
+    ),
 
-        try {
-          startDaemon();
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return `Daemon ${wasRunning ? 'stopped but' : 'was not running and'} failed to restart: ${msg}`;
-        }
+    cron_delete: withCronMeta(
+      'cron_delete',
+      'write',
+      tool({
+        description: 'Delete a cron job.',
+        parameters: z.object({
+          id: z.string().describe('Job ID'),
+        }),
+        execute: async ({ id }): Promise<string> => {
+          debugLog('cron_delete:execute', { id });
 
-        return `Daemon restarted. ${enabled.length} enabled job${enabled.length === 1 ? '' : 's'}.`;
-      },
-    }),
+          const deleted = store.deleteJob(id);
+          if (!deleted) return `Error: No job found with ID "${id}".`;
+
+          logStore.deleteJobLogs(id);
+
+          const suffix = stopIfNoEnabledJobs(store);
+          if (suffix) return `Job deleted.${suffix}`;
+
+          return `Job "${id}" deleted.`;
+        },
+      }),
+    ),
+
+    cron_enable: withCronMeta(
+      'cron_enable',
+      'write',
+      tool({
+        description: 'Enable a disabled cron job.',
+        parameters: z.object({
+          id: z.string().describe('Job ID'),
+        }),
+        execute: async ({ id }): Promise<string> => {
+          debugLog('cron_enable:execute', { id });
+
+          const job = store.updateJob(id, { enabled: true });
+          if (!job) return `Error: No job found with ID "${id}".`;
+
+          const daemonErr = ensureDaemon();
+          if (daemonErr) {
+            return `Job "${job.name}" enabled but daemon failed to start: ${daemonErr}`;
+          }
+
+          return `Job "${job.name}" enabled. Daemon running.`;
+        },
+      }),
+    ),
+
+    cron_disable: withCronMeta(
+      'cron_disable',
+      'write',
+      tool({
+        description: 'Disable an active cron job.',
+        parameters: z.object({
+          id: z.string().describe('Job ID'),
+        }),
+        execute: async ({ id }): Promise<string> => {
+          debugLog('cron_disable:execute', { id });
+
+          const job = store.updateJob(id, { enabled: false });
+          if (!job) return `Error: No job found with ID "${id}".`;
+
+          const suffix = stopIfNoEnabledJobs(store);
+          if (suffix) return `Job "${job.name}" disabled.${suffix}`;
+
+          return `Job "${job.name}" disabled.`;
+        },
+      }),
+    ),
+
+    cron_status: withCronMeta(
+      'cron_status',
+      'read',
+      tool({
+        description: 'Check cron daemon status and job counts.',
+        parameters: z.object({}),
+        execute: async (): Promise<string> => {
+          debugLog('cron_status:execute', {});
+
+          const running = isDaemonRunning();
+          const jobs = store.loadJobs();
+          const enabled = jobs.filter((j) => j.enabled).length;
+          const alerts = store.listAlerts().filter((a) => !a.acknowledged);
+
+          let result = `Daemon: ${running ? 'running' : 'stopped'}\n`;
+          result += `Jobs: ${jobs.length} total, ${enabled} enabled\n`;
+          result += `Unacknowledged alerts: ${alerts.length}`;
+
+          if (alerts.length > 0) {
+            result += '\n\nRecent alerts:';
+            for (const alert of alerts.slice(0, 5)) {
+              result += `\n  - [${alert.timestamp}] ${alert.jobName}: ${alert.message}`;
+            }
+          }
+
+          return result;
+        },
+      }),
+    ),
+
+    cron_bounce: withCronMeta(
+      'cron_bounce',
+      'write',
+      tool({
+        description:
+          'Restart the cron daemon. Useful after code updates or if the daemon is misbehaving.',
+        parameters: z.object({}),
+        execute: async (): Promise<string> => {
+          debugLog('cron_bounce:execute', {});
+
+          const wasRunning = isDaemonRunning();
+          if (wasRunning) {
+            stopDaemon();
+            // Brief delay for process cleanup
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+
+          const enabled = store.loadJobs().filter((j) => j.enabled);
+          if (enabled.length === 0) {
+            return wasRunning
+              ? 'Daemon stopped. No enabled jobs — not restarting.'
+              : 'Daemon was not running. No enabled jobs — nothing to do.';
+          }
+
+          try {
+            startDaemon();
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return `Daemon ${wasRunning ? 'stopped but' : 'was not running and'} failed to restart: ${msg}`;
+          }
+
+          return `Daemon restarted. ${enabled.length} enabled job${enabled.length === 1 ? '' : 's'}.`;
+        },
+      }),
+    ),
   };
 }

--- a/src/tools/datetime.ts
+++ b/src/tools/datetime.ts
@@ -1,29 +1,39 @@
 import { tool, type UserContent } from 'ai';
 import { z } from 'zod';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /** Regex matching the [ISO-8601] prefix produced by timestampUserMessage. */
 const TIMESTAMP_PREFIX_RE = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}\] /;
 
 /** Creates a tool that returns the current local date and time as a human-readable string. */
 export function createDateTimeTool() {
-  return tool({
-    description:
-      'Get the current date and time including hours and minutes. Timestamps are automatically attached to user messages, so use this only when you need a precise mid-turn timestamp (e.g., after a long-running tool call).',
-    parameters: z.object({}),
-    execute: async (): Promise<string> => {
-      const now = new Date();
-      return now.toLocaleString('en-US', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        second: '2-digit',
-        timeZoneName: 'short',
-      });
+  return attachMeta(
+    tool({
+      description:
+        'Get the current date and time including hours and minutes. Timestamps are automatically attached to user messages, so use this only when you need a precise mid-turn timestamp (e.g., after a long-running tool call).',
+      parameters: z.object({}),
+      execute: async (): Promise<string> => {
+        const now = new Date();
+        return now.toLocaleString('en-US', {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          second: '2-digit',
+          timeZoneName: 'short',
+        });
+      },
+    }),
+    {
+      name: 'datetime',
+      kind: 'read',
+      deterministic: false,
+      sideEffect: 'none',
+      cacheable: false,
     },
-  });
+  );
 }
 
 /** Returns a human-readable date+time string for use in system prompts. */

--- a/src/tools/file.ts
+++ b/src/tools/file.ts
@@ -1,5 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { attachMeta } from '../framework/tools/adapter.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
@@ -167,290 +168,315 @@ function detectLineEnding(content: string): string {
 /** Creates file_read_lines and file_edit_lines tools. */
 export function createFileTools() {
   return {
-    file_read_lines: tool({
-      description:
-        'Read a file with line numbers. Returns structured line-numbered content for precise referencing. Use offset/limit to paginate large files.',
-      parameters: z.object({
-        path: z.string().describe('File path to read (relative or absolute)'),
-        offset: z
-          .number()
-          .int()
-          .min(1)
-          .optional()
-          .describe('Start line number (1-based, default 1)'),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .optional()
-          .describe('Maximum lines to return (default 1000)'),
-      }),
-      execute: async ({
-        path: filePath,
-        offset = 1,
-        limit = 1000,
-      }): Promise<
-        | {
-            path: string;
-            total_lines: number;
-            offset: number;
-            limit: number;
-            lines: Array<{ num: number; content: string }>;
-            truncated: boolean;
-          }
-        | { error: string }
-      > => {
-        try {
-          const absPath = path.resolve(filePath);
-
-          // Validate file exists
-          let stat: fs.Stats;
-          try {
-            stat = fs.statSync(absPath);
-          } catch (err: unknown) {
-            const code = (err as NodeJS.ErrnoException).code;
-            if (code === 'ENOENT') return { error: `File not found: ${absPath}` };
-            return { error: `Cannot access ${absPath}: ${(err as Error).message}` };
-          }
-
-          if (stat.isDirectory()) {
-            return { error: `Path is a directory, not a file: ${absPath}` };
-          }
-
-          if (stat.size > MAX_FILE_SIZE) {
-            return {
-              error: `File too large (${stat.size} bytes, max ${MAX_FILE_SIZE}): ${absPath}`,
-            };
-          }
-
-          // Read once — use buffer for binary check, then decode
-          const rawBuffer = fs.readFileSync(absPath);
-          if (isBinaryContent(rawBuffer)) {
-            return { error: `File appears to be binary: ${absPath}` };
-          }
-          const content = rawBuffer.toString('utf-8');
-          const allLines = splitLines(content);
-          const totalLines = allLines.length;
-
-          const startIdx = offset - 1;
-          const endIdx = Math.min(startIdx + limit, totalLines);
-          const sliced = startIdx < totalLines ? allLines.slice(startIdx, endIdx) : [];
-
-          const lines = sliced.map((line, i) => ({
-            num: startIdx + i + 1,
-            content: line,
-          }));
-
-          return {
-            path: absPath,
-            total_lines: totalLines,
-            offset,
-            limit,
-            lines,
-            truncated: endIdx < totalLines,
-          };
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return { error: msg };
-        }
-      },
-    }),
-
-    file_edit_lines: tool({
-      description:
-        'Edit a file with precise line-based operations. Supports replace, insert, delete, and append actions. Multiple edits are applied atomically (all or nothing). Always read the file first with file_read_lines to get current line numbers.',
-      parameters: z.object({
-        path: z.string().describe('File path to edit (relative or absolute)'),
-        edits: z
-          .array(
-            z.object({
-              action: z
-                .enum(['replace', 'insert', 'delete', 'append'])
-                .describe(
-                  'replace: replace content at a line number; insert: insert before a line; delete: remove specific lines; append: add to end of file',
-                ),
-              line: z.number().int().min(1).optional().describe('Line number for replace action'),
-              before: z.number().int().min(1).optional().describe('Line number to insert before'),
-              lines: z.array(z.number().int().min(1)).optional().describe('Line numbers to delete'),
-              content: z
-                .string()
-                .optional()
-                .describe('New content for replace/insert/append (may contain \\n for multi-line)'),
-            }),
-          )
-          .min(1)
-          .describe('Array of edit operations to apply'),
-      }),
-      execute: async ({
-        path: filePath,
-        edits,
-      }): Promise<
-        | {
-            path: string;
-            old_hash: string;
-            new_hash: string;
-            edits_applied: number;
-            total_lines: number;
-            diff: string;
-          }
-        | { error: string }
-      > => {
-        try {
-          const absPath = path.resolve(filePath);
-
-          // Validate file exists
-          let stat: fs.Stats;
-          try {
-            stat = fs.statSync(absPath);
-          } catch (err: unknown) {
-            const code = (err as NodeJS.ErrnoException).code;
-            if (code === 'ENOENT') return { error: `File not found: ${absPath}` };
-            return { error: `Cannot access ${absPath}: ${(err as Error).message}` };
-          }
-
-          if (stat.isDirectory()) {
-            return { error: `Path is a directory, not a file: ${absPath}` };
-          }
-
-          if (stat.size > MAX_FILE_SIZE) {
-            return {
-              error: `File too large (${stat.size} bytes, max ${MAX_FILE_SIZE}): ${absPath}`,
-            };
-          }
-
-          // Read once — use buffer for binary check, then decode
-          const rawBuffer = fs.readFileSync(absPath);
-          if (isBinaryContent(rawBuffer)) {
-            return { error: `File appears to be binary: ${absPath}` };
-          }
-          const rawContent = rawBuffer.toString('utf-8');
-          const lineEnding = detectLineEnding(rawContent);
-          const hadTrailingNewline =
-            rawContent.length > 0 && (rawContent.endsWith('\n') || rawContent.endsWith('\r\n'));
-          const oldLines = splitLines(rawContent);
-          const totalLines = oldLines.length;
-          const oldHash = hashContent(rawContent);
-
-          // Validate all edits upfront
-          const validationErrors: string[] = [];
-
-          for (let i = 0; i < edits.length; i++) {
-            const e = edits[i];
-            const prefix = `Edit ${i + 1} (${e.action})`;
-
-            switch (e.action) {
-              case 'replace':
-                if (e.line === undefined) validationErrors.push(`${prefix}: "line" is required`);
-                else if (e.line > totalLines)
-                  validationErrors.push(
-                    `${prefix}: line ${e.line} out of bounds (file has ${totalLines} lines)`,
-                  );
-                if (e.content === undefined)
-                  validationErrors.push(`${prefix}: "content" is required`);
-                break;
-              case 'insert':
-                if (e.before === undefined)
-                  validationErrors.push(`${prefix}: "before" is required`);
-                else if (e.before > totalLines + 1)
-                  validationErrors.push(
-                    `${prefix}: before ${e.before} out of bounds (file has ${totalLines} lines, max ${totalLines + 1})`,
-                  );
-                if (e.content === undefined)
-                  validationErrors.push(`${prefix}: "content" is required`);
-                break;
-              case 'delete':
-                if (!e.lines || e.lines.length === 0)
-                  validationErrors.push(
-                    `${prefix}: "lines" array is required and must not be empty`,
-                  );
-                else {
-                  for (const ln of e.lines) {
-                    if (ln > totalLines)
-                      validationErrors.push(
-                        `${prefix}: line ${ln} out of bounds (file has ${totalLines} lines)`,
-                      );
-                  }
-                }
-                break;
-              case 'append':
-                if (e.content === undefined)
-                  validationErrors.push(`${prefix}: "content" is required`);
-                break;
+    file_read_lines: attachMeta(
+      tool({
+        description:
+          'Read a file with line numbers. Returns structured line-numbered content for precise referencing. Use offset/limit to paginate large files.',
+        parameters: z.object({
+          path: z.string().describe('File path to read (relative or absolute)'),
+          offset: z
+            .number()
+            .int()
+            .min(1)
+            .optional()
+            .describe('Start line number (1-based, default 1)'),
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .optional()
+            .describe('Maximum lines to return (default 1000)'),
+        }),
+        execute: async ({
+          path: filePath,
+          offset = 1,
+          limit = 1000,
+        }): Promise<
+          | {
+              path: string;
+              total_lines: number;
+              offset: number;
+              limit: number;
+              lines: Array<{ num: number; content: string }>;
+              truncated: boolean;
             }
-          }
-
-          // Check for conflicts
-          const conflicts = detectConflicts(edits);
-          validationErrors.push(...conflicts);
-
-          if (validationErrors.length > 0) {
-            return { error: validationErrors.join('; ') };
-          }
-
-          // Sort edits descending so high-line edits are applied first
-          const sorted = sortEditsDescending(edits);
-
-          // Apply edits to in-memory lines
-          const lines = [...oldLines];
-
-          for (const { original: e } of sorted) {
-            switch (e.action) {
-              case 'replace': {
-                const newLines = e.content!.split('\n');
-                lines.splice(e.line! - 1, 1, ...newLines);
-                break;
-              }
-              case 'insert':
-                lines.splice(e.before! - 1, 0, ...e.content!.split('\n'));
-                break;
-              case 'delete': {
-                // Sort delete line numbers descending within this edit
-                const delLines = [...e.lines!].sort((a, b) => b - a);
-                for (const ln of delLines) {
-                  lines.splice(ln - 1, 1);
-                }
-                break;
-              }
-              case 'append':
-                lines.push(...e.content!.split('\n'));
-                break;
-            }
-          }
-
-          // Write atomically: write to temp file, then rename (POSIX rename atomically replaces target)
-          const newContent =
-            lines.length > 0 ? lines.join(lineEnding) + (hadTrailingNewline ? lineEnding : '') : '';
-          const tmpPath = `${absPath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
-
+          | { error: string }
+        > => {
           try {
-            fs.writeFileSync(tmpPath, newContent, 'utf-8');
-            fs.renameSync(tmpPath, absPath);
-          } catch (writeErr: unknown) {
+            const absPath = path.resolve(filePath);
+
+            // Validate file exists
+            let stat: fs.Stats;
             try {
-              fs.unlinkSync(tmpPath);
-            } catch {
-              // Best-effort cleanup
+              stat = fs.statSync(absPath);
+            } catch (err: unknown) {
+              const code = (err as NodeJS.ErrnoException).code;
+              if (code === 'ENOENT') return { error: `File not found: ${absPath}` };
+              return { error: `Cannot access ${absPath}: ${(err as Error).message}` };
             }
-            const msg = writeErr instanceof Error ? writeErr.message : String(writeErr);
-            return { error: `Write failed: ${msg}` };
+
+            if (stat.isDirectory()) {
+              return { error: `Path is a directory, not a file: ${absPath}` };
+            }
+
+            if (stat.size > MAX_FILE_SIZE) {
+              return {
+                error: `File too large (${stat.size} bytes, max ${MAX_FILE_SIZE}): ${absPath}`,
+              };
+            }
+
+            // Read once — use buffer for binary check, then decode
+            const rawBuffer = fs.readFileSync(absPath);
+            if (isBinaryContent(rawBuffer)) {
+              return { error: `File appears to be binary: ${absPath}` };
+            }
+            const content = rawBuffer.toString('utf-8');
+            const allLines = splitLines(content);
+            const totalLines = allLines.length;
+
+            const startIdx = offset - 1;
+            const endIdx = Math.min(startIdx + limit, totalLines);
+            const sliced = startIdx < totalLines ? allLines.slice(startIdx, endIdx) : [];
+
+            const lines = sliced.map((line, i) => ({
+              num: startIdx + i + 1,
+              content: line,
+            }));
+
+            return {
+              path: absPath,
+              total_lines: totalLines,
+              offset,
+              limit,
+              lines,
+              truncated: endIdx < totalLines,
+            };
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return { error: msg };
           }
-
-          const newHash = hashContent(newContent);
-          const diff = generateDiffSummary(oldLines, edits);
-
-          return {
-            path: absPath,
-            old_hash: oldHash,
-            new_hash: newHash,
-            edits_applied: edits.length,
-            total_lines: lines.length,
-            diff,
-          };
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return { error: msg };
-        }
+        },
+      }),
+      {
+        name: 'file_read_lines',
+        kind: 'read',
+        deterministic: false,
+        sideEffect: 'local',
+        cacheable: false,
       },
-    }),
+    ),
+
+    file_edit_lines: attachMeta(
+      tool({
+        description:
+          'Edit a file with precise line-based operations. Supports replace, insert, delete, and append actions. Multiple edits are applied atomically (all or nothing). Always read the file first with file_read_lines to get current line numbers.',
+        parameters: z.object({
+          path: z.string().describe('File path to edit (relative or absolute)'),
+          edits: z
+            .array(
+              z.object({
+                action: z
+                  .enum(['replace', 'insert', 'delete', 'append'])
+                  .describe(
+                    'replace: replace content at a line number; insert: insert before a line; delete: remove specific lines; append: add to end of file',
+                  ),
+                line: z.number().int().min(1).optional().describe('Line number for replace action'),
+                before: z.number().int().min(1).optional().describe('Line number to insert before'),
+                lines: z
+                  .array(z.number().int().min(1))
+                  .optional()
+                  .describe('Line numbers to delete'),
+                content: z
+                  .string()
+                  .optional()
+                  .describe(
+                    'New content for replace/insert/append (may contain \\n for multi-line)',
+                  ),
+              }),
+            )
+            .min(1)
+            .describe('Array of edit operations to apply'),
+        }),
+        execute: async ({
+          path: filePath,
+          edits,
+        }): Promise<
+          | {
+              path: string;
+              old_hash: string;
+              new_hash: string;
+              edits_applied: number;
+              total_lines: number;
+              diff: string;
+            }
+          | { error: string }
+        > => {
+          try {
+            const absPath = path.resolve(filePath);
+
+            // Validate file exists
+            let stat: fs.Stats;
+            try {
+              stat = fs.statSync(absPath);
+            } catch (err: unknown) {
+              const code = (err as NodeJS.ErrnoException).code;
+              if (code === 'ENOENT') return { error: `File not found: ${absPath}` };
+              return { error: `Cannot access ${absPath}: ${(err as Error).message}` };
+            }
+
+            if (stat.isDirectory()) {
+              return { error: `Path is a directory, not a file: ${absPath}` };
+            }
+
+            if (stat.size > MAX_FILE_SIZE) {
+              return {
+                error: `File too large (${stat.size} bytes, max ${MAX_FILE_SIZE}): ${absPath}`,
+              };
+            }
+
+            // Read once — use buffer for binary check, then decode
+            const rawBuffer = fs.readFileSync(absPath);
+            if (isBinaryContent(rawBuffer)) {
+              return { error: `File appears to be binary: ${absPath}` };
+            }
+            const rawContent = rawBuffer.toString('utf-8');
+            const lineEnding = detectLineEnding(rawContent);
+            const hadTrailingNewline =
+              rawContent.length > 0 && (rawContent.endsWith('\n') || rawContent.endsWith('\r\n'));
+            const oldLines = splitLines(rawContent);
+            const totalLines = oldLines.length;
+            const oldHash = hashContent(rawContent);
+
+            // Validate all edits upfront
+            const validationErrors: string[] = [];
+
+            for (let i = 0; i < edits.length; i++) {
+              const e = edits[i];
+              const prefix = `Edit ${i + 1} (${e.action})`;
+
+              switch (e.action) {
+                case 'replace':
+                  if (e.line === undefined) validationErrors.push(`${prefix}: "line" is required`);
+                  else if (e.line > totalLines)
+                    validationErrors.push(
+                      `${prefix}: line ${e.line} out of bounds (file has ${totalLines} lines)`,
+                    );
+                  if (e.content === undefined)
+                    validationErrors.push(`${prefix}: "content" is required`);
+                  break;
+                case 'insert':
+                  if (e.before === undefined)
+                    validationErrors.push(`${prefix}: "before" is required`);
+                  else if (e.before > totalLines + 1)
+                    validationErrors.push(
+                      `${prefix}: before ${e.before} out of bounds (file has ${totalLines} lines, max ${totalLines + 1})`,
+                    );
+                  if (e.content === undefined)
+                    validationErrors.push(`${prefix}: "content" is required`);
+                  break;
+                case 'delete':
+                  if (!e.lines || e.lines.length === 0)
+                    validationErrors.push(
+                      `${prefix}: "lines" array is required and must not be empty`,
+                    );
+                  else {
+                    for (const ln of e.lines) {
+                      if (ln > totalLines)
+                        validationErrors.push(
+                          `${prefix}: line ${ln} out of bounds (file has ${totalLines} lines)`,
+                        );
+                    }
+                  }
+                  break;
+                case 'append':
+                  if (e.content === undefined)
+                    validationErrors.push(`${prefix}: "content" is required`);
+                  break;
+              }
+            }
+
+            // Check for conflicts
+            const conflicts = detectConflicts(edits);
+            validationErrors.push(...conflicts);
+
+            if (validationErrors.length > 0) {
+              return { error: validationErrors.join('; ') };
+            }
+
+            // Sort edits descending so high-line edits are applied first
+            const sorted = sortEditsDescending(edits);
+
+            // Apply edits to in-memory lines
+            const lines = [...oldLines];
+
+            for (const { original: e } of sorted) {
+              switch (e.action) {
+                case 'replace': {
+                  const newLines = e.content!.split('\n');
+                  lines.splice(e.line! - 1, 1, ...newLines);
+                  break;
+                }
+                case 'insert':
+                  lines.splice(e.before! - 1, 0, ...e.content!.split('\n'));
+                  break;
+                case 'delete': {
+                  // Sort delete line numbers descending within this edit
+                  const delLines = [...e.lines!].sort((a, b) => b - a);
+                  for (const ln of delLines) {
+                    lines.splice(ln - 1, 1);
+                  }
+                  break;
+                }
+                case 'append':
+                  lines.push(...e.content!.split('\n'));
+                  break;
+              }
+            }
+
+            // Write atomically: write to temp file, then rename (POSIX rename atomically replaces target)
+            const newContent =
+              lines.length > 0
+                ? lines.join(lineEnding) + (hadTrailingNewline ? lineEnding : '')
+                : '';
+            const tmpPath = `${absPath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+
+            try {
+              fs.writeFileSync(tmpPath, newContent, 'utf-8');
+              fs.renameSync(tmpPath, absPath);
+            } catch (writeErr: unknown) {
+              try {
+                fs.unlinkSync(tmpPath);
+              } catch {
+                // Best-effort cleanup
+              }
+              const msg = writeErr instanceof Error ? writeErr.message : String(writeErr);
+              return { error: `Write failed: ${msg}` };
+            }
+
+            const newHash = hashContent(newContent);
+            const diff = generateDiffSummary(oldLines, edits);
+
+            return {
+              path: absPath,
+              old_hash: oldHash,
+              new_hash: newHash,
+              edits_applied: edits.length,
+              total_lines: lines.length,
+              diff,
+            };
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return { error: msg };
+          }
+        },
+      }),
+      {
+        name: 'file_edit_lines',
+        kind: 'write',
+        deterministic: false,
+        sideEffect: 'local',
+        cacheable: false,
+      },
+    ),
   };
 }

--- a/src/tools/mcp-url.ts
+++ b/src/tools/mcp-url.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { addMCPUrlServer } from '../mcp.js';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /**
  * Creates the tool for adding URL-based (SSE/HTTP) MCP servers.
@@ -9,22 +10,31 @@ import { addMCPUrlServer } from '../mcp.js';
  * rather than local stdio processes. Changes require a Bernard restart.
  */
 export function createMCPAddUrlTool() {
-  return tool({
-    description:
-      'Add a URL-based MCP server (SSE or HTTP endpoint). Use this when given an MCP server URL. Changes take effect after restarting Bernard.',
-    parameters: z.object({
-      key: z.string().describe('Unique name for this server, e.g. "my-mcp"'),
-      url: z.string().describe('The MCP server URL, e.g. "http://localhost:6288/web/sse"'),
+  return attachMeta(
+    tool({
+      description:
+        'Add a URL-based MCP server (SSE or HTTP endpoint). Use this when given an MCP server URL. Changes take effect after restarting Bernard.',
+      parameters: z.object({
+        key: z.string().describe('Unique name for this server, e.g. "my-mcp"'),
+        url: z.string().describe('The MCP server URL, e.g. "http://localhost:6288/web/sse"'),
+      }),
+      execute: async ({ key, url }): Promise<string> => {
+        try {
+          const type = url.endsWith('/sse') ? ('sse' as const) : ('http' as const);
+          addMCPUrlServer(key, url, type);
+          return `MCP server added:\n  Key: ${key}\n  URL: ${url}\n  Transport: ${type}\n\nRestart Bernard for the server to connect.`;
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return `Error adding server: ${msg}`;
+        }
+      },
     }),
-    execute: async ({ key, url }): Promise<string> => {
-      try {
-        const type = url.endsWith('/sse') ? ('sse' as const) : ('http' as const);
-        addMCPUrlServer(key, url, type);
-        return `MCP server added:\n  Key: ${key}\n  URL: ${url}\n  Transport: ${type}\n\nRestart Bernard for the server to connect.`;
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return `Error adding server: ${msg}`;
-      }
+    {
+      name: 'mcp_add_url',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/mcp.ts
+++ b/src/tools/mcp.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { listMCPServers, addMCPServer, removeMCPServer, getMCPServer } from '../mcp.js';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /**
  * Creates the MCP server configuration tool for managing stdio-based MCP servers.
@@ -9,119 +10,129 @@ import { listMCPServers, addMCPServer, removeMCPServer, getMCPServer } from '../
  * a Bernard restart to take effect.
  */
 export function createMCPConfigTool() {
-  return tool({
-    description:
-      'Manage MCP server configuration. Add, remove, list, or inspect MCP servers. Changes take effect after restarting Bernard.',
-    parameters: z.object({
-      action: z.enum(['list', 'add', 'remove', 'get']).describe('The action to perform'),
-      key: z.string().optional().describe('Server name/key (required for add, remove, get)'),
-      command: z
-        .string()
-        .optional()
-        .describe('Executable to run, e.g. "npx", "python", "node" (required for add)'),
-      args: z
-        .array(z.string())
-        .optional()
-        .describe(
-          'Command arguments, e.g. ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]',
-        ),
-      env: z
-        .record(z.string())
-        .optional()
-        .describe('Environment variables to pass to the server process'),
-    }),
-    execute: async ({ action, key, command, args, env }): Promise<string> => {
-      switch (action) {
-        case 'list': {
-          try {
-            const servers = listMCPServers();
-            if (servers.length === 0) return 'No MCP servers configured.';
-
-            const lines = servers.map((s) => {
-              if (s.url) {
-                const typeStr = s.type ? ` (${s.type})` : ' (sse)';
-                return `  - ${s.key}\n    URL: ${s.url}${typeStr}`;
-              }
-              const argsStr = s.args && s.args.length > 0 ? `\n    Args: ${s.args.join(' ')}` : '';
-              return `  - ${s.key}\n    Command: ${s.command}${argsStr}`;
-            });
-
-            return `MCP servers (${servers.length}):\n${lines.join('\n')}`;
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return `Error listing servers: ${msg}`;
-          }
-        }
-
-        case 'add': {
-          if (!key) return 'Error: key is required for add action.';
-          if (!command) return 'Error: command is required for add action.';
-
-          try {
-            addMCPServer(key, command, args, env);
-            const argsStr = args && args.length > 0 ? `\n  Args: ${args.join(' ')}` : '';
-            const envStr =
-              env && Object.keys(env).length > 0 ? `\n  Env: ${Object.keys(env).join(', ')}` : '';
-            return `MCP server added:\n  Key: ${key}\n  Command: ${command}${argsStr}${envStr}\n\nRestart Bernard for the server to connect.`;
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return `Error adding server: ${msg}`;
-          }
-        }
-
-        case 'remove': {
-          if (!key) return 'Error: key is required for remove action.';
-
-          try {
-            removeMCPServer(key);
-            return `MCP server "${key}" removed. Restart Bernard for changes to take effect.`;
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return `Error removing server: ${msg}`;
-          }
-        }
-
-        case 'get': {
-          if (!key) return 'Error: key is required for get action.';
-
-          try {
-            const server = getMCPServer(key);
-            if (!server) {
+  return attachMeta(
+    tool({
+      description:
+        'Manage MCP server configuration. Add, remove, list, or inspect MCP servers. Changes take effect after restarting Bernard.',
+      parameters: z.object({
+        action: z.enum(['list', 'add', 'remove', 'get']).describe('The action to perform'),
+        key: z.string().optional().describe('Server name/key (required for add, remove, get)'),
+        command: z
+          .string()
+          .optional()
+          .describe('Executable to run, e.g. "npx", "python", "node" (required for add)'),
+        args: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Command arguments, e.g. ["-y", "@modelcontextprotocol/server-filesystem", "/home/user"]',
+          ),
+        env: z
+          .record(z.string())
+          .optional()
+          .describe('Environment variables to pass to the server process'),
+      }),
+      execute: async ({ action, key, command, args, env }): Promise<string> => {
+        switch (action) {
+          case 'list': {
+            try {
               const servers = listMCPServers();
-              const hint =
-                servers.length > 0
-                  ? ` Available servers: ${servers.map((s) => s.key).join(', ')}`
-                  : ' No servers configured.';
-              return `MCP server "${key}" not found.${hint}`;
-            }
+              if (servers.length === 0) return 'No MCP servers configured.';
 
-            if ('url' in server) {
-              const typeStr = server.type ?? 'sse';
-              const headersStr =
-                server.headers && Object.keys(server.headers).length > 0
-                  ? `\n  Headers: ${Object.keys(server.headers).join(', ')}`
-                  : '';
-              return `MCP server "${key}":\n  URL: ${server.url}\n  Transport: ${typeStr}${headersStr}`;
-            }
+              const lines = servers.map((s) => {
+                if (s.url) {
+                  const typeStr = s.type ? ` (${s.type})` : ' (sse)';
+                  return `  - ${s.key}\n    URL: ${s.url}${typeStr}`;
+                }
+                const argsStr =
+                  s.args && s.args.length > 0 ? `\n    Args: ${s.args.join(' ')}` : '';
+                return `  - ${s.key}\n    Command: ${s.command}${argsStr}`;
+              });
 
-            const argsStr =
-              server.args && server.args.length > 0 ? `\n  Args: ${server.args.join(' ')}` : '';
-            const envStr =
-              server.env && Object.keys(server.env).length > 0
-                ? `\n  Env: ${Object.entries(server.env)
-                    .map(([k, v]) => `${k}=${v}`)
-                    .join(', ')}`
-                : '';
-            return `MCP server "${key}":\n  Command: ${server.command}${argsStr}${envStr}`;
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return `Error getting server: ${msg}`;
+              return `MCP servers (${servers.length}):\n${lines.join('\n')}`;
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : String(err);
+              return `Error listing servers: ${msg}`;
+            }
           }
-        }
 
-        default:
-          return `Unknown action: ${action}`;
-      }
+          case 'add': {
+            if (!key) return 'Error: key is required for add action.';
+            if (!command) return 'Error: command is required for add action.';
+
+            try {
+              addMCPServer(key, command, args, env);
+              const argsStr = args && args.length > 0 ? `\n  Args: ${args.join(' ')}` : '';
+              const envStr =
+                env && Object.keys(env).length > 0 ? `\n  Env: ${Object.keys(env).join(', ')}` : '';
+              return `MCP server added:\n  Key: ${key}\n  Command: ${command}${argsStr}${envStr}\n\nRestart Bernard for the server to connect.`;
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : String(err);
+              return `Error adding server: ${msg}`;
+            }
+          }
+
+          case 'remove': {
+            if (!key) return 'Error: key is required for remove action.';
+
+            try {
+              removeMCPServer(key);
+              return `MCP server "${key}" removed. Restart Bernard for changes to take effect.`;
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : String(err);
+              return `Error removing server: ${msg}`;
+            }
+          }
+
+          case 'get': {
+            if (!key) return 'Error: key is required for get action.';
+
+            try {
+              const server = getMCPServer(key);
+              if (!server) {
+                const servers = listMCPServers();
+                const hint =
+                  servers.length > 0
+                    ? ` Available servers: ${servers.map((s) => s.key).join(', ')}`
+                    : ' No servers configured.';
+                return `MCP server "${key}" not found.${hint}`;
+              }
+
+              if ('url' in server) {
+                const typeStr = server.type ?? 'sse';
+                const headersStr =
+                  server.headers && Object.keys(server.headers).length > 0
+                    ? `\n  Headers: ${Object.keys(server.headers).join(', ')}`
+                    : '';
+                return `MCP server "${key}":\n  URL: ${server.url}\n  Transport: ${typeStr}${headersStr}`;
+              }
+
+              const argsStr =
+                server.args && server.args.length > 0 ? `\n  Args: ${server.args.join(' ')}` : '';
+              const envStr =
+                server.env && Object.keys(server.env).length > 0
+                  ? `\n  Env: ${Object.entries(server.env)
+                      .map(([k, v]) => `${k}=${v}`)
+                      .join(', ')}`
+                  : '';
+              return `MCP server "${key}":\n  Command: ${server.command}${argsStr}${envStr}`;
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : String(err);
+              return `Error getting server: ${msg}`;
+            }
+          }
+
+          default:
+            return `Unknown action: ${action}`;
+        }
+      },
+    }),
+    {
+      name: 'mcp_config',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -23,7 +23,13 @@ type MemoryArgs = z.infer<typeof MEMORY_PARAMETERS>;
  */
 export function createMemoryTool(memoryStore: MemoryStore): BernardTool<MemoryArgs, string> {
   return {
-    meta: { name: 'memory', kind: 'write' },
+    meta: {
+      name: 'memory',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
+    },
     description: `Persistent memory that survives across sessions. Use this to remember user preferences, project knowledge, or anything worth recalling later. Stored as files on disk at ${MEMORY_DIR}.`,
     parameters: MEMORY_PARAMETERS,
     execute: async ({ action, key, content }) => {
@@ -72,7 +78,13 @@ export function createMemoryTool(memoryStore: MemoryStore): BernardTool<MemoryAr
  */
 export function createScratchTool(memoryStore: MemoryStore): BernardTool<MemoryArgs, string> {
   return {
-    meta: { name: 'scratch', kind: 'write' },
+    meta: {
+      name: 'scratch',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
+    },
     description:
       'Session scratch notes for tracking complex task progress, intermediate findings, and working plans. These notes survive context compression but are discarded when the session ends. Use this to keep track of multi-step work within a single session.',
     parameters: MEMORY_PARAMETERS,

--- a/src/tools/routine.ts
+++ b/src/tools/routine.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { RoutineStore } from '../routines.js';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /**
  * Creates the routine management tool for saving and retrieving reusable multi-step workflows.
@@ -11,74 +12,83 @@ import { RoutineStore } from '../routines.js';
 export function createRoutineTool(routineStore?: RoutineStore) {
   const store = routineStore ?? new RoutineStore();
 
-  return tool({
-    description:
-      'Manage reusable multi-step workflows (routines). Routines capture procedures the user teaches you — deploy scripts, release checklists, onboarding flows, etc. Once saved, the user can invoke them with /{routine-id} in the REPL. Content should be free-form markdown capturing steps, decisions, and intent.',
-    parameters: z.object({
-      action: z
-        .enum(['create', 'update', 'list', 'read', 'delete'])
-        .describe('The action to perform'),
-      id: z
-        .string()
-        .optional()
-        .describe(
-          'Routine ID (kebab-case slug, e.g. "deploy-staging"). Required for create/read/update/delete.',
-        ),
-      name: z.string().optional().describe('Display name (required for create)'),
-      description: z.string().optional().describe('One-line summary (required for create)'),
-      content: z.string().optional().describe('Full procedure as markdown (required for create)'),
-    }),
-    execute: async ({ action, id, name, description, content }): Promise<string> => {
-      switch (action) {
-        case 'list': {
-          const routines = store.list();
-          if (routines.length === 0) return 'No routines saved yet.';
-          return `Routines (${routines.length}):\n${routines.map((r) => `  - /${r.id} — ${r.name}: ${r.description}`).join('\n')}`;
-        }
-
-        case 'read': {
-          if (!id) return 'Error: id is required for read action.';
-          const routine = store.get(id);
-          if (!routine) return `No routine found with id "${id}".`;
-          return `# ${routine.name} (/${routine.id})\n${routine.description}\n\n${routine.content}`;
-        }
-
-        case 'create': {
-          if (!id) return 'Error: id is required for create action.';
-          if (!name) return 'Error: name is required for create action.';
-          if (!description) return 'Error: description is required for create action.';
-          if (!content) return 'Error: content is required for create action.';
-          try {
-            const routine = store.create(id, name, description, content);
-            return `Routine "${routine.name}" (/${routine.id}) created. The user can now invoke it with /${routine.id}.`;
-          } catch (err: unknown) {
-            return `Error: ${err instanceof Error ? err.message : String(err)}`;
+  return attachMeta(
+    tool({
+      description:
+        'Manage reusable multi-step workflows (routines). Routines capture procedures the user teaches you — deploy scripts, release checklists, onboarding flows, etc. Once saved, the user can invoke them with /{routine-id} in the REPL. Content should be free-form markdown capturing steps, decisions, and intent.',
+      parameters: z.object({
+        action: z
+          .enum(['create', 'update', 'list', 'read', 'delete'])
+          .describe('The action to perform'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Routine ID (kebab-case slug, e.g. "deploy-staging"). Required for create/read/update/delete.',
+          ),
+        name: z.string().optional().describe('Display name (required for create)'),
+        description: z.string().optional().describe('One-line summary (required for create)'),
+        content: z.string().optional().describe('Full procedure as markdown (required for create)'),
+      }),
+      execute: async ({ action, id, name, description, content }): Promise<string> => {
+        switch (action) {
+          case 'list': {
+            const routines = store.list();
+            if (routines.length === 0) return 'No routines saved yet.';
+            return `Routines (${routines.length}):\n${routines.map((r) => `  - /${r.id} — ${r.name}: ${r.description}`).join('\n')}`;
           }
-        }
 
-        case 'update': {
-          if (!id) return 'Error: id is required for update action.';
-          const updates: Record<string, string> = {};
-          if (name !== undefined) updates.name = name;
-          if (description !== undefined) updates.description = description;
-          if (content !== undefined) updates.content = content;
-          if (Object.keys(updates).length === 0)
-            return 'Error: provide at least one field to update (name, description, or content).';
-          const updated = store.update(id, updates);
-          if (!updated) return `No routine found with id "${id}".`;
-          return `Routine "${updated.name}" (/${updated.id}) updated.`;
-        }
+          case 'read': {
+            if (!id) return 'Error: id is required for read action.';
+            const routine = store.get(id);
+            if (!routine) return `No routine found with id "${id}".`;
+            return `# ${routine.name} (/${routine.id})\n${routine.description}\n\n${routine.content}`;
+          }
 
-        case 'delete': {
-          if (!id) return 'Error: id is required for delete action.';
-          const deleted = store.delete(id);
-          if (!deleted) return `No routine found with id "${id}".`;
-          return `Routine "${id}" deleted.`;
-        }
+          case 'create': {
+            if (!id) return 'Error: id is required for create action.';
+            if (!name) return 'Error: name is required for create action.';
+            if (!description) return 'Error: description is required for create action.';
+            if (!content) return 'Error: content is required for create action.';
+            try {
+              const routine = store.create(id, name, description, content);
+              return `Routine "${routine.name}" (/${routine.id}) created. The user can now invoke it with /${routine.id}.`;
+            } catch (err: unknown) {
+              return `Error: ${err instanceof Error ? err.message : String(err)}`;
+            }
+          }
 
-        default:
-          return `Unknown action: ${action}`;
-      }
+          case 'update': {
+            if (!id) return 'Error: id is required for update action.';
+            const updates: Record<string, string> = {};
+            if (name !== undefined) updates.name = name;
+            if (description !== undefined) updates.description = description;
+            if (content !== undefined) updates.content = content;
+            if (Object.keys(updates).length === 0)
+              return 'Error: provide at least one field to update (name, description, or content).';
+            const updated = store.update(id, updates);
+            if (!updated) return `No routine found with id "${id}".`;
+            return `Routine "${updated.name}" (/${updated.id}) updated.`;
+          }
+
+          case 'delete': {
+            if (!id) return 'Error: id is required for delete action.';
+            const deleted = store.delete(id);
+            if (!deleted) return `No routine found with id "${id}".`;
+            return `Routine "${id}" deleted.`;
+          }
+
+          default:
+            return `Unknown action: ${action}`;
+        }
+      },
+    }),
+    {
+      name: 'routine',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -102,7 +102,14 @@ type ShellArgs = z.infer<typeof SHELL_PARAMETERS>;
  */
 export function createShellTool(options: ToolOptions): BernardTool<ShellArgs, ShellResult> {
   return {
-    meta: { name: 'shell', kind: 'dangerous', category: 'shell' },
+    meta: {
+      name: 'shell',
+      kind: 'dangerous',
+      category: 'shell',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
+    },
     description: SHELL_DESCRIPTION,
     parameters: SHELL_PARAMETERS,
     execute: async ({ command }, execOptions) => {

--- a/src/tools/specialist.ts
+++ b/src/tools/specialist.ts
@@ -8,6 +8,7 @@ import {
 } from '../specialists.js';
 import type { CandidateStoreReader } from '../specialist-candidates.js';
 import { type BernardConfig, PROVIDER_MODELS, isValidProvider } from '../config.js';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 const goodExampleSchema = z.object({
   input: z.string(),
@@ -37,235 +38,248 @@ export function createSpecialistTool(
 ) {
   const store = specialistStore ?? new SpecialistStore();
 
-  return tool({
-    description:
-      'Manage reusable expert profiles (specialists). Specialists are persistent personas with custom instructions and behavioral guidelines that shape how a sub-agent approaches work. Unlike routines (step-by-step procedures), specialists define expertise and behavioral rules for recurring task patterns.',
-    parameters: z.object({
-      action: z
-        .enum(['create', 'update', 'list', 'read', 'delete'])
-        .describe('The action to perform'),
-      id: z
-        .string()
-        .optional()
-        .describe(
-          'Specialist ID (kebab-case slug, e.g. "email-triage"). Required for create/read/update/delete.',
-        ),
-      name: z.string().optional().describe('Display name (required for create)'),
-      description: z.string().optional().describe('One-line summary (required for create)'),
-      systemPrompt: z
-        .string()
-        .optional()
-        .describe("The specialist's persona and behavioral instructions (required for create)"),
-      guidelines: z
-        .array(z.string())
-        .optional()
-        .describe('Short behavioral rules, appended as bullets (optional, defaults to [])'),
-      provider: z
-        .string()
-        .optional()
-        .describe(
-          'Optional LLM provider override for this specialist (e.g. "xai", "openai"). Used with create/update.',
-        ),
-      model: z
-        .string()
-        .optional()
-        .describe(
-          'Optional model override for this specialist (e.g. "grok-code-fast-1"). Used with create/update.',
-        ),
-      kind: z
-        .enum(['persona', 'tool-wrapper', 'meta'])
-        .optional()
-        .describe(
-          'Specialist category. "persona" (default) is the historical role-based specialist. "tool-wrapper" fronts a concrete tool or CLI and is invoked via tool_wrapper_run. "meta" specialists operate on other specialists (e.g. specialist-creator).',
-        ),
-      targetTools: z
-        .array(z.string())
-        .optional()
-        .describe(
-          'For tool-wrapper or meta specialists: the tool names exposed to the child agent (e.g. ["shell"] or ["specialist", "tool_wrapper_run"]). Isolates the specialist from unrelated tools.',
-        ),
-      goodExamples: z
-        .array(goodExampleSchema)
-        .optional()
-        .describe(
-          'Few-shot examples of correct tool usage. Each entry: {input, call, note?}. Used by tool-wrapper specialists.',
-        ),
-      badExamples: z
-        .array(badExampleSchema)
-        .optional()
-        .describe(
-          'Few-shot examples of incorrect tool usage with their corrections. Each entry: {input, call, error, fix, note?}.',
-        ),
-      structuredOutput: z
-        .boolean()
-        .optional()
-        .describe(
-          'When true, the specialist must emit JSON {status, result, error?, reasoning?} as its final message. Default: true for tool-wrapper kind, false otherwise.',
-        ),
-    }),
-    execute: async ({
-      action,
-      id,
-      name,
-      description,
-      systemPrompt,
-      guidelines,
-      provider,
-      model,
-      kind,
-      targetTools,
-      goodExamples,
-      badExamples,
-      structuredOutput,
-    }): Promise<string> => {
-      switch (action) {
-        case 'list': {
-          const specialists = store.list();
-          if (specialists.length === 0) return 'No specialists saved yet.';
-          return `Specialists (${specialists.length}):\n${specialists
-            .map((s) => {
-              const modelTag =
-                s.provider || s.model
-                  ? ` [${s.provider ?? 'default'}/${s.model ?? 'default'}]`
-                  : '';
-              return `  - ${s.id} — ${s.name}: ${s.description}${modelTag}`;
-            })
-            .join('\n')}`;
-        }
+  return attachMeta(
+    tool({
+      description:
+        'Manage reusable expert profiles (specialists). Specialists are persistent personas with custom instructions and behavioral guidelines that shape how a sub-agent approaches work. Unlike routines (step-by-step procedures), specialists define expertise and behavioral rules for recurring task patterns.',
+      parameters: z.object({
+        action: z
+          .enum(['create', 'update', 'list', 'read', 'delete'])
+          .describe('The action to perform'),
+        id: z
+          .string()
+          .optional()
+          .describe(
+            'Specialist ID (kebab-case slug, e.g. "email-triage"). Required for create/read/update/delete.',
+          ),
+        name: z.string().optional().describe('Display name (required for create)'),
+        description: z.string().optional().describe('One-line summary (required for create)'),
+        systemPrompt: z
+          .string()
+          .optional()
+          .describe("The specialist's persona and behavioral instructions (required for create)"),
+        guidelines: z
+          .array(z.string())
+          .optional()
+          .describe('Short behavioral rules, appended as bullets (optional, defaults to [])'),
+        provider: z
+          .string()
+          .optional()
+          .describe(
+            'Optional LLM provider override for this specialist (e.g. "xai", "openai"). Used with create/update.',
+          ),
+        model: z
+          .string()
+          .optional()
+          .describe(
+            'Optional model override for this specialist (e.g. "grok-code-fast-1"). Used with create/update.',
+          ),
+        kind: z
+          .enum(['persona', 'tool-wrapper', 'meta'])
+          .optional()
+          .describe(
+            'Specialist category. "persona" (default) is the historical role-based specialist. "tool-wrapper" fronts a concrete tool or CLI and is invoked via tool_wrapper_run. "meta" specialists operate on other specialists (e.g. specialist-creator).',
+          ),
+        targetTools: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'For tool-wrapper or meta specialists: the tool names exposed to the child agent (e.g. ["shell"] or ["specialist", "tool_wrapper_run"]). Isolates the specialist from unrelated tools.',
+          ),
+        goodExamples: z
+          .array(goodExampleSchema)
+          .optional()
+          .describe(
+            'Few-shot examples of correct tool usage. Each entry: {input, call, note?}. Used by tool-wrapper specialists.',
+          ),
+        badExamples: z
+          .array(badExampleSchema)
+          .optional()
+          .describe(
+            'Few-shot examples of incorrect tool usage with their corrections. Each entry: {input, call, error, fix, note?}.',
+          ),
+        structuredOutput: z
+          .boolean()
+          .optional()
+          .describe(
+            'When true, the specialist must emit JSON {status, result, error?, reasoning?} as its final message. Default: true for tool-wrapper kind, false otherwise.',
+          ),
+      }),
+      execute: async ({
+        action,
+        id,
+        name,
+        description,
+        systemPrompt,
+        guidelines,
+        provider,
+        model,
+        kind,
+        targetTools,
+        goodExamples,
+        badExamples,
+        structuredOutput,
+      }): Promise<string> => {
+        switch (action) {
+          case 'list': {
+            const specialists = store.list();
+            if (specialists.length === 0) return 'No specialists saved yet.';
+            return `Specialists (${specialists.length}):\n${specialists
+              .map((s) => {
+                const modelTag =
+                  s.provider || s.model
+                    ? ` [${s.provider ?? 'default'}/${s.model ?? 'default'}]`
+                    : '';
+                return `  - ${s.id} — ${s.name}: ${s.description}${modelTag}`;
+              })
+              .join('\n')}`;
+          }
 
-        case 'read': {
-          if (!id) return 'Error: id is required for read action.';
-          const specialist = store.get(id);
-          if (!specialist) return `No specialist found with id "${id}".`;
-          let output = `# ${specialist.name} (${specialist.id})\n${specialist.description}`;
-          if (specialist.kind && specialist.kind !== 'persona') {
-            output += `\n\nKind: ${specialist.kind}`;
-          }
-          if (specialist.targetTools && specialist.targetTools.length > 0) {
-            output += `\nTarget tools: ${specialist.targetTools.join(', ')}`;
-          }
-          if (specialist.structuredOutput) {
-            output += `\nStructured output: true`;
-          }
-          if (specialist.provider || specialist.model) {
-            output += `\n\n## Model Override\nProvider: ${specialist.provider ?? 'default'}\nModel: ${specialist.model ?? 'default'}`;
-          }
-          output += `\n\n## System Prompt\n${specialist.systemPrompt}`;
-          if (specialist.guidelines.length > 0) {
-            output += `\n\n## Guidelines\n${specialist.guidelines.map((g) => `- ${g}`).join('\n')}`;
-          }
-          if (specialist.goodExamples && specialist.goodExamples.length > 0) {
-            output += `\n\n## Good Examples`;
-            for (const ex of specialist.goodExamples) {
-              output += `\n- input: ${ex.input}\n  call: ${ex.call}`;
-              if (ex.note) output += `\n  note: ${ex.note}`;
+          case 'read': {
+            if (!id) return 'Error: id is required for read action.';
+            const specialist = store.get(id);
+            if (!specialist) return `No specialist found with id "${id}".`;
+            let output = `# ${specialist.name} (${specialist.id})\n${specialist.description}`;
+            if (specialist.kind && specialist.kind !== 'persona') {
+              output += `\n\nKind: ${specialist.kind}`;
             }
-          }
-          if (specialist.badExamples && specialist.badExamples.length > 0) {
-            output += `\n\n## Bad Examples`;
-            for (const ex of specialist.badExamples) {
-              output += `\n- input: ${ex.input}\n  call: ${ex.call}\n  error: ${ex.error}\n  fix: ${ex.fix}`;
-              if (ex.note) output += `\n  note: ${ex.note}`;
+            if (specialist.targetTools && specialist.targetTools.length > 0) {
+              output += `\nTarget tools: ${specialist.targetTools.join(', ')}`;
             }
-          }
-          return output;
-        }
-
-        case 'create': {
-          if (!id) return 'Error: id is required for create action.';
-          if (!name) return 'Error: name is required for create action.';
-          if (!description) return 'Error: description is required for create action.';
-          if (!systemPrompt) return 'Error: systemPrompt is required for create action.';
-          if (provider !== undefined) {
-            if (!isValidProvider(provider))
-              return `Error: Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_MODELS).join(', ')}`;
-            if (model !== undefined && !PROVIDER_MODELS[provider]?.includes(model))
-              return `Error: Unknown model "${model}" for provider "${provider}". Valid models: ${PROVIDER_MODELS[provider].join(', ')}`;
-          } else if (model !== undefined && config) {
-            // Validate model against the global config's provider when no explicit provider given
-            if (!PROVIDER_MODELS[config.provider]?.includes(model))
-              return `Error: Unknown model "${model}" for provider "${config.provider}". Valid models: ${PROVIDER_MODELS[config.provider].join(', ')}`;
-          }
-          try {
-            const specialist = store.createFull({
-              id,
-              name,
-              description,
-              systemPrompt,
-              guidelines: guidelines ?? [],
-              provider,
-              model,
-              kind,
-              targetTools,
-              goodExamples: goodExamples as SpecialistExample[] | undefined,
-              badExamples: badExamples as SpecialistBadExample[] | undefined,
-              structuredOutput,
-            });
-            // Auto-mark matching candidate as accepted (best-effort)
-            try {
-              if (candidateStore) {
-                const pending = candidateStore.listPending();
-                const match = pending.find(
-                  (c) => c.draftId === id || c.name.toLowerCase() === name.toLowerCase(),
-                );
-                if (match) candidateStore.updateStatus(match.id, 'accepted');
+            if (specialist.structuredOutput) {
+              output += `\nStructured output: true`;
+            }
+            if (specialist.provider || specialist.model) {
+              output += `\n\n## Model Override\nProvider: ${specialist.provider ?? 'default'}\nModel: ${specialist.model ?? 'default'}`;
+            }
+            output += `\n\n## System Prompt\n${specialist.systemPrompt}`;
+            if (specialist.guidelines.length > 0) {
+              output += `\n\n## Guidelines\n${specialist.guidelines.map((g) => `- ${g}`).join('\n')}`;
+            }
+            if (specialist.goodExamples && specialist.goodExamples.length > 0) {
+              output += `\n\n## Good Examples`;
+              for (const ex of specialist.goodExamples) {
+                output += `\n- input: ${ex.input}\n  call: ${ex.call}`;
+                if (ex.note) output += `\n  note: ${ex.note}`;
               }
-            } catch {
-              // candidate status update is best-effort; don't block specialist creation
             }
-            return `Specialist "${specialist.name}" (${specialist.id}) created. Use specialist_run to invoke it.`;
-          } catch (err: unknown) {
-            return `Error: ${err instanceof Error ? err.message : String(err)}`;
+            if (specialist.badExamples && specialist.badExamples.length > 0) {
+              output += `\n\n## Bad Examples`;
+              for (const ex of specialist.badExamples) {
+                output += `\n- input: ${ex.input}\n  call: ${ex.call}\n  error: ${ex.error}\n  fix: ${ex.fix}`;
+                if (ex.note) output += `\n  note: ${ex.note}`;
+              }
+            }
+            return output;
           }
-        }
 
-        case 'update': {
-          if (!id) return 'Error: id is required for update action.';
-          if (provider !== undefined && provider !== '') {
-            if (!isValidProvider(provider))
-              return `Error: Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_MODELS).join(', ')}`;
-            if (model !== undefined && model !== '' && !PROVIDER_MODELS[provider]?.includes(model))
-              return `Error: Unknown model "${model}" for provider "${provider}". Valid models: ${PROVIDER_MODELS[provider].join(', ')}`;
-          } else if (model !== undefined && model !== '' && provider === undefined) {
-            // Model-only update: validate against existing specialist's provider or global config
-            const existing = store.get(id);
-            const effectiveProvider = existing?.provider || config?.provider;
-            if (effectiveProvider && !PROVIDER_MODELS[effectiveProvider]?.includes(model))
-              return `Error: Unknown model "${model}" for provider "${effectiveProvider}". Valid models: ${PROVIDER_MODELS[effectiveProvider]?.join(', ') ?? 'none'}`;
+          case 'create': {
+            if (!id) return 'Error: id is required for create action.';
+            if (!name) return 'Error: name is required for create action.';
+            if (!description) return 'Error: description is required for create action.';
+            if (!systemPrompt) return 'Error: systemPrompt is required for create action.';
+            if (provider !== undefined) {
+              if (!isValidProvider(provider))
+                return `Error: Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_MODELS).join(', ')}`;
+              if (model !== undefined && !PROVIDER_MODELS[provider]?.includes(model))
+                return `Error: Unknown model "${model}" for provider "${provider}". Valid models: ${PROVIDER_MODELS[provider].join(', ')}`;
+            } else if (model !== undefined && config) {
+              // Validate model against the global config's provider when no explicit provider given
+              if (!PROVIDER_MODELS[config.provider]?.includes(model))
+                return `Error: Unknown model "${model}" for provider "${config.provider}". Valid models: ${PROVIDER_MODELS[config.provider].join(', ')}`;
+            }
+            try {
+              const specialist = store.createFull({
+                id,
+                name,
+                description,
+                systemPrompt,
+                guidelines: guidelines ?? [],
+                provider,
+                model,
+                kind,
+                targetTools,
+                goodExamples: goodExamples as SpecialistExample[] | undefined,
+                badExamples: badExamples as SpecialistBadExample[] | undefined,
+                structuredOutput,
+              });
+              // Auto-mark matching candidate as accepted (best-effort)
+              try {
+                if (candidateStore) {
+                  const pending = candidateStore.listPending();
+                  const match = pending.find(
+                    (c) => c.draftId === id || c.name.toLowerCase() === name.toLowerCase(),
+                  );
+                  if (match) candidateStore.updateStatus(match.id, 'accepted');
+                }
+              } catch {
+                // candidate status update is best-effort; don't block specialist creation
+              }
+              return `Specialist "${specialist.name}" (${specialist.id}) created. Use specialist_run to invoke it.`;
+            } catch (err: unknown) {
+              return `Error: ${err instanceof Error ? err.message : String(err)}`;
+            }
           }
-          const updates: SpecialistUpdates = {};
-          if (name !== undefined) updates.name = name;
-          if (description !== undefined) updates.description = description;
-          if (systemPrompt !== undefined) updates.systemPrompt = systemPrompt;
-          if (guidelines !== undefined) updates.guidelines = guidelines;
-          if (provider !== undefined) updates.provider = provider;
-          if (model !== undefined) updates.model = model;
-          if (kind !== undefined) updates.kind = kind;
-          if (targetTools !== undefined) updates.targetTools = targetTools;
-          if (goodExamples !== undefined)
-            updates.goodExamples = goodExamples as SpecialistExample[];
-          if (badExamples !== undefined)
-            updates.badExamples = badExamples as SpecialistBadExample[];
-          if (structuredOutput !== undefined) updates.structuredOutput = structuredOutput;
-          // Auto-clear model when provider is cleared and model not explicitly provided
-          if (provider === '' && model === undefined) updates.model = '';
-          if (Object.keys(updates).length === 0)
-            return 'Error: provide at least one field to update (name, description, systemPrompt, guidelines, provider, model, kind, targetTools, goodExamples, badExamples, or structuredOutput).';
-          const updated = store.update(id, updates);
-          if (!updated) return `No specialist found with id "${id}".`;
-          return `Specialist "${updated.name}" (${updated.id}) updated.`;
-        }
 
-        case 'delete': {
-          if (!id) return 'Error: id is required for delete action.';
-          const deleted = store.delete(id);
-          if (!deleted) return `No specialist found with id "${id}".`;
-          return `Specialist "${id}" deleted.`;
-        }
+          case 'update': {
+            if (!id) return 'Error: id is required for update action.';
+            if (provider !== undefined && provider !== '') {
+              if (!isValidProvider(provider))
+                return `Error: Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_MODELS).join(', ')}`;
+              if (
+                model !== undefined &&
+                model !== '' &&
+                !PROVIDER_MODELS[provider]?.includes(model)
+              )
+                return `Error: Unknown model "${model}" for provider "${provider}". Valid models: ${PROVIDER_MODELS[provider].join(', ')}`;
+            } else if (model !== undefined && model !== '' && provider === undefined) {
+              // Model-only update: validate against existing specialist's provider or global config
+              const existing = store.get(id);
+              const effectiveProvider = existing?.provider || config?.provider;
+              if (effectiveProvider && !PROVIDER_MODELS[effectiveProvider]?.includes(model))
+                return `Error: Unknown model "${model}" for provider "${effectiveProvider}". Valid models: ${PROVIDER_MODELS[effectiveProvider]?.join(', ') ?? 'none'}`;
+            }
+            const updates: SpecialistUpdates = {};
+            if (name !== undefined) updates.name = name;
+            if (description !== undefined) updates.description = description;
+            if (systemPrompt !== undefined) updates.systemPrompt = systemPrompt;
+            if (guidelines !== undefined) updates.guidelines = guidelines;
+            if (provider !== undefined) updates.provider = provider;
+            if (model !== undefined) updates.model = model;
+            if (kind !== undefined) updates.kind = kind;
+            if (targetTools !== undefined) updates.targetTools = targetTools;
+            if (goodExamples !== undefined)
+              updates.goodExamples = goodExamples as SpecialistExample[];
+            if (badExamples !== undefined)
+              updates.badExamples = badExamples as SpecialistBadExample[];
+            if (structuredOutput !== undefined) updates.structuredOutput = structuredOutput;
+            // Auto-clear model when provider is cleared and model not explicitly provided
+            if (provider === '' && model === undefined) updates.model = '';
+            if (Object.keys(updates).length === 0)
+              return 'Error: provide at least one field to update (name, description, systemPrompt, guidelines, provider, model, kind, targetTools, goodExamples, badExamples, or structuredOutput).';
+            const updated = store.update(id, updates);
+            if (!updated) return `No specialist found with id "${id}".`;
+            return `Specialist "${updated.name}" (${updated.id}) updated.`;
+          }
 
-        default:
-          return `Unknown action: ${action}`;
-      }
+          case 'delete': {
+            if (!id) return 'Error: id is required for delete action.';
+            const deleted = store.delete(id);
+            if (!deleted) return `No specialist found with id "${id}".`;
+            return `Specialist "${id}" deleted.`;
+          }
+
+          default:
+            return `Unknown action: ${action}`;
+        }
+      },
+    }),
+    {
+      name: 'specialist',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/time.ts
+++ b/src/tools/time.ts
@@ -1,5 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /**
  * Converts a military/24-hour time integer to total minutes since midnight.
@@ -45,37 +46,60 @@ export function formatHours(totalMinutes: number): string {
 /** Creates tools for calculating durations between military/24-hour time ranges. */
 export function createTimeTools() {
   return {
-    time_range: tool({
-      description:
-        'Calculate the duration between two military/24-hour times. Handles next-day wrap (e.g. 2300 to 0100 = 2 hours).',
-      parameters: z.object({
-        start: z
-          .number()
-          .describe('Start time in military format (e.g. 800 for 8:00 AM, 1530 for 3:30 PM)'),
-        end: z.number().describe('End time in military format'),
+    time_range: attachMeta(
+      tool({
+        description:
+          'Calculate the duration between two military/24-hour times. Handles next-day wrap (e.g. 2300 to 0100 = 2 hours).',
+        parameters: z.object({
+          start: z
+            .number()
+            .describe('Start time in military format (e.g. 800 for 8:00 AM, 1530 for 3:30 PM)'),
+          end: z.number().describe('End time in military format'),
+        }),
+        execute: async ({ start, end }): Promise<string> => {
+          const minutes = calcRangeMinutes(start, end);
+          return formatHours(minutes);
+        },
       }),
-      execute: async ({ start, end }): Promise<string> => {
-        const minutes = calcRangeMinutes(start, end);
-        return formatHours(minutes);
+      {
+        name: 'time_range',
+        kind: 'read',
+        deterministic: true,
+        sideEffect: 'none',
+        cacheable: true,
+        cacheTtlMs: 0,
       },
-    }),
+    ),
 
-    time_range_total: tool({
-      description: 'Calculate the total duration across multiple military time ranges.',
-      parameters: z.object({
-        ranges: z
-          .array(
-            z.object({
-              start: z.number().describe('Start time in military format'),
-              end: z.number().describe('End time in military format'),
-            }),
-          )
-          .describe('Array of time ranges'),
+    time_range_total: attachMeta(
+      tool({
+        description: 'Calculate the total duration across multiple military time ranges.',
+        parameters: z.object({
+          ranges: z
+            .array(
+              z.object({
+                start: z.number().describe('Start time in military format'),
+                end: z.number().describe('End time in military format'),
+              }),
+            )
+            .describe('Array of time ranges'),
+        }),
+        execute: async ({ ranges }): Promise<string> => {
+          const total = ranges.reduce(
+            (sum, { start, end }) => sum + calcRangeMinutes(start, end),
+            0,
+          );
+          return formatHours(total);
+        },
       }),
-      execute: async ({ ranges }): Promise<string> => {
-        const total = ranges.reduce((sum, { start, end }) => sum + calcRangeMinutes(start, end), 0);
-        return formatHours(total);
+      {
+        name: 'time_range_total',
+        kind: 'read',
+        deterministic: true,
+        sideEffect: 'none',
+        cacheable: true,
+        cacheTtlMs: 0,
       },
-    }),
+    ),
   };
 }

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { createTools, type ToolOptions } from './index.js';
 import { createSubAgentTool } from './subagent.js';
 import { createTaskTool } from './task.js';
-import { toolToAISDK } from '../framework/tools/adapter.js';
+import { toolToAISDK, attachMeta, readToolMeta } from '../framework/tools/adapter.js';
+import { redactArgs, REDACTED } from '../framework/tools/redact.js';
 import { createSpecialistRunTool } from './specialist-run.js';
 import { printSpecialistStart, printSpecialistEnd } from '../output.js';
 import { debugLog } from '../logger.js';
@@ -57,8 +58,15 @@ export function captureLastToolCall(steps: any[] | undefined): string {
 
 /**
  * Builds a compact record of tool calls for the reasoning log.
+ *
+ * When a `toolRegistry` is provided, each call's args and result preview are
+ * scrubbed against the tool's `ToolMeta.sensitiveArgs` / `sensitiveResult`
+ * fields before persistence.
  */
-export function captureToolCalls(steps: any[] | undefined): Array<{
+export function captureToolCalls(
+  steps: any[] | undefined,
+  toolRegistry?: Record<string, unknown>,
+): Array<{
   tool: string;
   args: unknown;
   resultPreview: string;
@@ -71,11 +79,13 @@ export function captureToolCalls(steps: any[] | undefined): Array<{
     for (let i = 0; i < calls.length; i++) {
       const tc = calls[i];
       const tr = results[i];
+      const meta = toolRegistry ? readToolMeta(toolRegistry[tc.toolName]) : undefined;
       const resultText = tr?.result === undefined ? '' : String(tr.result);
+      const rawPreview = resultText.slice(0, 300);
       out.push({
         tool: tc.toolName,
-        args: tc.args,
-        resultPreview: resultText.slice(0, 300),
+        args: meta ? redactArgs(tc.args, meta.sensitiveArgs) : tc.args,
+        resultPreview: meta?.sensitiveResult ? REDACTED : rawPreview,
       });
     }
   }
@@ -268,7 +278,7 @@ export async function dispatchToolWrapper(
       ts: new Date().toISOString(),
       specialistId,
       input,
-      toolCalls: captureToolCalls(result.steps as any[]),
+      toolCalls: captureToolCalls(result.steps as any[], childTools),
       finalOutput: wrapped.result,
       status:
         wrapped.status === 'ok'
@@ -353,42 +363,51 @@ export function renderWrapperParentView(
  */
 export function createToolWrapperRunTool(ctx: AgentContext) {
   const deps = ctxToToolWrapperDeps(ctx);
-  return tool({
-    description:
-      'Dispatch to a saved tool-wrapper specialist that handles a concrete tool or CLI (e.g. shell-wrapper, file-wrapper). Returns JSON {status, result, error?}. Use this for tool-heavy operations where domain-specific examples and error handling reduce misuse. Also used to invoke meta specialists (specialist-creator, correction-agent).',
-    parameters: z.object({
-      specialistId: z
-        .string()
-        .describe(
-          'The ID of the tool-wrapper or meta specialist to invoke (e.g. "shell-wrapper").',
-        ),
-      input: z
-        .string()
-        .describe(
-          'The natural-language request to hand to the specialist. Be specific — the specialist has no prior context.',
-        ),
-      context: z
-        .string()
-        .optional()
-        .describe('Optional additional context (file paths, prior findings, constraints).'),
-      provider: z.string().optional().describe('Optional provider override for this invocation.'),
-      model: z.string().optional().describe('Optional model override for this invocation.'),
+  return attachMeta(
+    tool({
+      description:
+        'Dispatch to a saved tool-wrapper specialist that handles a concrete tool or CLI (e.g. shell-wrapper, file-wrapper). Returns JSON {status, result, error?}. Use this for tool-heavy operations where domain-specific examples and error handling reduce misuse. Also used to invoke meta specialists (specialist-creator, correction-agent).',
+      parameters: z.object({
+        specialistId: z
+          .string()
+          .describe(
+            'The ID of the tool-wrapper or meta specialist to invoke (e.g. "shell-wrapper").',
+          ),
+        input: z
+          .string()
+          .describe(
+            'The natural-language request to hand to the specialist. Be specific — the specialist has no prior context.',
+          ),
+        context: z
+          .string()
+          .optional()
+          .describe('Optional additional context (file paths, prior findings, constraints).'),
+        provider: z.string().optional().describe('Optional provider override for this invocation.'),
+        model: z.string().optional().describe('Optional model override for this invocation.'),
+      }),
+      execute: async ({ specialistId, input, context, provider, model }, execOptions) => {
+        const wrapped = await dispatchToolWrapper(
+          {
+            specialistId,
+            input,
+            context,
+            provider,
+            model,
+            abortSignal: execOptions.abortSignal,
+          },
+          deps,
+        );
+        return renderWrapperParentView(wrapped);
+      },
     }),
-    execute: async ({ specialistId, input, context, provider, model }, execOptions) => {
-      const wrapped = await dispatchToolWrapper(
-        {
-          specialistId,
-          input,
-          context,
-          provider,
-          model,
-          abortSignal: execOptions.abortSignal,
-        },
-        deps,
-      );
-      return renderWrapperParentView(wrapped);
+    {
+      name: 'tool_wrapper_run',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
     },
-  });
+  );
 }
 
 export { toolWrapperDefinition };

--- a/src/tools/wait.ts
+++ b/src/tools/wait.ts
@@ -1,5 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /** Upper bound for the wait tool's delay (5 minutes). */
 export const MAX_WAIT_SECONDS = 300;
@@ -8,22 +9,31 @@ export const MIN_WAIT_SECONDS = 0.1;
 
 /** Creates a tool that pauses execution for a specified number of seconds. */
 export function createWaitTool() {
-  return tool({
-    description:
-      'Pause execution for a specified number of seconds. ' +
-      'Use when a task requires waiting within the current turn ' +
-      '(e.g., server restart, build, deploy propagation). ' +
-      `Min: ${MIN_WAIT_SECONDS}s, max: ${MAX_WAIT_SECONDS}s.`,
-    parameters: z.object({
-      seconds: z
-        .number()
-        .min(MIN_WAIT_SECONDS)
-        .max(MAX_WAIT_SECONDS)
-        .describe('Number of seconds to wait (0.1–300)'),
+  return attachMeta(
+    tool({
+      description:
+        'Pause execution for a specified number of seconds. ' +
+        'Use when a task requires waiting within the current turn ' +
+        '(e.g., server restart, build, deploy propagation). ' +
+        `Min: ${MIN_WAIT_SECONDS}s, max: ${MAX_WAIT_SECONDS}s.`,
+      parameters: z.object({
+        seconds: z
+          .number()
+          .min(MIN_WAIT_SECONDS)
+          .max(MAX_WAIT_SECONDS)
+          .describe('Number of seconds to wait (0.1–300)'),
+      }),
+      execute: async ({ seconds }): Promise<string> => {
+        await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+        return `Waited ${seconds} second${seconds === 1 ? '' : 's'}.`;
+      },
     }),
-    execute: async ({ seconds }): Promise<string> => {
-      await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
-      return `Waited ${seconds} second${seconds === 1 ? '' : 's'}.`;
+    {
+      name: 'wait',
+      kind: 'inert',
+      deterministic: false,
+      sideEffect: 'none',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { parse } from 'node-html-parser';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /** One search result. Kept minimal so the LLM can cheaply decide which URLs to `web_read`. */
 export interface SearchResult {
@@ -135,41 +136,50 @@ function formatResults(results: SearchResult[]): string {
  * without API keys.
  */
 export function createWebSearchTool() {
-  return tool({
-    description:
-      'Search the web and return a ranked list of {title, url, snippet} results. Use before web_read when you do not yet know the right URL. Provider chain: Brave → Tavily → DuckDuckGo (no API key required for the fallback).',
-    parameters: z.object({
-      query: z
-        .string()
-        .describe('The search query. Prefer specific phrasing over generic keywords.'),
-      limit: z
-        .number()
-        .int()
-        .min(1)
-        .max(MAX_LIMIT)
-        .optional()
-        .describe(`Maximum results to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
-    }),
-    execute: async ({ query, limit }): Promise<string> => {
-      const cappedLimit = Math.min(Math.max(1, limit ?? DEFAULT_LIMIT), MAX_LIMIT);
-      const attempts: Array<[string, () => Promise<SearchResult[] | undefined>]> = [
-        ['brave', () => searchBrave(query, cappedLimit)],
-        ['tavily', () => searchTavily(query, cappedLimit)],
-        ['duckduckgo', () => searchDuckDuckGo(query, cappedLimit)],
-      ];
-      const failures: string[] = [];
-      for (const [name, fn] of attempts) {
-        const results = await fn();
-        if (results && results.length > 0) {
-          return `Provider: ${name}\n\n${formatResults(results)}`;
+  return attachMeta(
+    tool({
+      description:
+        'Search the web and return a ranked list of {title, url, snippet} results. Use before web_read when you do not yet know the right URL. Provider chain: Brave → Tavily → DuckDuckGo (no API key required for the fallback).',
+      parameters: z.object({
+        query: z
+          .string()
+          .describe('The search query. Prefer specific phrasing over generic keywords.'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_LIMIT)
+          .optional()
+          .describe(`Maximum results to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
+      }),
+      execute: async ({ query, limit }): Promise<string> => {
+        const cappedLimit = Math.min(Math.max(1, limit ?? DEFAULT_LIMIT), MAX_LIMIT);
+        const attempts: Array<[string, () => Promise<SearchResult[] | undefined>]> = [
+          ['brave', () => searchBrave(query, cappedLimit)],
+          ['tavily', () => searchTavily(query, cappedLimit)],
+          ['duckduckgo', () => searchDuckDuckGo(query, cappedLimit)],
+        ];
+        const failures: string[] = [];
+        for (const [name, fn] of attempts) {
+          const results = await fn();
+          if (results && results.length > 0) {
+            return `Provider: ${name}\n\n${formatResults(results)}`;
+          }
+          failures.push(name);
         }
-        failures.push(name);
-      }
-      return (
-        `web_search returned no results (tried: ${failures.join(', ')}). ` +
-        'If you know a likely documentation URL, call web_read directly. ' +
-        'To enable higher-quality search, set BRAVE_API_KEY or TAVILY_API_KEY.'
-      );
+        return (
+          `web_search returned no results (tried: ${failures.join(', ')}). ` +
+          'If you know a likely documentation URL, call web_read directly. ' +
+          'To enable higher-quality search, set BRAVE_API_KEY or TAVILY_API_KEY.'
+        );
+      },
+    }),
+    {
+      name: 'web_search',
+      kind: 'read',
+      deterministic: false,
+      sideEffect: 'network',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { parse } from 'node-html-parser';
 import TurndownService from 'turndown';
+import { attachMeta } from '../framework/tools/adapter.js';
 
 /** CSS selectors for elements stripped before HTML-to-markdown conversion. */
 const STRIP_SELECTORS = [
@@ -35,103 +36,112 @@ const USER_AGENT =
  * Output is truncated to {@link MAX_OUTPUT_CHARS} characters.
  */
 export function createWebReadTool() {
-  return tool({
-    description:
-      'Fetch a web page by URL and return its content as markdown. Useful for reading documentation, articles, Stack Overflow answers, GitHub pages, or any URL.',
-    parameters: z.object({
-      url: z.string().describe('The URL to fetch (must start with http:// or https://)'),
-      selector: z
-        .string()
-        .optional()
-        .describe(
-          'Optional CSS selector to extract specific content (e.g., "article", "main", ".post-body")',
-        ),
-    }),
-    execute: async ({ url, selector }): Promise<string> => {
-      // Validate URL
-      if (!url.startsWith('http://') && !url.startsWith('https://')) {
-        return 'Error: URL must start with http:// or https://';
-      }
-
-      let response: Response;
-      try {
-        response = await fetch(url, {
-          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-          headers: {
-            'User-Agent': USER_AGENT,
-            Accept: 'text/html',
-          },
-        });
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return `Error: Failed to fetch URL — ${message}`;
-      }
-
-      if (!response.ok) {
-        return `Error: HTTP ${response.status} ${response.statusText}`;
-      }
-
-      const contentType = response.headers.get('content-type') || '';
-      if (
-        !contentType.includes('text/html') &&
-        !contentType.includes('text/plain') &&
-        !contentType.includes('application/xhtml')
-      ) {
-        return `Error: Non-HTML content type (${contentType}). This tool only reads web pages.`;
-      }
-
-      let html: string;
-      try {
-        const buffer = await response.arrayBuffer();
-        if (buffer.byteLength > MAX_HTML_BYTES) {
-          html = new TextDecoder().decode(buffer.slice(0, MAX_HTML_BYTES));
-        } else {
-          html = new TextDecoder().decode(buffer);
+  return attachMeta(
+    tool({
+      description:
+        'Fetch a web page by URL and return its content as markdown. Useful for reading documentation, articles, Stack Overflow answers, GitHub pages, or any URL.',
+      parameters: z.object({
+        url: z.string().describe('The URL to fetch (must start with http:// or https://)'),
+        selector: z
+          .string()
+          .optional()
+          .describe(
+            'Optional CSS selector to extract specific content (e.g., "article", "main", ".post-body")',
+          ),
+      }),
+      execute: async ({ url, selector }): Promise<string> => {
+        // Validate URL
+        if (!url.startsWith('http://') && !url.startsWith('https://')) {
+          return 'Error: URL must start with http:// or https://';
         }
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return `Error: Failed to read response body — ${message}`;
-      }
 
-      const root = parse(html);
+        let response: Response;
+        try {
+          response = await fetch(url, {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            headers: {
+              'User-Agent': USER_AGENT,
+              Accept: 'text/html',
+            },
+          });
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          return `Error: Failed to fetch URL — ${message}`;
+        }
 
-      // Strip junk elements
-      for (const sel of STRIP_SELECTORS) {
-        root.querySelectorAll(sel).forEach((el) => el.remove());
-      }
+        if (!response.ok) {
+          return `Error: HTTP ${response.status} ${response.statusText}`;
+        }
 
-      // Get page title
-      const title = root.querySelector('title')?.text.trim() ?? '';
+        const contentType = response.headers.get('content-type') || '';
+        if (
+          !contentType.includes('text/html') &&
+          !contentType.includes('text/plain') &&
+          !contentType.includes('application/xhtml')
+        ) {
+          return `Error: Non-HTML content type (${contentType}). This tool only reads web pages.`;
+        }
 
-      // Select content
-      let content: string;
-      if (selector) {
-        const selected = root.querySelector(selector);
-        content = selected ? selected.innerHTML : root.innerHTML;
-      } else {
-        // Try common content containers, fall back to root
-        const body = root.querySelector('body');
-        content = body ? body.innerHTML : root.innerHTML;
-      }
+        let html: string;
+        try {
+          const buffer = await response.arrayBuffer();
+          if (buffer.byteLength > MAX_HTML_BYTES) {
+            html = new TextDecoder().decode(buffer.slice(0, MAX_HTML_BYTES));
+          } else {
+            html = new TextDecoder().decode(buffer);
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          return `Error: Failed to read response body — ${message}`;
+        }
 
-      // Convert to markdown
-      const turndown = new TurndownService({
-        headingStyle: 'atx',
-        codeBlockStyle: 'fenced',
-      });
-      let markdown = turndown.turndown(content);
+        const root = parse(html);
 
-      // Prepend title
-      if (title) {
-        markdown = `# ${title}\n\n${markdown}`;
-      }
+        // Strip junk elements
+        for (const sel of STRIP_SELECTORS) {
+          root.querySelectorAll(sel).forEach((el) => el.remove());
+        }
 
-      // Truncate
-      if (markdown.length > MAX_OUTPUT_CHARS) {
-        markdown = markdown.slice(0, MAX_OUTPUT_CHARS) + '\n\n… (truncated)';
-      }
+        // Get page title
+        const title = root.querySelector('title')?.text.trim() ?? '';
 
-      return markdown;
+        // Select content
+        let content: string;
+        if (selector) {
+          const selected = root.querySelector(selector);
+          content = selected ? selected.innerHTML : root.innerHTML;
+        } else {
+          // Try common content containers, fall back to root
+          const body = root.querySelector('body');
+          content = body ? body.innerHTML : root.innerHTML;
+        }
+
+        // Convert to markdown
+        const turndown = new TurndownService({
+          headingStyle: 'atx',
+          codeBlockStyle: 'fenced',
+        });
+        let markdown = turndown.turndown(content);
+
+        // Prepend title
+        if (title) {
+          markdown = `# ${title}\n\n${markdown}`;
+        }
+
+        // Truncate
+        if (markdown.length > MAX_OUTPUT_CHARS) {
+          markdown = markdown.slice(0, MAX_OUTPUT_CHARS) + '\n\n… (truncated)';
+        }
+
+        return markdown;
+      },
+    }),
+    {
+      name: 'web_read',
+      kind: 'read',
+      deterministic: false,
+      sideEffect: 'network',
+      cacheable: false,
     },
-  });
+  );
 }

--- a/src/tools/wrap-with-specialist.ts
+++ b/src/tools/wrap-with-specialist.ts
@@ -1,5 +1,6 @@
 import { dispatchToolWrapper, type ToolWrapperDeps } from './tool-wrapper-run.js';
 import { debugLog } from '../logger.js';
+import { preserveMeta } from '../framework/tools/adapter.js';
 
 /**
  * Builds the natural-language input handed to a wrapper specialist when the
@@ -85,7 +86,7 @@ export function wrapToolWithSpecialist<TArgs>(
     return baseTool;
   }
 
-  return {
+  const shim = {
     ...baseTool,
     execute: async (args: TArgs, execOptions: any): Promise<unknown> => {
       const specialist = deps.specialistStore.get(specialistId);
@@ -120,6 +121,9 @@ export function wrapToolWithSpecialist<TArgs>(
       }
     },
   };
+  // Object spread drops the non-enumerable `__bernardMeta` from baseTool —
+  // copy it onto the shim so downstream readers still see the tool's class.
+  return preserveMeta(shim, baseTool);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extend `ToolMeta` with `deterministic`, `sideEffect`, `cacheable`, `cacheTtlMs`, `sensitiveArgs`, `sensitiveResult`; add `isCacheable()` helper. (`src/framework/tools/types.ts`)
- Migrate every built-in tool (~30) to declare the new fields via either `BernardTool.meta` (already-migrated tools) or the new `attachMeta()` adapter (legacy AI-SDK tools that haven't been refactored yet). Dynamic MCP default updated to `{ deterministic: false, sideEffect: 'external-api' }`.
- Wire `sensitiveArgs` / `sensitiveResult` redaction into the cron step recorder (`src/framework/hooks/cron-step-recorder.ts`) and the tool-wrapper reasoning log (`src/tools/tool-wrapper-run.ts captureToolCalls`). No built-in tool flips these on yet — infra is ready for future tools (e.g. an OAuth-token MCP).
- Add an in-memory, meta-aware result cache stub (`src/framework/tools/result-cache.ts`) with TTL + sensitive-arg-aware cache keys. **Not wired into `augmentTools` yet** — that's tracked under #171. Top-of-file TODO records the follow-up.
- Add coverage test that constructs `createTools()` against mocked stores and fails if any registered tool is missing the new meta fields. Future tools cannot regress the schema silently.

Closes #176.

## Test plan
- [x] `npm run build`
- [x] `npx vitest run src/framework/tools/meta-coverage.test.ts src/framework/tools/result-cache.test.ts` — 6 / 6 pass
- [x] `npm test` — 2189 / 2189 pass across 92 files
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] `npm run format` — applied
- [ ] Manual: confirm `logs/tool-wrappers.jsonl` continues to write normally after a few REPL turns (no redaction expected — no built-in sets `sensitiveArgs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)