### PR TITLE
feat(policy): central Policy Engine for per-turn decisions (closes #177)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -44,6 +44,8 @@ import { type ImageAttachment, IMAGE_TOKEN_ESTIMATE } from './image.js';
 import { PlanStore } from './plan-store.js';
 import { type ResolvedEntry } from './reference-resolver.js';
 import type { AgentContext } from './framework/context.js';
+import { DefaultPolicyEngine } from './policy/index.js';
+import type { PolicyEngine, PolicyResult } from './policy/index.js';
 
 // `buildSystemPrompt` lives in agent-prompt.ts (extracted to avoid a circular
 // import with framework/agents/main.ts). Re-exported here so existing imports
@@ -105,6 +107,8 @@ export class Agent {
   private stepLimitHitCount: number = 0;
   private lastStepLimitHit: boolean = false;
   private planStore: PlanStore = new PlanStore();
+  private policyEngine: PolicyEngine = new DefaultPolicyEngine();
+  private lastPolicyResult?: PolicyResult;
 
   private ctx: AgentContext;
 
@@ -149,6 +153,11 @@ export class Agent {
     this.abortController?.abort();
   }
 
+  /** Returns the most recent Policy Engine result, or undefined before any turn has run. */
+  getLastPolicyDecision(): PolicyResult | undefined {
+    return this.lastPolicyResult;
+  }
+
   /** Returns step limit hit info from last processInput, or null if limit wasn't hit. */
   getStepLimitHit(): { currentLimit: number; hitCount: number } | null {
     if (!this.lastStepLimitHit) return null;
@@ -179,7 +188,18 @@ export class Agent {
     resolvedReferences?: ResolvedEntry[],
   ): Promise<void> {
     this.lastStepLimitHit = false;
-    this.planStore.clear();
+
+    // Resolve every cross-cutting heuristic for this turn in one place.
+    // Sub-systems read the decision off `this.ctx.policyDecision` (e.g.
+    // strategy selection in `mainAgentDefinition.strategy`) or off the
+    // result returned here. Reasons go to `debugLog('policy:decide', ...)`.
+    const policyResult = this.policyEngine.decide({ userInput, config: this.config });
+    this.lastPolicyResult = policyResult;
+    this.ctx = { ...this.ctx, policyDecision: policyResult.decision };
+
+    if (policyResult.decision.scratch?.resetPlanOnly) {
+      this.planStore.clear();
+    }
     clearPinnedRegion('plan');
 
     const profile = getModelProfile(

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -158,6 +158,17 @@ export class Agent {
     return this.lastPolicyResult;
   }
 
+  /**
+   * Returns the live `AgentContext` (with the most recent `policyDecision`
+   * threaded in by `processInput`). The Agent class re-points `this.ctx`
+   * on every turn, so callers that need to invoke a definition outside the
+   * normal turn loop (e.g. the correction agent at REPL shutdown) should
+   * read this fresh rather than caching the value handed back at startup.
+   */
+  getContext(): AgentContext {
+    return this.ctx;
+  }
+
   /** Returns step limit hit info from last processInput, or null if limit wasn't hit. */
   getStepLimitHit(): { currentLimit: number; hitCount: number } | null {
     if (!this.lastStepLimitHit) return null;
@@ -199,6 +210,9 @@ export class Agent {
 
     if (policyResult.decision.scratch?.resetPlanOnly) {
       this.planStore.clear();
+    }
+    if (policyResult.decision.scratch?.resetAll) {
+      this.memoryStore.clearScratch();
     }
     clearPinnedRegion('plan');
 
@@ -501,5 +515,10 @@ export class Agent {
     this.lastRAGResults = [];
     this.stepLimitHitCount = 0;
     this.lastStepLimitHit = false;
+    this.planStore.clear();
+    this.lastPolicyResult = undefined;
+    if (this.ctx.policyDecision) {
+      this.ctx = { ...this.ctx, policyDecision: undefined };
+    }
   }
 }

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -175,7 +175,7 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
   },
 
   strategy(ctx) {
-    return buildStrategy(ctx.config);
+    return buildStrategy(ctx.config, { strategyId: ctx.policyDecision?.strategyId });
   },
 
   stepBudget(config) {

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -17,6 +17,7 @@ import { augmentTools } from '../../tools/augment.js';
 import { toolToAISDK } from '../tools/adapter.js';
 import { buildToolProfilesPrompt } from '../../tool-profiles.js';
 import { getModelProfile } from '../../providers/index.js';
+import { isReactEffective } from '../../policy/effective.js';
 import { buildSystemPrompt } from '../../agent-prompt.js';
 import { SHARE_REASONING_PROMPT, REASONING_FAMILIES } from '../../agent-prompt.js';
 import { buildContextMessage } from '../../context-message.js';
@@ -155,6 +156,11 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
       ctx.stores.candidates,
       ctx.config,
     );
+    // Gate plan/evaluate on the SAME effective decision the strategy uses
+    // (see strategy(ctx) below). Reading `ctx.config.reactMode` directly
+    // would let `tools()` and `strategy()` drift apart the moment a
+    // sub-policy emits a `strategyId` that doesn't mirror the global flag.
+    const reactActive = isReactEffective(ctx.config, ctx.policyDecision);
     const tools: Record<string, Tool> = {
       ...baseTools,
       agent: createSubAgentTool(ctx),
@@ -163,7 +169,7 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
       tool_wrapper_run: createToolWrapperRunTool(ctx),
       think: createThinkTool(),
       ask_user: createAskUserTool(ctx.toolOptions.askUser),
-      ...(ctx.config.reactMode
+      ...(reactActive
         ? {
             plan: createPlanTool(input.planStore),
             evaluate: createEvaluateTool(),

--- a/src/framework/context.ts
+++ b/src/framework/context.ts
@@ -6,6 +6,7 @@ import { CandidateStore, type CandidateStoreReader } from '../specialist-candida
 import { CorrectionCandidateStore } from '../correction-candidates.js';
 import { ToolProfileStore } from '../tool-profiles.js';
 import type { RAGStore } from '../rag.js';
+import type { PolicyDecision } from '../policy/types.js';
 import type { ToolOptions } from '../tools/types.js';
 
 export interface AgentContextStores {
@@ -28,6 +29,12 @@ export interface AgentContext {
   mcp: AgentContextMCP;
   rag?: RAGStore;
   toolOptions: ToolOptions;
+  /**
+   * Per-turn decision resolved by {@link DefaultPolicyEngine}. Set by the
+   * Agent class at the top of `processInput`; read by sub-systems that
+   * need to honour policy (today: `mainAgentDefinition.strategy`).
+   */
+  policyDecision?: PolicyDecision;
 }
 
 export interface AssembleContextInput {

--- a/src/framework/strategies/__tests__/build-strategy.test.ts
+++ b/src/framework/strategies/__tests__/build-strategy.test.ts
@@ -50,9 +50,31 @@ describe('buildStrategy', () => {
     );
   });
 
+  it('opts.strategyId="react" actually injects coordinator prompt at runtime (not just by type)', async () => {
+    // Regression for Copilot review: instance-check alone was insufficient
+    // because ReActStrategy.run used to short-circuit on ctx.config.reactMode,
+    // making the override a runtime no-op despite the right type.
+    const config = makeConfig({ reactMode: false, maxSteps: 40 });
+    const strategy = buildStrategy(config, { strategyId: 'react' });
+    const ctx = makeCtx(config);
+    await strategy.run(ctx);
+    const firstCall = (ctx.iterate as any).mock.calls[0][0];
+    expect(firstCall.systemSuffix).toContain('Coordinator Mode');
+    expect(firstCall.maxStepsOverride).toBe(120);
+  });
+
   it('opts.strategyId="normal" forces NormalStrategy even when config.reactMode is true', () => {
     expect(buildStrategy(makeConfig({ reactMode: true }), { strategyId: 'normal' })).toBeInstanceOf(
       NormalStrategy,
     );
+  });
+
+  it('opts.strategyId="normal" runs as Normal at runtime even with reactMode=true', async () => {
+    const config = makeConfig({ reactMode: true });
+    const strategy = buildStrategy(config, { strategyId: 'normal' });
+    const ctx = makeCtx(config);
+    await strategy.run(ctx);
+    const firstCall = (ctx.iterate as any).mock.calls[0][0];
+    expect(firstCall.systemSuffix).toBeUndefined();
   });
 });

--- a/src/framework/strategies/__tests__/build-strategy.test.ts
+++ b/src/framework/strategies/__tests__/build-strategy.test.ts
@@ -43,4 +43,16 @@ describe('buildStrategy', () => {
     expect(ctx.iterate as any).toHaveBeenCalledTimes(1);
     expect((ctx.iterate as any).mock.calls[0][0].systemSuffix).toBeUndefined();
   });
+
+  it('opts.strategyId="react" forces ReActStrategy even when config.reactMode is false', () => {
+    expect(buildStrategy(makeConfig({ reactMode: false }), { strategyId: 'react' })).toBeInstanceOf(
+      ReActStrategy,
+    );
+  });
+
+  it('opts.strategyId="normal" forces NormalStrategy even when config.reactMode is true', () => {
+    expect(buildStrategy(makeConfig({ reactMode: true }), { strategyId: 'normal' })).toBeInstanceOf(
+      NormalStrategy,
+    );
+  });
 });

--- a/src/framework/strategies/build-strategy.ts
+++ b/src/framework/strategies/build-strategy.ts
@@ -1,4 +1,5 @@
 import type { BernardConfig } from '../../config.js';
+import { isReactEffective } from '../../policy/effective.js';
 import type { PolicyDecision } from '../../policy/types.js';
 import { NormalStrategy } from './normal.js';
 import { ReActStrategy } from './react.js';
@@ -70,9 +71,14 @@ registerStrategy((inner, config, opts) => {
   // Prefer the Policy Engine's per-turn decision; fall back to the global
   // `BERNARD_REACT_MODE` config flag when the engine hasn't supplied one
   // (e.g. specialist sub-agents, which don't run through the engine).
-  const reactWanted =
-    opts.strategyId === 'react' || (opts.strategyId === undefined && config.reactMode);
+  const reactWanted = isReactEffective(config, { strategyId: opts.strategyId });
+  // Forward `effectiveReactMode: true` so the constructed strategy's runtime
+  // guard (and its `shouldEnforcePlan` call) doesn't re-consult the global
+  // flag and silently no-op when the policy override wanted ReAct.
   return reactWanted
-    ? new ReActStrategy(inner, { enforcementStepRatio: opts.enforcementStepRatio })
+    ? new ReActStrategy(inner, {
+        enforcementStepRatio: opts.enforcementStepRatio,
+        effectiveReactMode: true,
+      })
     : null;
 });

--- a/src/framework/strategies/build-strategy.ts
+++ b/src/framework/strategies/build-strategy.ts
@@ -1,4 +1,5 @@
 import type { BernardConfig } from '../../config.js';
+import type { PolicyDecision } from '../../policy/types.js';
 import { NormalStrategy } from './normal.js';
 import { ReActStrategy } from './react.js';
 import type { ExecutionStrategy } from './types.js';
@@ -9,6 +10,13 @@ export interface BuildStrategyOpts {
    * the historical reduced enforcement budget; main agent leaves it undefined.
    */
   enforcementStepRatio?: number;
+  /**
+   * Per-turn strategy override from the Policy Engine. When undefined,
+   * wrappers fall back to `config.reactMode`. When defined, wrappers prefer
+   * this value — that's the seam future issues (#167) use to vary strategy
+   * per turn without flipping the global config flag.
+   */
+  strategyId?: PolicyDecision['strategyId'];
 }
 
 /**
@@ -58,8 +66,13 @@ export function buildStrategy(
 // ---- Bootstrap registrations -------------------------------------------------
 // Each new strategy adds one import + one registerStrategy call here.
 
-registerStrategy((inner, config, opts) =>
-  config.reactMode
+registerStrategy((inner, config, opts) => {
+  // Prefer the Policy Engine's per-turn decision; fall back to the global
+  // `BERNARD_REACT_MODE` config flag when the engine hasn't supplied one
+  // (e.g. specialist sub-agents, which don't run through the engine).
+  const reactWanted =
+    opts.strategyId === 'react' || (opts.strategyId === undefined && config.reactMode);
+  return reactWanted
     ? new ReActStrategy(inner, { enforcementStepRatio: opts.enforcementStepRatio })
-    : null,
-);
+    : null;
+});

--- a/src/framework/strategies/react.ts
+++ b/src/framework/strategies/react.ts
@@ -21,6 +21,15 @@ export interface ReActStrategyOpts {
    * `SPECIALIST_ENFORCEMENT_STEP_RATIO`.
    */
   enforcementStepRatio?: number;
+  /**
+   * Effective ReAct flag for this turn, resolved by the Policy Engine when
+   * available (see `src/policy/effective.ts`). When set, `run()` uses this
+   * instead of `ctx.config.reactMode`, which is required so a per-turn
+   * `strategyId: 'react'` override actually engages coordinator behavior
+   * even when the global flag is off. Defaults to `ctx.config.reactMode` to
+   * preserve behavior for sub-agent paths that don't go through the engine.
+   */
+  effectiveReactMode?: boolean;
 }
 
 /**
@@ -39,7 +48,8 @@ export class ReActStrategy implements ExecutionStrategy {
   ) {}
 
   async run(ctx: StrategyContext): Promise<AgentResult> {
-    if (!ctx.config.reactMode) return this.inner.run(ctx);
+    const reactActive = this.opts.effectiveReactMode ?? ctx.config.reactMode;
+    if (!reactActive) return this.inner.run(ctx);
 
     const baseMaxSteps = ctx.baseMaxSteps ?? ctx.config.maxSteps;
     const initialMaxSteps = computeEffectiveMaxSteps(baseMaxSteps, true);
@@ -60,7 +70,7 @@ export class ReActStrategy implements ExecutionStrategy {
     if (
       !planStore ||
       !shouldEnforcePlan({
-        reactMode: ctx.config.reactMode,
+        reactMode: reactActive,
         aborted: ctx.abortSignal?.aborted === true,
         stepLimitHit: ctx.getStepLimitHit?.() === true,
         hasSteps: planStore.unresolvedCount() > 0,

--- a/src/policy/caching.test.ts
+++ b/src/policy/caching.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { cachingPolicy } from './caching.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('cachingPolicy', () => {
+  it('is disabled by default and points at issue #171', () => {
+    const result = cachingPolicy(makePolicyInput());
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe('pending-issue-171');
+  });
+});

--- a/src/policy/caching.ts
+++ b/src/policy/caching.ts
@@ -1,0 +1,13 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type Caching = NonNullable<PolicyDecision['caching']>;
+
+/**
+ * Stub sub-policy — issue #171 will introduce LLM-subcall + deterministic
+ * tool caching and gate it here based on `userInput` and tool metadata
+ * (delivered by #176).
+ */
+export const cachingPolicy: SubPolicy<Caching> = () => ({
+  enabled: false,
+  reason: 'pending-issue-171',
+});

--- a/src/policy/citations.test.ts
+++ b/src/policy/citations.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { citationsPolicy } from './citations.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('citationsPolicy', () => {
+  it('is off by default and points at issue #173', () => {
+    const result = citationsPolicy(makePolicyInput());
+    expect(result.requireForFactualClaims).toBe(false);
+    expect(result.reason).toBe('pending-issue-173');
+  });
+});

--- a/src/policy/citations.ts
+++ b/src/policy/citations.ts
@@ -1,0 +1,13 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type Citations = NonNullable<PolicyDecision['citations']>;
+
+/**
+ * Stub sub-policy — issue #173 will require citations for factual claims
+ * surfaced from web/RAG sources, gated here based on `userInput` shape
+ * (e.g. questions vs. casual replies).
+ */
+export const citationsPolicy: SubPolicy<Citations> = () => ({
+  requireForFactualClaims: false,
+  reason: 'pending-issue-173',
+});

--- a/src/policy/concise.test.ts
+++ b/src/policy/concise.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { concisePolicy } from './concise.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('concisePolicy', () => {
+  it('is disabled by default and points at issue #175', () => {
+    const result = concisePolicy(makePolicyInput());
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe('pending-issue-175');
+  });
+});

--- a/src/policy/concise.ts
+++ b/src/policy/concise.ts
@@ -1,0 +1,13 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type Concise = NonNullable<PolicyDecision['concise']>;
+
+/**
+ * Stub sub-policy — issue #175 will gate concise-mode and pick max line /
+ * bullet counts here. Today the agent's own `BASE_SYSTEM_PROMPT` carries the
+ * concise guidance, so this sub-policy is inert.
+ */
+export const concisePolicy: SubPolicy<Concise> = () => ({
+  enabled: false,
+  reason: 'pending-issue-175',
+});

--- a/src/policy/effective.test.ts
+++ b/src/policy/effective.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isReactEffective } from './effective.js';
+
+describe('isReactEffective', () => {
+  it('returns true when policy says "react", regardless of config.reactMode', () => {
+    expect(isReactEffective({ reactMode: false }, { strategyId: 'react' })).toBe(true);
+    expect(isReactEffective({ reactMode: true }, { strategyId: 'react' })).toBe(true);
+  });
+
+  it('returns false when policy says "normal", regardless of config.reactMode', () => {
+    expect(isReactEffective({ reactMode: false }, { strategyId: 'normal' })).toBe(false);
+    expect(isReactEffective({ reactMode: true }, { strategyId: 'normal' })).toBe(false);
+  });
+
+  it('falls back to config.reactMode when no decision is supplied', () => {
+    expect(isReactEffective({ reactMode: true })).toBe(true);
+    expect(isReactEffective({ reactMode: false })).toBe(false);
+  });
+
+  it('falls back to config.reactMode when strategyId is undefined', () => {
+    expect(isReactEffective({ reactMode: true }, {})).toBe(true);
+    expect(isReactEffective({ reactMode: false }, {})).toBe(false);
+  });
+});

--- a/src/policy/effective.ts
+++ b/src/policy/effective.ts
@@ -1,0 +1,23 @@
+import type { BernardConfig } from '../config.js';
+import type { PolicyDecision } from './types.js';
+
+/**
+ * Single source of truth for whether the active turn is running in ReAct
+ * (coordinator) mode. The Policy Engine's per-turn `strategyId` wins when
+ * present; otherwise the global `config.reactMode` flag is consulted.
+ *
+ * Every site that branches on ReAct vs. Normal must route through this
+ * helper — otherwise the strategy registration, the strategy's runtime
+ * guard, and the tool-set assembly drift apart and the agent ends up
+ * running a coordinator loop without the tools the coordinator needs (or
+ * vice versa).
+ */
+export function isReactEffective(
+  config: Pick<BernardConfig, 'reactMode'>,
+  decision?: Pick<PolicyDecision, 'strategyId'>,
+): boolean {
+  const id = decision?.strategyId;
+  if (id === 'react') return true;
+  if (id === 'normal') return false;
+  return config.reactMode;
+}

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as logger from '../logger.js';
+import { DefaultPolicyEngine } from './engine.js';
+import { MODEL_COMPONENTS } from './model.js';
+import { makePolicyInput } from './test-helpers.js';
+
+vi.mock('../logger.js', () => ({ debugLog: vi.fn() }));
+
+describe('DefaultPolicyEngine', () => {
+  beforeEach(() => {
+    vi.mocked(logger.debugLog).mockClear();
+  });
+
+  it('populates every PolicyDecision key from its sub-policy', () => {
+    const engine = new DefaultPolicyEngine();
+    const { decision } = engine.decide(makePolicyInput({ config: { reactMode: true } }));
+
+    expect(decision.strategyId).toBe('react');
+    expect(Object.keys(decision.models ?? {}).sort()).toEqual([...MODEL_COMPONENTS].sort());
+    expect(decision.concise?.enabled).toBe(false);
+    expect(decision.scratch).toEqual({
+      resetAll: false,
+      resetPlanOnly: true,
+      reason: 'per-turn-default',
+    });
+    expect(decision.caching?.enabled).toBe(false);
+    expect(decision.citations?.requireForFactualClaims).toBe(false);
+    expect(decision.toolMode).toEqual({ mode: 'write', requireConfirmForWrite: true });
+  });
+
+  it('emits a reason code for every sub-policy', () => {
+    const engine = new DefaultPolicyEngine();
+    const { reasons } = engine.decide(makePolicyInput());
+    expect(Object.keys(reasons).sort()).toEqual(
+      ['caching', 'citations', 'concise', 'models', 'scratch', 'strategy', 'toolMode'].sort(),
+    );
+    for (const value of Object.values(reasons)) {
+      expect(value).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it('logs the decision via debugLog under the "policy:decide" label', () => {
+    const engine = new DefaultPolicyEngine();
+    engine.decide(makePolicyInput());
+    expect(logger.debugLog).toHaveBeenCalledTimes(1);
+    const [label, payload] = vi.mocked(logger.debugLog).mock.calls[0];
+    expect(label).toBe('policy:decide');
+    expect(payload).toHaveProperty('decision');
+    expect(payload).toHaveProperty('reasons');
+  });
+
+  it('reacts to config.reactMode changes between calls', () => {
+    const engine = new DefaultPolicyEngine();
+    const off = engine.decide(makePolicyInput({ config: { reactMode: false } }));
+    const on = engine.decide(makePolicyInput({ config: { reactMode: true } }));
+    expect(off.decision.strategyId).toBe('normal');
+    expect(off.reasons.strategy).toBe('react-mode-disabled');
+    expect(on.decision.strategyId).toBe('react');
+    expect(on.reasons.strategy).toBe('react-mode-flag');
+  });
+});

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,0 +1,66 @@
+import { debugLog } from '../logger.js';
+import { cachingPolicy } from './caching.js';
+import { citationsPolicy } from './citations.js';
+import { concisePolicy } from './concise.js';
+import { modelPolicy } from './model.js';
+import { scratchPolicy } from './scratch.js';
+import { strategyPolicy } from './strategy.js';
+import { toolModePolicy } from './tool-mode.js';
+import type { PolicyDecision, PolicyEngine, PolicyInput, PolicyResult } from './types.js';
+
+/**
+ * Composes every sub-policy in a fixed order, builds a {@link PolicyDecision}
+ * plus a parallel reason map, and logs one entry per call when
+ * `BERNARD_DEBUG` is on.
+ *
+ * Sub-policies are pure functions over {@link PolicyInput}. Adding a new
+ * heuristic is: create `src/policy/<name>.ts` that exports a `SubPolicy<…>`,
+ * import + invoke it here, write `<name>.test.ts`. The engine itself stays
+ * trivial — that's the point.
+ */
+export class DefaultPolicyEngine implements PolicyEngine {
+  decide(input: PolicyInput): PolicyResult {
+    const strategy = strategyPolicy(input);
+    const models = modelPolicy(input);
+    const concise = concisePolicy(input);
+    const scratch = scratchPolicy(input);
+    const caching = cachingPolicy(input);
+    const citations = citationsPolicy(input);
+    const toolMode = toolModePolicy(input);
+
+    const decision: PolicyDecision = {
+      strategyId: strategy.id,
+      models: models.models,
+      concise: {
+        enabled: concise.enabled,
+        maxLines: concise.maxLines,
+        maxBullets: concise.maxBullets,
+      },
+      scratch: {
+        resetAll: scratch.resetAll,
+        resetPlanOnly: scratch.resetPlanOnly,
+        reason: scratch.reason,
+      },
+      caching: { enabled: caching.enabled },
+      citations: { requireForFactualClaims: citations.requireForFactualClaims },
+      toolMode: {
+        mode: toolMode.mode,
+        requireConfirmForWrite: toolMode.requireConfirmForWrite,
+      },
+    };
+
+    const reasons: Record<string, string> = {
+      strategy: strategy.reason,
+      models: models.reason,
+      concise: concise.reason,
+      scratch: scratch.reason,
+      caching: caching.reason,
+      citations: citations.reason,
+      toolMode: toolMode.reason,
+    };
+
+    debugLog('policy:decide', { decision, reasons });
+
+    return { decision, reasons };
+  }
+}

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -1,0 +1,10 @@
+export { DefaultPolicyEngine } from './engine.js';
+export { MODEL_COMPONENTS, type ModelComponent } from './model.js';
+export type {
+  PolicyDecision,
+  PolicyEngine,
+  PolicyInput,
+  PolicyResult,
+  SubDecision,
+  SubPolicy,
+} from './types.js';

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -1,4 +1,5 @@
 export { DefaultPolicyEngine } from './engine.js';
+export { isReactEffective } from './effective.js';
 export { MODEL_COMPONENTS, type ModelComponent } from './model.js';
 export type {
   PolicyDecision,

--- a/src/policy/model.test.ts
+++ b/src/policy/model.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { MODEL_COMPONENTS, modelPolicy } from './model.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('modelPolicy', () => {
+  it('mirrors config.provider and config.model for every known component', () => {
+    const result = modelPolicy(
+      makePolicyInput({ config: { provider: 'openai', model: 'gpt-4o' } }),
+    );
+    expect(result.reason).toBe('config-default');
+    for (const key of MODEL_COMPONENTS) {
+      expect(result.models[key]).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    }
+  });
+
+  it('emits exactly the known component keys (no extras, no gaps)', () => {
+    const result = modelPolicy(makePolicyInput());
+    expect(Object.keys(result.models).sort()).toEqual([...MODEL_COMPONENTS].sort());
+  });
+});

--- a/src/policy/model.ts
+++ b/src/policy/model.ts
@@ -1,0 +1,36 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+/**
+ * Component identifiers used as keys in the per-component model map. Listed
+ * here (not just in the sub-policy body) so downstream call sites in
+ * different files can share the same constants when issue #170 wires them up.
+ */
+export const MODEL_COMPONENTS = [
+  'main',
+  'sub',
+  'wrapper',
+  'cron',
+  'prompt-rewriter',
+  'repair',
+  'reference-resolver',
+  'specialist-detector',
+  'context-compression',
+] as const;
+
+export type ModelComponent = (typeof MODEL_COMPONENTS)[number];
+
+type Models = NonNullable<PolicyDecision['models']>;
+
+/**
+ * Returns the per-component provider/model map. Today: every component
+ * mirrors `config.provider` / `config.model`. Issue #170 will replace this
+ * with multi-model assignment driven by preferences.
+ */
+export const modelPolicy: SubPolicy<{ models: Models }> = (input) => {
+  const base = { provider: input.config.provider, model: input.config.model };
+  const models: Models = {};
+  for (const key of MODEL_COMPONENTS) {
+    models[key] = base;
+  }
+  return { models, reason: 'config-default' };
+};

--- a/src/policy/model.ts
+++ b/src/policy/model.ts
@@ -1,21 +1,17 @@
 import type { PolicyDecision, SubPolicy } from './types.js';
 
 /**
- * Component identifiers used as keys in the per-component model map. Listed
- * here (not just in the sub-policy body) so downstream call sites in
- * different files can share the same constants when issue #170 wires them up.
+ * Component identifiers used as keys in the per-component model map.
+ *
+ * Only the components whose call sites currently receive `AgentContext`
+ * (and can therefore read `ctx.policyDecision`) are listed: `main` and
+ * sub-agents. Issue #170 will extend this set as it threads policy access
+ * through the other model-selection call sites (`wrapper`, `cron`,
+ * `prompt-rewriter`, `repair`, `reference-resolver`, `specialist-detector`,
+ * `context-compression`) — each one gets added together with its wiring so
+ * the policy contract never advertises a slot that nothing reads.
  */
-export const MODEL_COMPONENTS = [
-  'main',
-  'sub',
-  'wrapper',
-  'cron',
-  'prompt-rewriter',
-  'repair',
-  'reference-resolver',
-  'specialist-detector',
-  'context-compression',
-] as const;
+export const MODEL_COMPONENTS = ['main', 'sub'] as const;
 
 export type ModelComponent = (typeof MODEL_COMPONENTS)[number];
 

--- a/src/policy/scratch.test.ts
+++ b/src/policy/scratch.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { scratchPolicy } from './scratch.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('scratchPolicy', () => {
+  it('clears the plan store every turn and leaves scratch alone', () => {
+    const result = scratchPolicy(makePolicyInput());
+    expect(result.resetPlanOnly).toBe(true);
+    expect(result.resetAll).toBe(false);
+    expect(result.reason).toBe('per-turn-default');
+  });
+});

--- a/src/policy/scratch.ts
+++ b/src/policy/scratch.ts
@@ -1,0 +1,15 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type Scratch = NonNullable<PolicyDecision['scratch']>;
+
+/**
+ * Today: clears plan-store only, every turn. Matches the historical
+ * unconditional `planStore.clear()` at the top of `Agent.processInput`.
+ * Issue #169 will switch this to a real heuristic (subject change, "new
+ * task" detection, etc.) and may set `resetAll: true` to also drop scratch.
+ */
+export const scratchPolicy: SubPolicy<Scratch> = () => ({
+  resetAll: false,
+  resetPlanOnly: true,
+  reason: 'per-turn-default',
+});

--- a/src/policy/strategy.test.ts
+++ b/src/policy/strategy.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { strategyPolicy } from './strategy.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('strategyPolicy', () => {
+  it('returns react with react-mode-flag when reactMode is on', () => {
+    const result = strategyPolicy(makePolicyInput({ config: { reactMode: true } }));
+    expect(result.id).toBe('react');
+    expect(result.reason).toBe('react-mode-flag');
+  });
+
+  it('returns normal with react-mode-disabled when reactMode is off', () => {
+    const result = strategyPolicy(makePolicyInput({ config: { reactMode: false } }));
+    expect(result.id).toBe('normal');
+    expect(result.reason).toBe('react-mode-disabled');
+  });
+});

--- a/src/policy/strategy.ts
+++ b/src/policy/strategy.ts
@@ -1,0 +1,16 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type StrategyId = NonNullable<PolicyDecision['strategyId']>;
+
+/**
+ * Selects the execution strategy for the main agent. Today: mirrors
+ * `config.reactMode`. Future work (#167) introduces a Qualifier that
+ * inspects `userInput` to choose `pac` / `single-shot` / etc.; this
+ * sub-policy is the only place that needs to change.
+ */
+export const strategyPolicy: SubPolicy<{ id: StrategyId }> = (input) => {
+  if (input.config.reactMode) {
+    return { id: 'react', reason: 'react-mode-flag' };
+  }
+  return { id: 'normal', reason: 'react-mode-disabled' };
+};

--- a/src/policy/test-helpers.ts
+++ b/src/policy/test-helpers.ts
@@ -2,17 +2,17 @@ import type { BernardConfig } from '../config.js';
 import type { PolicyInput } from './types.js';
 
 /**
- * Builds a {@link PolicyInput} for tests. Constructs only the
- * `BernardConfig` fields sub-policies currently read (provider, model,
- * reactMode); the rest are filled with safe defaults via a cast so tests
- * stay short.
+ * Builds a {@link PolicyInput} for tests. The default config is a fully-typed
+ * `BernardConfig` value (no `as` cast) so missing fields surface as compile
+ * errors when the type evolves; callers can selectively override any field
+ * via `overrides.config`.
  */
 export function makePolicyInput(overrides?: {
   userInput?: string;
   config?: Partial<BernardConfig>;
   turnIndex?: number;
 }): PolicyInput {
-  const config = {
+  const baseConfig: BernardConfig = {
     provider: 'anthropic',
     model: 'claude-sonnet-4-5-20250929',
     maxTokens: 4096,
@@ -31,11 +31,10 @@ export function makePolicyInput(overrides?: {
     referenceLookup: true,
     referenceLookupTools: [],
     customProviders: {},
-    ...overrides?.config,
-  } as BernardConfig;
+  };
   return {
     userInput: overrides?.userInput ?? 'hello',
-    config,
+    config: { ...baseConfig, ...overrides?.config },
     turnIndex: overrides?.turnIndex,
   };
 }

--- a/src/policy/test-helpers.ts
+++ b/src/policy/test-helpers.ts
@@ -1,0 +1,41 @@
+import type { BernardConfig } from '../config.js';
+import type { PolicyInput } from './types.js';
+
+/**
+ * Builds a {@link PolicyInput} for tests. Constructs only the
+ * `BernardConfig` fields sub-policies currently read (provider, model,
+ * reactMode); the rest are filled with safe defaults via a cast so tests
+ * stay short.
+ */
+export function makePolicyInput(overrides?: {
+  userInput?: string;
+  config?: Partial<BernardConfig>;
+  turnIndex?: number;
+}): PolicyInput {
+  const config = {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5-20250929',
+    maxTokens: 4096,
+    shellTimeout: 30000,
+    tokenWindow: 0,
+    ragEnabled: true,
+    theme: 'bernard',
+    maxSteps: 25,
+    reactMode: false,
+    subagentPac: true,
+    toolDetails: false,
+    autoCreateSpecialists: false,
+    autoCreateThreshold: 0.8,
+    correctionEnabled: true,
+    promptRewriter: true,
+    referenceLookup: true,
+    referenceLookupTools: [],
+    customProviders: {},
+    ...overrides?.config,
+  } as BernardConfig;
+  return {
+    userInput: overrides?.userInput ?? 'hello',
+    config,
+    turnIndex: overrides?.turnIndex,
+  };
+}

--- a/src/policy/tool-mode.test.ts
+++ b/src/policy/tool-mode.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { toolModePolicy } from './tool-mode.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('toolModePolicy', () => {
+  it('defaults to write-mode with confirm-on-write', () => {
+    const result = toolModePolicy(makePolicyInput());
+    expect(result.mode).toBe('write');
+    expect(result.requireConfirmForWrite).toBe(true);
+    expect(result.reason).toBe('config-default');
+  });
+});

--- a/src/policy/tool-mode.ts
+++ b/src/policy/tool-mode.ts
@@ -1,0 +1,16 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type ToolMode = NonNullable<PolicyDecision['toolMode']>;
+
+/**
+ * Default tool-mode: writes allowed, with the existing per-command
+ * confirmation prompts intact (see `BERNARD_TMP_PREFIX` safelist in
+ * `src/tools/shell.ts`). Issue #144 will narrow to `'read-only'` for
+ * questions and other low-risk asks based on `userInput` and tool
+ * metadata from #176.
+ */
+export const toolModePolicy: SubPolicy<ToolMode> = () => ({
+  mode: 'write',
+  requireConfirmForWrite: true,
+  reason: 'config-default',
+});

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -1,0 +1,50 @@
+import type { BernardConfig } from '../config.js';
+
+/**
+ * Per-turn input the Policy Engine sees. Pure data — sub-policies must be
+ * deterministic over this shape. New fields are added here as sub-policies
+ * grow in sophistication (see issues #167, #169, #170, #171, #173, #175).
+ */
+export interface PolicyInput {
+  userInput: string;
+  config: BernardConfig;
+  turnIndex?: number;
+}
+
+/**
+ * Verbatim from issue #177. Every field is optional so future sub-policies
+ * can extend without forcing call sites to handle every key. Today this PR
+ * actively wires only `strategyId` and `scratch`; the rest carry default
+ * sub-policy values that mirror current behavior and will be consumed by
+ * downstream issues.
+ */
+export interface PolicyDecision {
+  strategyId?: 'normal' | 'react' | 'pac' | 'single-shot';
+  models?: Record<string, { provider: string; model: string }>;
+  concise?: { enabled: boolean; maxLines?: number; maxBullets?: number };
+  scratch?: { resetAll: boolean; resetPlanOnly: boolean; reason: string };
+  caching?: { enabled: boolean };
+  citations?: { requireForFactualClaims: boolean };
+  toolMode?: { mode: 'read-only' | 'write'; requireConfirmForWrite: boolean };
+}
+
+/**
+ * What a sub-policy emits: its own sub-decision shape (the value for one
+ * `PolicyDecision` key) plus a free-form `reason` string. Reason codes are
+ * stable identifiers (kebab-case), not free prose — they end up in
+ * `debugLog` and in the `/policy` REPL command output.
+ */
+export type SubDecision<T> = T & { reason: string };
+
+/** Pure per-turn function from input to one sub-decision. */
+export type SubPolicy<T> = (input: PolicyInput) => SubDecision<T>;
+
+export interface PolicyResult {
+  decision: PolicyDecision;
+  /** Map keyed by sub-policy name (e.g. `'strategy'`, `'scratch'`). */
+  reasons: Record<string, string>;
+}
+
+export interface PolicyEngine {
+  decide(input: PolicyInput): PolicyResult;
+}

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1015,7 +1015,10 @@ export async function startRepl(
         const pending = correctionStore.listPending();
         if (pending.length > 0) {
           printInfo(`Reviewing ${pending.length} tool-wrapper failure(s) for learning...`);
-          const result = await runCorrectionAgent({ ctx: agentCtx }, pending);
+          // Read the live ctx off the agent so the correction pass sees
+          // the latest policyDecision and any other per-turn refinements
+          // made by `processInput`; `agentCtx` is the startup snapshot.
+          const result = await runCorrectionAgent({ ctx: agent.getContext() }, pending);
           if (result.applied > 0) {
             printInfo(
               `  Learned from ${result.applied}/${result.processed} failure(s); examples updated.`,

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -149,6 +149,7 @@ export async function startRepl(
     { command: '/compact', description: 'Compress conversation history in-place' },
     { command: '/memory', description: 'List persistent memories' },
     { command: '/scratch', description: 'List session scratch notes' },
+    { command: '/policy', description: 'Show last policy decision and reason codes' },
     { command: '/mcp', description: 'List MCP servers and tools' },
     { command: '/cron', description: 'Show cron jobs and daemon status' },
     { command: '/rag', description: 'Show RAG memory stats and recent facts' },
@@ -1415,6 +1416,22 @@ export async function startRepl(
           printInfo('Scratch notes:');
           for (const key of keys) {
             printInfo(`  - ${key}`);
+          }
+        }
+        void prompt();
+        return;
+      }
+
+      if (trimmed === '/policy') {
+        const last = agent.getLastPolicyDecision();
+        if (!last) {
+          printInfo('No policy decision yet — send a message first.');
+        } else {
+          printInfo('Last policy decision:');
+          printInfo(JSON.stringify(last.decision, null, 2));
+          printInfo('Reason codes:');
+          for (const [key, reason] of Object.entries(last.reasons)) {
+            printInfo(`  ${key}: ${reason}`);
           }
         }
         void prompt();


### PR DESCRIPTION
## Summary

- Adds `src/policy/` — a single engine that resolves per-turn heuristics (strategy, models, concise, scratch, caching, citations, tool-mode) in one place.
- Each heuristic is a pure sub-policy in its own file with its own test; the engine composes them, builds a `PolicyDecision`, and logs decisions + reason codes under `policy:decide`.
- Active wire-ups preserve current behavior: `Agent.processInput` calls `engine.decide()` at the top of every turn; `planStore.clear()` is gated on `decision.scratch.resetPlanOnly`; `build-strategy.ts` prefers `opts.strategyId` when defined, falling back to `config.reactMode`.
- Stub sub-policies (model / concise / caching / citations / tool-mode) return current-behavior defaults so downstream issues (#167, #169, #170, #171, #173, #175) can change sub-policy internals without touching call sites.
- New `/policy` REPL command prints the last decision + reason map; `BERNARD_DEBUG=1` emits one `policy:decide` log entry per turn.

## Test plan

- [x] `npm run build` — clean.
- [x] `npx vitest run src/policy/` — 13 tests pass (one per sub-policy + 4 engine composition tests).
- [x] `npx vitest run src/framework/strategies/` — existing tests + 2 new override tests pass.
- [x] `npx vitest run` — full suite, 2209 tests pass.
- [x] `npm run lint` — 0 errors.
- [x] `npm run format` — clean.
- [ ] Manual: launch REPL, send a message, run `/policy`, confirm output shows all decision keys + reason map.
- [ ] Manual: `BERNARD_DEBUG=1 npm run dev`, send a message, confirm `.logs/<date>.log` has a `policy:decide` entry.
- [ ] Manual: toggle `BERNARD_REACT_MODE=true|false` between runs and confirm `/policy` reflects `strategyId: 'react' | 'normal'` with matching reason codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)