### PR TITLE
feat(framework): unify memory-injection contract in runDefinition (closes #143)

### DIFF
--- a/src/framework/agents/__tests__/run.test.ts
+++ b/src/framework/agents/__tests__/run.test.ts
@@ -17,6 +17,19 @@ vi.mock('../../../tool-call-repair.js', () => ({
   makeRepairHook: vi.fn(() => vi.fn()),
 }));
 
+// Spy on buildContextMessage so the framework-default injection assertions can
+// inspect exactly what `runDefinition` passes in without needing a real
+// MemoryStore.
+vi.mock('../../../context-message.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../context-message.js')>(
+    '../../../context-message.js',
+  );
+  return {
+    ...actual,
+    buildContextMessage: vi.fn(),
+  };
+});
+
 import { generateText, type CoreMessage } from 'ai';
 import { runDefinition } from '../run.js';
 import { DefinitionRegistry, definitions } from '../registry.js';
@@ -24,6 +37,7 @@ import type { AgentDefinition } from '../types.js';
 import { NormalStrategy } from '../../strategies/normal.js';
 import type { AgentContext } from '../../context.js';
 import type { BernardConfig } from '../../../config.js';
+import { buildContextMessage } from '../../../context-message.js';
 
 function makeConfig(): BernardConfig {
   return {
@@ -46,7 +60,7 @@ function makeConfig(): BernardConfig {
 function makeCtx(): AgentContext {
   return {
     config: makeConfig(),
-    stores: {} as any,
+    stores: { memory: { fake: true } } as any,
     mcp: { tools: {}, serverNames: [] },
     toolOptions: {} as any,
   };
@@ -81,6 +95,10 @@ beforeEach(() => {
     response: { messages: [] },
     finishReason: 'stop',
   });
+  // Default: buildContextMessage returns null (no content) so existing tests
+  // that don't care about the context message see an empty messages prefix.
+  // Individual tests override this for context-message assertions.
+  (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mockReturnValue(null);
 });
 
 describe('runDefinition', () => {
@@ -222,6 +240,92 @@ describe('runDefinition wrapIterate + seedMessages getter', () => {
     expect(innerCalls).toBe(1);
     // inner called twice — generateText should be invoked twice
     expect((generateText as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+  });
+});
+
+describe('runDefinition framework-default context injection (issue #143)', () => {
+  it('injects memory + scratch by default when contextInputs is omitted', async () => {
+    const def = fakeDefinition(); // no contextInputs
+    const ctx = makeCtx();
+    const sentinel: CoreMessage = {
+      role: 'user',
+      content: '<system_provided_context>fake</system_provided_context>',
+    };
+    (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mockReturnValue(sentinel);
+
+    await runDefinition(ctx, def, { text: 'hi' });
+
+    expect(buildContextMessage).toHaveBeenCalledTimes(1);
+    const callArgs = (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.memoryStore).toBe(ctx.stores.memory);
+    expect(callArgs.includeScratch).toBe(true);
+
+    const arg = (generateText as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // Sentinel should be inserted before the user message.
+    expect(arg.messages).toEqual([sentinel, { role: 'user', content: 'hi' }]);
+  });
+
+  it('opts out entirely when contextInputs returns null', async () => {
+    const def = fakeDefinition({ contextInputs: () => null });
+    const ctx = makeCtx();
+    // Even if buildContextMessage would return something, it should not be called.
+    (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      role: 'user',
+      content: 'should not appear',
+    } satisfies CoreMessage);
+
+    await runDefinition(ctx, def, { text: 'hi' });
+
+    expect(buildContextMessage).not.toHaveBeenCalled();
+    const arg = (generateText as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg.messages).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
+  it('merges extras from contextInputs over the includeScratch default', async () => {
+    const def = fakeDefinition({
+      contextInputs: () => ({
+        includeScratch: false,
+        mcpServerNames: ['a', 'b'],
+      }),
+    });
+    const ctx = makeCtx();
+    (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    await runDefinition(ctx, def, { text: 'hi' });
+
+    expect(buildContextMessage).toHaveBeenCalledTimes(1);
+    const callArgs = (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.memoryStore).toBe(ctx.stores.memory);
+    expect(callArgs.includeScratch).toBe(false);
+    expect(callArgs.mcpServerNames).toEqual(['a', 'b']);
+  });
+
+  it('awaits async contextInputs', async () => {
+    const def = fakeDefinition({
+      async contextInputs() {
+        await new Promise((r) => setTimeout(r, 0));
+        return { mcpServerNames: ['from-async'] };
+      },
+    });
+    const ctx = makeCtx();
+
+    await runDefinition(ctx, def, { text: 'hi' });
+
+    expect(buildContextMessage).toHaveBeenCalledTimes(1);
+    const callArgs = (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.mcpServerNames).toEqual(['from-async']);
+    expect(callArgs.includeScratch).toBe(true);
+  });
+
+  it('drops the context message when buildContextMessage returns null even with defaults', async () => {
+    const def = fakeDefinition(); // default injection
+    const ctx = makeCtx();
+    (buildContextMessage as unknown as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    await runDefinition(ctx, def, { text: 'hi' });
+
+    const arg = (generateText as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg.messages).toEqual([{ role: 'user', content: 'hi' }]);
   });
 });
 

--- a/src/framework/agents/cron.ts
+++ b/src/framework/agents/cron.ts
@@ -1,6 +1,5 @@
 import { tool, type CoreMessage, type Tool } from 'ai';
 import { z } from 'zod';
-import { buildContextMessage } from '../../context-message.js';
 import { createShellTool } from '../../tools/shell.js';
 import { createMemoryTool, createScratchTool } from '../../tools/memory.js';
 import { createDateTimeTool, formatCurrentDateTime } from '../../tools/datetime.js';
@@ -112,14 +111,11 @@ export const cronDefinition: AgentDefinition<CronInput, string> = {
     return `${DAEMON_SYSTEM_PROMPT}\n\nCurrent date and time: ${formatCurrentDateTime()}`;
   },
 
-  contextMessages(ctx, input) {
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
+  contextInputs(_ctx, input) {
+    return {
       ragResults: input.ragResults,
-      includeScratch: true,
       mcpServerNames: input.serverNames,
-    });
-    return msg ? [msg] : [];
+    };
   },
 
   tools(ctx, input) {

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -108,19 +108,15 @@ export function buildMainSystemPrompt(
 }
 
 /**
- * Builds the lower-privilege per-turn context message for the main agent.
- * Returns 0 or 1 `CoreMessage`. Used both as the value returned from
- * `mainAgentDefinition.contextMessages` and (for the Agent class's preflight
- * token estimate) so the count reflects the actual wire payload.
+ * Builds the lower-privilege per-turn context-message extras for the main
+ * agent. Used both by the Agent class's preflight token estimate (via
+ * {@link buildMainContextMessages}) and by `mainAgentDefinition.contextInputs`
+ * — the framework merges these into a `buildContextMessage` call that also
+ * supplies the default `memoryStore` + `includeScratch: true` (issue #143).
  */
-export function buildMainContextMessages(
-  ctx: AgentContext,
-  input: Omit<MainInput, 'systemPrompt'>,
-): CoreMessage[] {
-  const msg = buildContextMessage({
-    memoryStore: ctx.stores.memory,
+function buildMainContextInputs(ctx: AgentContext, input: Omit<MainInput, 'systemPrompt'>) {
+  return {
     ragResults: input.ragResults,
-    includeScratch: true,
     mcpServerNames: ctx.mcp.serverNames,
     routineSummaries: input.routineSummaries,
     specialistSummaries: input.specialistSummaries,
@@ -128,6 +124,23 @@ export function buildMainContextMessages(
     resolvedReferences: input.resolvedReferences,
     alertContext: input.alertContext,
     provenance: ctx.provenance,
+  };
+}
+
+/**
+ * Preflight-estimate helper: returns the 0-or-1 `CoreMessage` array that the
+ * framework will inject for the main agent. The Agent class (`src/agent.ts`)
+ * calls this to size its token budget so the count reflects the actual wire
+ * payload that `runDefinition` will produce.
+ */
+export function buildMainContextMessages(
+  ctx: AgentContext,
+  input: Omit<MainInput, 'systemPrompt'>,
+): CoreMessage[] {
+  const msg = buildContextMessage({
+    memoryStore: ctx.stores.memory,
+    includeScratch: true,
+    ...buildMainContextInputs(ctx, input),
   });
   return msg ? [msg] : [];
 }
@@ -156,8 +169,8 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
     return input.systemPrompt;
   },
 
-  contextMessages(ctx, input) {
-    return buildMainContextMessages(ctx, input);
+  contextInputs(ctx, input) {
+    return buildMainContextInputs(ctx, input);
   },
 
   tools(ctx, input): Record<string, Tool> {

--- a/src/framework/agents/pac-actor.ts
+++ b/src/framework/agents/pac-actor.ts
@@ -1,5 +1,4 @@
 import type { CoreMessage } from 'ai';
-import { buildContextMessage } from '../../context-message.js';
 import { debugLog } from '../../logger.js';
 import { appendActivitySummary } from '../../tools/activity-summary.js';
 import { createTools } from '../../tools/index.js';
@@ -55,14 +54,8 @@ export const pacActorDefinition: AgentDefinition<PacActorInput, string> = {
     return PAC_ACTOR_SYSTEM_PROMPT;
   },
 
-  async contextMessages(ctx, input) {
-    const ragResults = await searchRag(ctx, input.task);
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      ragResults,
-      includeScratch: true,
-    });
-    return msg ? [msg] : [];
+  async contextInputs(ctx, input) {
+    return { ragResults: await searchRag(ctx, input.task) };
   },
 
   tools(ctx) {

--- a/src/framework/agents/pac-critic.ts
+++ b/src/framework/agents/pac-critic.ts
@@ -85,6 +85,14 @@ export const pacCriticDefinition: AgentDefinition<PacCriticInput, PacCriticVerdi
     return PAC_CRITIC_SYSTEM_PROMPT;
   },
 
+  // The Critic intentionally opts out of the framework's default
+  // `<system_provided_context>` injection (issue #143). Memory + scratch are
+  // exposed as read-only tools (`memory.read` / `scratch.read` via
+  // `buildCriticTools`) so the Critic must explicitly look up whatever it
+  // needs to verify against — keeps verification grounded in the task and the
+  // Actor's report rather than ambient memory.
+  contextInputs: () => null,
+
   tools(ctx) {
     return buildCriticTools(ctx);
   },

--- a/src/framework/agents/pac-planner.ts
+++ b/src/framework/agents/pac-planner.ts
@@ -1,5 +1,4 @@
 import type { CoreMessage, Tool } from 'ai';
-import { buildContextMessage } from '../../context-message.js';
 import { createDateTimeTool } from '../../tools/datetime.js';
 import { createFileTools } from '../../tools/file.js';
 import { createThinkTool } from '../../tools/think.js';
@@ -82,13 +81,7 @@ export const pacPlannerDefinition: AgentDefinition<PacPlannerInput, string> = {
     return PAC_PLANNER_SYSTEM_PROMPT;
   },
 
-  contextMessages(ctx) {
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      includeScratch: true,
-    });
-    return msg ? [msg] : [];
-  },
+  // contextInputs omitted: framework default injects memory + scratch.
 
   tools(ctx) {
     return buildPlannerTools(ctx);

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage } from 'ai';
 import { defaultProviderErrorMessage, resolveProviderAndModel } from '../../config.js';
+import { buildContextMessage, type ContextMessageInputs } from '../../context-message.js';
 import { getModelForConfig, getProviderOptionsForConfig } from '../../providers/index.js';
 import { makeRepairHook } from '../../tool-call-repair.js';
 import type { AgentContext } from '../context.js';
@@ -87,12 +88,28 @@ export async function runDefinition<TInput, TFormatted>(
           return () => arr;
         })();
 
-  // Per-turn lower-privilege context (issue #172). Resolved fresh on every
-  // iterate so memory updates / new RAG hits are reflected, and NOT persisted
-  // into the caller's history.
+  // Per-turn lower-privilege context (issue #172 + #143). The framework
+  // ALWAYS wraps `memoryStore` + `includeScratch: true` by default so a new
+  // AgentDefinition inherits OWASP LLM01 channel separation without
+  // remembering to wire it up. Definitions only declare extras (RAG hits,
+  // MCP names, routine listings, etc.) via `contextInputs`. Returning `null`
+  // opts the definition out entirely (used by pac-critic, which exposes
+  // `memory.read` / `scratch.read` as tools instead).
+  //
+  // Resolved fresh on every iterate so memory updates / new RAG hits are
+  // reflected, and NOT persisted into the caller's history.
   const getContextMessages = async (): Promise<CoreMessage[]> => {
-    if (!def.contextMessages) return [];
-    return Promise.resolve(def.contextMessages(ctx, input));
+    let extras: Partial<ContextMessageInputs> | null = {};
+    if (def.contextInputs) {
+      extras = await Promise.resolve(def.contextInputs(ctx, input));
+    }
+    if (extras === null) return [];
+    const msg = buildContextMessage({
+      memoryStore: ctx.stores.memory,
+      includeScratch: true,
+      ...extras,
+    });
+    return msg ? [msg] : [];
   };
 
   // `messages` here is a placeholder — `innerIterate` rebuilds the messages

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -99,15 +99,22 @@ export async function runDefinition<TInput, TFormatted>(
   // Resolved fresh on every iterate so memory updates / new RAG hits are
   // reflected, and NOT persisted into the caller's history.
   const getContextMessages = async (): Promise<CoreMessage[]> => {
-    let extras: Partial<ContextMessageInputs> | null = {};
+    let extras: Partial<Omit<ContextMessageInputs, 'memoryStore'>> | null = {};
     if (def.contextInputs) {
-      extras = await Promise.resolve(def.contextInputs(ctx, input));
+      try {
+        extras = await Promise.resolve(def.contextInputs(ctx, input));
+      } catch {
+        // Fail-soft: a thrown contextInputs (e.g. RAG search error) must not
+        // abort the turn. Drop the extras and fall back to the framework
+        // default memory + scratch contract.
+        extras = {};
+      }
     }
     if (extras === null) return [];
     const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      includeScratch: true,
       ...extras,
+      memoryStore: ctx.stores.memory,
+      includeScratch: extras.includeScratch ?? true,
     });
     return msg ? [msg] : [];
   };

--- a/src/framework/agents/specialist.ts
+++ b/src/framework/agents/specialist.ts
@@ -1,7 +1,6 @@
 import type { CoreMessage, Tool } from 'ai';
 import { defaultProviderErrorMessage, resolveProviderAndModel } from '../../config.js';
 import { getModelForConfig, getProviderOptionsForConfig } from '../../providers/index.js';
-import { buildContextMessage } from '../../context-message.js';
 import { debugLog } from '../../logger.js';
 import { PlanStore } from '../../plan-store.js';
 import { capSubagentResult } from '../../tools/result-cap.js';
@@ -75,14 +74,8 @@ export const specialistDefinition: AgentDefinition<SpecialistInput, string> = {
     return systemPrompt;
   },
 
-  async contextMessages(ctx, input) {
-    const ragResults = await searchRagForSpecialist(ctx, input);
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      ragResults,
-      includeScratch: true,
-    });
-    return msg ? [msg] : [];
+  async contextInputs(ctx, input) {
+    return { ragResults: await searchRagForSpecialist(ctx, input) };
   },
 
   async tools(ctx, input) {

--- a/src/framework/agents/sub.ts
+++ b/src/framework/agents/sub.ts
@@ -1,5 +1,4 @@
 import type { CoreMessage } from 'ai';
-import { buildContextMessage } from '../../context-message.js';
 import { debugLog } from '../../logger.js';
 import { capSubagentResult } from '../../tools/result-cap.js';
 import { appendActivitySummary } from '../../tools/activity-summary.js';
@@ -60,14 +59,8 @@ export const subAgentDefinition: AgentDefinition<SubAgentInput, string> = {
     return SUB_AGENT_SYSTEM_PROMPT;
   },
 
-  async contextMessages(ctx, input) {
-    const ragResults = await searchRag(ctx, input.task);
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      ragResults,
-      includeScratch: true,
-    });
-    return msg ? [msg] : [];
+  async contextInputs(ctx, input) {
+    return { ragResults: await searchRag(ctx, input.task) };
   },
 
   tools(ctx) {

--- a/src/framework/agents/task.ts
+++ b/src/framework/agents/task.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import type { CoreMessage } from 'ai';
 import type { BernardConfig } from '../../config.js';
-import { buildContextMessage } from '../../context-message.js';
 import { debugLog } from '../../logger.js';
 import { extractJsonBlock } from '../../structured-output.js';
 import { createTools } from '../../tools/index.js';
@@ -140,14 +139,11 @@ export const taskDefinition: AgentDefinition<TaskInput, TaskResult> = {
     return TASK_SYSTEM_PROMPT + autoContext;
   },
 
-  async contextMessages(ctx, input) {
-    const ragResults = await searchRag(ctx, input.task);
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      ragResults,
+  async contextInputs(ctx, input) {
+    return {
+      ragResults: await searchRag(ctx, input.task),
       includeScratch: false,
-    });
-    return msg ? [msg] : [];
+    };
   },
 
   tools(ctx) {

--- a/src/framework/agents/tool-wrapper.ts
+++ b/src/framework/agents/tool-wrapper.ts
@@ -1,7 +1,6 @@
 import type { CoreMessage, Tool } from 'ai';
 import { defaultProviderErrorMessage, resolveProviderAndModel } from '../../config.js';
 import { getModelForConfig, getProviderOptionsForConfig } from '../../providers/index.js';
-import { buildContextMessage } from '../../context-message.js';
 import { osPromptBlock } from '../../os-info.js';
 import {
   STRUCTURED_OUTPUT_RULES,
@@ -78,13 +77,7 @@ export const toolWrapperDefinition: AgentDefinition<ToolWrapperInput, WrapperRes
     return systemPrompt;
   },
 
-  contextMessages(ctx) {
-    const msg = buildContextMessage({
-      memoryStore: ctx.stores.memory,
-      includeScratch: true,
-    });
-    return msg ? [msg] : [];
-  },
+  // contextInputs omitted: framework default injects memory + scratch.
 
   tools(_ctx, input) {
     return input.childTools;

--- a/src/framework/agents/types.ts
+++ b/src/framework/agents/types.ts
@@ -96,11 +96,20 @@ export interface AgentDefinition<TInput = unknown, TFormatted = unknown> {
    * wiring (issue #172 + #143).
    *
    * Rebuilt on every iterate call — NOT persisted into the caller's history.
+   *
+   * `memoryStore` is intentionally omitted from the return type: definitions
+   * MUST NOT shadow the framework-injected store, because doing so would
+   * silently drop `<persistent_memory>` + `<scratch_notes>` and re-introduce
+   * the LLM01 vector this contract exists to prevent. To opt out entirely,
+   * return `null`.
    */
   contextInputs?(
     ctx: AgentContext,
     input: TInput,
-  ): Partial<ContextMessageInputs> | null | Promise<Partial<ContextMessageInputs> | null>;
+  ):
+    | Partial<Omit<ContextMessageInputs, 'memoryStore'>>
+    | null
+    | Promise<Partial<Omit<ContextMessageInputs, 'memoryStore'>> | null>;
 
   /** Hooks composed onto onStepFinish (output, token-stats, cron-step-recorder, etc.). */
   hooks(ctx: AgentContext, input: TInput): AgentHook[];

--- a/src/framework/agents/types.ts
+++ b/src/framework/agents/types.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage, LanguageModel, Tool } from 'ai';
 import type { BernardConfig } from '../../config.js';
+import type { ContextMessageInputs } from '../../context-message.js';
 import type { RepairLabel } from '../../tool-call-repair.js';
 import type { AgentContext } from '../context.js';
 import type { AgentHook } from '../hooks/types.js';
@@ -76,16 +77,30 @@ export interface AgentDefinition<TInput = unknown, TFormatted = unknown> {
   buildUserMessage(input: TInput): CoreMessage;
 
   /**
-   * Per-turn lower-privilege reference data prepended to the messages array
-   * each iterate call. Used to inject memory, RAG hits, scratch notes, MCP
-   * names, routine/specialist listings, resolved references, and alert
-   * context as a `role:'user'` `<system_provided_context>` message instead of
-   * stitching them into the SYSTEM prompt (see issue #172).
+   * Per-turn extras merged into the framework-managed
+   * `<system_provided_context>` block. The framework always wraps
+   * `memoryStore` + `includeScratch: true` by default — definitions only
+   * declare what they add on top (RAG hits, MCP server names, routine /
+   * specialist listings, resolved references, alert context, provenance).
+   * Issue #143.
+   *
+   * Returning `null` is an explicit opt-out (no context message is injected
+   * at all). This is the contract used by `pac-critic`, which exposes
+   * `memory.read` / `scratch.read` as tools instead of injecting memory
+   * up-front.
+   *
+   * Omitting this method entirely gets the safe default: a context message
+   * with `<persistent_memory>` + `<scratch_notes>` populated from
+   * `ctx.stores.memory`. Adding a brand-new `AgentDefinition` therefore
+   * inherits OWASP LLM01 channel separation without any per-definition
+   * wiring (issue #172 + #143).
    *
    * Rebuilt on every iterate call — NOT persisted into the caller's history.
-   * Returning an empty array (or omitting the method) skips injection.
    */
-  contextMessages?(ctx: AgentContext, input: TInput): Promise<CoreMessage[]> | CoreMessage[];
+  contextInputs?(
+    ctx: AgentContext,
+    input: TInput,
+  ): Partial<ContextMessageInputs> | null | Promise<Partial<ContextMessageInputs> | null>;
 
   /** Hooks composed onto onStepFinish (output, token-stats, cron-step-recorder, etc.). */
   hooks(ctx: AgentContext, input: TInput): AgentHook[];

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -100,23 +100,12 @@ import {
   promotePendingCandidates,
 } from './candidate-bootstrap.js';
 import { detectSpecialistCandidate } from './specialist-detector.js';
-import {
-  TASK_SYSTEM_PROMPT,
-  wrapTaskResult,
-  getTaskMaxSteps,
-  makeLastStepTextOnly,
-} from './tools/task.js';
+import { taskDefinition } from './tools/task.js';
+import { runDefinition } from './framework/agents/run.js';
+import type { TaskInput } from './framework/agents/task.js';
+import { acquireSlot, releaseSlot, MAX_CONCURRENT_AGENTS } from './tools/agent-pool.js';
 import { createTools } from './tools/index.js';
-import {
-  printTaskStart,
-  printTaskEnd,
-  printToolCall,
-  printToolResult,
-  printAssistantText,
-  printWarning,
-  setToolDetailsVisible,
-} from './output.js';
-import { buildContextMessage } from './context-message.js';
+import { printTaskStart, printTaskEnd, printWarning, setToolDetailsVisible } from './output.js';
 import { debugLog } from './logger.js';
 import {
   loadImage,
@@ -1194,67 +1183,25 @@ export async function startRepl(
     printTaskStart(description);
     startSpinner('Running task...');
 
+    const slot = acquireSlot();
+    if (!slot) {
+      stopSpinner();
+      processing = false;
+      taskAbortController = null;
+      printError(`Maximum concurrent agents (${MAX_CONCURRENT_AGENTS}) reached.`);
+      return;
+    }
+
     try {
-      const baseTools = createTools(toolOptions, memoryStore, mcpTools);
-
-      // Optional RAG search for context
-      let ragResults;
-      if (ragStore) {
-        try {
-          ragResults = await ragStore.search(description);
-          if (ragResults.length > 0) {
-            debugLog('repl:task:rag', {
-              query: description.slice(0, 100),
-              results: ragResults.length,
-            });
-          }
-        } catch (err) {
-          debugLog('repl:task:rag:error', err instanceof Error ? err.message : String(err));
-        }
-      }
-
-      const autoContext = `\n\nWorking directory: ${process.cwd()}\nAvailable tools: ${Object.keys(baseTools).join(', ')}`;
-
-      // Memory/RAG moves to a lower-privilege user-role message (issue #172).
-      const systemPrompt = TASK_SYSTEM_PROMPT + autoContext;
-      const contextMsg = buildContextMessage({
-        memoryStore,
-        ragResults,
-        includeScratch: false,
-      });
-
-      let userMessage = `Task: ${description}`;
-      if (context) {
-        userMessage += `\n\nAdditional context: ${context}`;
-      }
-
-      const messagesPayload: CoreMessage[] = contextMsg
-        ? [contextMsg, { role: 'user', content: userMessage }]
-        : [{ role: 'user', content: userMessage }];
-
-      const taskMaxSteps = getTaskMaxSteps(config);
-      const result = await generateText({
-        model: getModelForConfig(config, config.provider, config.model),
-        providerOptions: getProviderOptionsForConfig(config, config.provider),
-        tools: baseTools,
-        maxSteps: taskMaxSteps,
-        maxTokens: config.maxTokens,
-        system: systemPrompt,
-        messages: messagesPayload,
-        abortSignal: taskAbortController.signal,
-        experimental_prepareStep: makeLastStepTextOnly(taskMaxSteps),
-        onStepFinish: ({ text, toolCalls, toolResults }) => {
-          for (const tc of toolCalls) {
-            printToolCall(tc.toolName, tc.args as Record<string, unknown>);
-          }
-          for (const tr of toolResults) {
-            printToolResult(tr.toolName, tr.result);
-          }
-          if (text) {
-            printAssistantText(text);
-          }
-        },
-      });
+      const input: TaskInput = context
+        ? { task: description, context, slotId: slot.id }
+        : { task: description, slotId: slot.id };
+      const { result, formatted: taskResult } = await runDefinition(
+        agent.getContext(),
+        taskDefinition,
+        input,
+        { abortSignal: taskAbortController.signal },
+      );
 
       if (result.finishReason === 'length') {
         const recommended = Math.ceil((config.maxTokens * 2) / 1024) * 1024;
@@ -1265,7 +1212,6 @@ export async function startRepl(
       }
 
       stopSpinner();
-      const taskResult = wrapTaskResult(result.text);
       printTaskEnd(JSON.stringify(taskResult));
 
       // Print the full output for the user
@@ -1287,6 +1233,7 @@ export async function startRepl(
         printError(message);
       }
     } finally {
+      releaseSlot();
       processing = false;
       taskAbortController = null;
       stopSpinner();

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -73,7 +73,7 @@ import { interactiveUpdate, getLocalVersion } from './update.js';
 import { CronStore } from './cron/store.js';
 import { isDaemonRunning } from './cron/client.js';
 import { HistoryStore } from './history.js';
-import { generateText, type CoreMessage } from 'ai';
+import { generateText } from 'ai';
 import {
   getModelForConfig,
   getModelProfile,
@@ -104,7 +104,6 @@ import { taskDefinition } from './tools/task.js';
 import { runDefinition } from './framework/agents/run.js';
 import type { TaskInput } from './framework/agents/task.js';
 import { acquireSlot, releaseSlot, MAX_CONCURRENT_AGENTS } from './tools/agent-pool.js';
-import { createTools } from './tools/index.js';
 import { printTaskStart, printTaskEnd, printWarning, setToolDetailsVisible } from './output.js';
 import { debugLog } from './logger.js';
 import {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1180,28 +1180,31 @@ export async function startRepl(
     processing = true;
     interrupted = false;
     taskAbortController = new AbortController();
-    printTaskStart(description);
-    startSpinner('Running task...');
 
     const slot = acquireSlot();
     if (!slot) {
-      stopSpinner();
       processing = false;
       taskAbortController = null;
       printError(`Maximum concurrent agents (${MAX_CONCURRENT_AGENTS}) reached.`);
       return;
     }
 
+    printTaskStart(description);
+    startSpinner('Running task...');
+
+    // Provenance is per-turn (cleared at processInput entry). /task runs
+    // outside processInput, so clear here to isolate its citations from the
+    // last main-agent turn and from any prior /task in the same prompt.
+    const ctx = agent.getContext();
+    ctx.provenance.clear();
+
     try {
       const input: TaskInput = context
         ? { task: description, context, slotId: slot.id }
         : { task: description, slotId: slot.id };
-      const { result, formatted: taskResult } = await runDefinition(
-        agent.getContext(),
-        taskDefinition,
-        input,
-        { abortSignal: taskAbortController.signal },
-      );
+      const { result, formatted: taskResult } = await runDefinition(ctx, taskDefinition, input, {
+        abortSignal: taskAbortController.signal,
+      });
 
       if (result.finishReason === 'length') {
         const recommended = Math.ceil((config.maxTokens * 2) / 1024) * 1024;
@@ -1227,7 +1230,9 @@ export async function startRepl(
       }
     } catch (err: unknown) {
       stopSpinner();
-      if (!interrupted) {
+      if (interrupted) {
+        printTaskEnd(JSON.stringify({ status: 'cancelled', output: 'interrupted' }));
+      } else {
         const message = err instanceof Error ? err.message : String(err);
         printTaskEnd(JSON.stringify({ status: 'error', output: message }));
         printError(message);


### PR DESCRIPTION
## Summary

- Replace `AgentDefinition.contextMessages` with `contextInputs?(ctx, input): Partial<ContextMessageInputs> | null`. `runDefinition` now always wraps `ctx.stores.memory` + `includeScratch: true` into a `<system_provided_context>` user-role message by default, merging extras from the hook. A brand-new `AgentDefinition` therefore inherits OWASP LLM01 channel separation (issue #172) without any per-definition wiring.
- Collapse the duplicated `buildContextMessage(...)` calls across `main` / `sub` / `specialist` / `task` / `tool-wrapper` / `cron` / `pac-actor` / `pac-planner` into either a single-line extras hook or nothing at all. `pac-critic` opts out explicitly with `contextInputs: () => null` because it intentionally uses tool-based memory access.
- Migrate the REPL inline `/task` runner (`executeTask` in `src/repl.ts`) to `runDefinition(taskDefinition, …)` so it no longer bypasses the framework. Picks up `ctx.provenance` for free.

## Acceptance criteria (issue #143)

- [x] Memory + scratch are wrapped by the framework, not by individual definitions.
- [x] A new `AgentDefinition` with no `contextInputs` still gets `<persistent_memory>` / `<scratch_notes>` channel separation.
- [x] Duplicated `buildContextMessage(...)` calls across the 8 definitions + `repl.ts` are gone (or reduced to a one-line `contextInputs`).
- [x] Opt-out path exists for definitions like `pac-critic` (`contextInputs: () => null`).
- [x] Regression tests added in #172 still pass without per-definition wiring (no test changes required).

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm run format\` — clean
- [x] \`npm test\` — 2291 tests across 106 files pass, including the issue #172 regression suites (\`src/agent.test.ts\`, \`src/context-message.test.ts\`, \`src/tools/subagent.test.ts\`, \`src/cron/runner.test.ts\`)
- [x] New framework-level tests in \`src/framework/agents/__tests__/run.test.ts\` cover: default memory+scratch injection when \`contextInputs\` is omitted; null opt-out; async hook; extras-merge over defaults; null \`buildContextMessage\` result drop
- [ ] Manual smoke: run \`/task\` in the REPL and confirm step-by-step output still streams with the new \`[task:N]\` prefix and the wrapped \`{status, output}\` JSON renders
- [ ] Manual smoke: trigger a sub-agent and confirm RAG hits surface in \`<recalled_context>\`
- [ ] Manual smoke: run the PAC pipeline end to end and confirm pac-critic receives no \`<system_provided_context>\` block (opt-out) while pac-actor and pac-planner do

🤖 Generated with [Claude Code](https://claude.com/claude-code)