### PR TITLE
feat(policy): multi-model assignment policy (closes #170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,11 @@ Keys for custom providers are stored in `keys.json` (same path as built-ins) and
 
 Per-provider tier → model mapping (in `src/model-policy.ts`):
 
-| Provider  | premium                          | mid                              | cheap                      |
-|-----------|----------------------------------|----------------------------------|----------------------------|
-| anthropic | claude-opus-4-6                  | claude-sonnet-4-5-20250929       | claude-haiku-4-5-20251001  |
-| openai    | gpt-5.2                          | gpt-4.1                          | gpt-4.1-mini               |
-| xai       | grok-4-1-fast-reasoning          | grok-4-fast-non-reasoning        | grok-3-mini                |
+| Provider  | premium                 | mid                        | cheap                     |
+| --------- | ----------------------- | -------------------------- | ------------------------- |
+| anthropic | claude-opus-4-6         | claude-sonnet-4-5-20250929 | claude-haiku-4-5-20251001 |
+| openai    | gpt-5.2                 | gpt-4.1                    | gpt-4.1-mini              |
+| xai       | grok-4-1-fast-reasoning | grok-4-fast-non-reasoning  | grok-3-mini               |
 
 Custom providers fall back to `config.model` for every site (no tier mapping). Invocation-level overrides and per-specialist `provider`/`model` records always win over the policy. When `modelMode !== 'off'` and a specialist is created without an explicit provider/model, the policy-resolved `specialist`-tier model is persisted onto the new record so later mode changes don't silently re-tier it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,32 @@ bernard providers                # lists built-ins and custom side-by-side
 
 Keys for custom providers are stored in `keys.json` (same path as built-ins) and never injected into `process.env`. Built-in providers are unaffected.
 
+## Model Mode (multi-model assignment)
+
+`config.modelMode` (#170) tiers the (provider, model) used by each LLM call site within the active provider's model lineup. Four presets:
+
+- `off` (default) — every site uses `config.provider`/`config.model`. Legacy behavior, zero overhead.
+- `optimize-tokens` — aggressive cost-saving. Main uses **mid**, every sub-agent/wrapper/router site uses **cheap**.
+- `balanced` — main **premium**; specialist/tool-wrapper/compressor **mid**; rewriter/reference-resolver/reference-lookup/specialist-detector **cheap**.
+- `optimize-performance` — every site uses **premium**.
+
+Per-provider tier → model mapping (in `src/model-policy.ts`):
+
+| Provider  | premium                          | mid                              | cheap                      |
+|-----------|----------------------------------|----------------------------------|----------------------------|
+| anthropic | claude-opus-4-6                  | claude-sonnet-4-5-20250929       | claude-haiku-4-5-20251001  |
+| openai    | gpt-5.2                          | gpt-4.1                          | gpt-4.1-mini               |
+| xai       | grok-4-1-fast-reasoning          | grok-4-fast-non-reasoning        | grok-3-mini                |
+
+Custom providers fall back to `config.model` for every site (no tier mapping). Invocation-level overrides and per-specialist `provider`/`model` records always win over the policy. When `modelMode !== 'off'` and a specialist is created without an explicit provider/model, the policy-resolved `specialist`-tier model is persisted onto the new record so later mode changes don't silently re-tier it.
+
+```bash
+bernard set-model-mode balanced            # CLI
+# REPL: /agent-options → Model mode
+```
+
+The single source of truth is `resolveSiteModel(config, site, opts?)` in `src/model-policy.ts`. Every `generateText` call site routes through it. Set `BERNARD_DEBUG=1` to see `model-policy:resolve` log entries per site.
+
 ## Key Patterns
 
 - **Vercel AI SDK** (`ai` package) provides unified tool calling across Anthropic/OpenAI/xAI
@@ -113,6 +139,7 @@ On first run, files are auto-migrated from `~/.bernard/` to XDG locations. A `~/
 - `BERNARD_HOME` — Override all XDG directories with a single flat path
 - `BERNARD_COORDINATOR_MODE` — Tri-state execution-strategy selector: `on | off | auto` (default: `auto`). `on` runs ReAct every turn (think → act → evaluate → decide loop with plan tool + enforcement, per-turn step budget `min(BERNARD_MAX_STEPS * 3, 150)`, up to 2 extra re-prompts if the plan still has unresolved steps — worst-case step count `effectiveMaxSteps * 3`, subagent budgets unaffected). `off` runs single-shot Normal every turn. `auto` runs the per-turn Qualifier (`src/qualifier/`) which classifies the user message via rule-based features grounded in LLM-routing research (RouteLLM, FrugalGPT, Topaz, MoMA, RouterArena) and emits `strategyId: 'normal' | 'react'` plus a kebab-case reason that flows through `policy:decide` + `qualifier:outcome` debug logs.
 - `BERNARD_REACT_MODE` — Deprecated alias for `BERNARD_COORDINATOR_MODE`: `true` → `on`, `false` → `off`. Use `BERNARD_COORDINATOR_MODE` directly.
+- `BERNARD_MODEL_MODE` — Multi-model assignment policy (#170): `off | optimize-tokens | balanced | optimize-performance` (default: `off`). See the "Model Mode" section above.
 - `BERNARD_SUBAGENT_PAC` — Route sub-agent dispatch through the PAC (Planner → Actor → Critic) pipeline instead of the legacy single-agent path (default: true). Each phase is a distinct `AgentDefinition` with its own ephemeral history, tool subset, and step budget (20% / 60% / 20% of the sub-agent allotment). On critic `fail` the orchestrator re-plans with critic feedback and re-runs the actor once (`PAC_MAX_RETRIES = 1`); after final failure the actor output is returned with a `## Critic Verdict: FAIL` footer. Set to `false` to fall back to the legacy `sub` definition. See `src/framework/pac/run-pac.ts`.
 - `BERNARD_SUBAGENT_RESULT_MAX_CHARS` — Max characters returned from a sub-agent / specialist into the parent agent's context, default 4000. The user still sees full output in the terminal.
 - `BERNARD_AUTO_CREATE_SPECIALISTS` — Auto-create specialists above confidence threshold (default: false)

--- a/src/candidate-bootstrap.test.ts
+++ b/src/candidate-bootstrap.test.ts
@@ -117,6 +117,8 @@ describe('bootstrapPendingCandidates', () => {
       'above threshold',
       'You are demo',
       [],
+      undefined,
+      undefined,
     );
     expect(candidateStore.updateStatus).toHaveBeenCalledWith('cand-above', 'accepted');
     expect(result.pending).toEqual([below]);
@@ -164,6 +166,8 @@ describe('promotePendingCandidates', () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
+      undefined,
+      undefined,
     );
     expect(candidateStore.updateStatus).toHaveBeenCalledWith('at', 'accepted');
     expect(candidateStore.updateStatus).not.toHaveBeenCalledWith('below', 'accepted');
@@ -191,6 +195,8 @@ describe('promoteCandidate', () => {
       'wraps demo',
       'Do demo things',
       ['be concise'],
+      undefined,
+      undefined,
     );
     expect(candidateStore.updateStatus).toHaveBeenCalledWith('cand-x', 'accepted');
     expect(mockPrintInfo).toHaveBeenCalledWith(

--- a/src/candidate-bootstrap.ts
+++ b/src/candidate-bootstrap.ts
@@ -9,9 +9,7 @@ import { resolveSiteModel } from './model-policy.js';
  * Picks the policy-resolved (provider, model) for a newly auto-created
  * specialist, or `{}` when multi-model mode is off / policy can't resolve.
  */
-function pickAutoCreateModel(
-  config?: BernardConfig,
-): { provider?: string; model?: string } {
+function pickAutoCreateModel(config?: BernardConfig): { provider?: string; model?: string } {
   if (!config || config.modelMode === 'off') return {};
   try {
     const site = resolveSiteModel(config, 'specialist');

--- a/src/candidate-bootstrap.ts
+++ b/src/candidate-bootstrap.ts
@@ -3,6 +3,26 @@ import { CandidateStore, type SpecialistCandidate } from './specialist-candidate
 import { printInfo, printWarning } from './output.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
+import { resolveSiteModel } from './model-policy.js';
+
+/**
+ * Picks the policy-resolved (provider, model) for a newly auto-created
+ * specialist, or `{}` when multi-model mode is off / policy can't resolve.
+ */
+function pickAutoCreateModel(
+  config?: BernardConfig,
+): { provider?: string; model?: string } {
+  if (!config || config.modelMode === 'off') return {};
+  try {
+    const site = resolveSiteModel(config, 'specialist');
+    if (site.source === 'policy') {
+      return { provider: site.provider, model: site.modelName };
+    }
+  } catch {
+    /* fall through */
+  }
+  return {};
+}
 
 /** Promote a pending candidate to a full specialist, updating status and logging. */
 export function promoteCandidate(
@@ -13,13 +33,17 @@ export function promoteCandidate(
   specialistStore: SpecialistStore,
   candidateStore: CandidateStore,
   threshold: number,
+  config?: BernardConfig,
 ): void {
+  const { provider, model } = pickAutoCreateModel(config);
   specialistStore.create(
     candidate.draftId,
     candidate.name,
     candidate.description,
     candidate.systemPrompt,
     candidate.guidelines,
+    provider,
+    model,
   );
   candidateStore.updateStatus(candidate.id, 'accepted');
   debugLog('repl:auto-create', {
@@ -37,12 +61,13 @@ export function promotePendingCandidates(
   candidateStore: CandidateStore,
   specialistStore: SpecialistStore,
   threshold: number,
+  config?: BernardConfig,
 ): void {
   const pending = candidateStore.listPending();
   for (const c of pending) {
     if (c.confidence >= threshold) {
       try {
-        promoteCandidate(c, specialistStore, candidateStore, threshold);
+        promoteCandidate(c, specialistStore, candidateStore, threshold, config);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         debugLog('repl:auto-create', {
@@ -77,11 +102,12 @@ export function bootstrapPendingCandidates(
   candidateStore: CandidateStore,
   specialistStore: SpecialistStore,
   opts: Pick<BernardConfig, 'autoCreateSpecialists' | 'autoCreateThreshold'>,
+  config?: BernardConfig,
 ): BootstrapResult {
   candidateStore.pruneOld();
   candidateStore.reconcileSaved(specialistStore.list());
   if (opts.autoCreateSpecialists) {
-    promotePendingCandidates(candidateStore, specialistStore, opts.autoCreateThreshold);
+    promotePendingCandidates(candidateStore, specialistStore, opts.autoCreateThreshold, config);
   }
   const pending = candidateStore.listPending();
   if (pending.length === 0) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,14 @@ export interface BernardConfig {
    * turn. The Policy Engine reads this field via `strategyPolicy` (#167).
    */
   coordinatorMode: 'on' | 'off' | 'auto';
+  /**
+   * Multi-model assignment policy (#170). `'off'` keeps every LLM call site
+   * pinned to `provider`/`model` (legacy behavior). `'optimize-tokens'`,
+   * `'balanced'`, and `'optimize-performance'` route each site through
+   * `resolveSiteModel` in `src/model-policy.ts` to pick a cheap / mid / premium
+   * tier of the active provider's model lineup.
+   */
+  modelMode: 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance';
   /** Whether sub-agent delegations run through the PAC (Planner → Actor → Critic) pipeline. */
   subagentPac: boolean;
   /** Whether tool-call arguments and full tool result output are shown in the terminal. Tool names and call lines are always shown. */
@@ -82,11 +90,21 @@ const DEFAULT_MAX_STEPS = 25;
 const DEFAULT_AUTO_CREATE_SPECIALISTS = false;
 const DEFAULT_AUTO_CREATE_THRESHOLD = 0.8;
 const DEFAULT_COORDINATOR_MODE: 'on' | 'off' | 'auto' = 'auto';
+const DEFAULT_MODEL_MODE: 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance' = 'off';
 const DEFAULT_SCRATCH_SUBJECT_THRESHOLD = 0.15;
 
 /** Type guard for `coordinatorMode` string values. */
 function isCoordinatorMode(v: unknown): v is 'on' | 'off' | 'auto' {
   return v === 'on' || v === 'off' || v === 'auto';
+}
+
+/** Type guard for `modelMode` string values (#170). */
+export function isModelMode(
+  v: unknown,
+): v is 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance' {
+  return (
+    v === 'off' || v === 'optimize-tokens' || v === 'balanced' || v === 'optimize-performance'
+  );
 }
 
 /**
@@ -175,6 +193,7 @@ export function savePreferences(prefs: {
   theme?: string;
   autoUpdate?: boolean;
   coordinatorMode?: 'on' | 'off' | 'auto';
+  modelMode?: 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance';
   subagentPac?: boolean;
   toolDetails?: boolean;
   autoCreateSpecialists?: boolean;
@@ -195,6 +214,7 @@ export function savePreferences(prefs: {
   if (prefs.theme !== undefined) data.theme = prefs.theme;
   if (prefs.autoUpdate !== undefined) data.autoUpdate = prefs.autoUpdate;
   if (prefs.coordinatorMode !== undefined) data.coordinatorMode = prefs.coordinatorMode;
+  if (prefs.modelMode !== undefined) data.modelMode = prefs.modelMode;
   if (prefs.subagentPac !== undefined) data.subagentPac = prefs.subagentPac;
   if (prefs.toolDetails !== undefined) data.toolDetails = prefs.toolDetails;
   if (prefs.autoCreateSpecialists !== undefined)
@@ -224,6 +244,9 @@ export function savePreferences(prefs: {
     if (prefs[k] === undefined && existing && typeof existing[k] === 'boolean') {
       data[k] = existing[k];
     }
+  }
+  if (prefs.modelMode === undefined && existing && isModelMode(existing.modelMode)) {
+    data.modelMode = existing.modelMode;
   }
   if (prefs.coordinatorMode === undefined && existing) {
     if (isCoordinatorMode(existing.coordinatorMode)) {
@@ -292,6 +315,7 @@ export function loadPreferences(): {
   theme?: string;
   autoUpdate?: boolean;
   coordinatorMode?: 'on' | 'off' | 'auto';
+  modelMode?: 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance';
   subagentPac?: boolean;
   toolDetails?: boolean;
   autoCreateSpecialists?: boolean;
@@ -320,6 +344,7 @@ export function loadPreferences(): {
       theme: typeof parsed.theme === 'string' ? parsed.theme : undefined,
       autoUpdate: typeof parsed.autoUpdate === 'boolean' ? parsed.autoUpdate : undefined,
       coordinatorMode,
+      modelMode: isModelMode(parsed.modelMode) ? parsed.modelMode : undefined,
       subagentPac: typeof parsed.subagentPac === 'boolean' ? parsed.subagentPac : undefined,
       toolDetails: typeof parsed.toolDetails === 'boolean' ? parsed.toolDetails : undefined,
       autoCreateSpecialists:
@@ -806,6 +831,16 @@ export function loadConfig(overrides?: {
     legacyReactModeToCoordinator(envLegacyReact) ??
     DEFAULT_COORDINATOR_MODE;
 
+  // Multi-model assignment mode (#170). Precedence: pref > env > default.
+  const envModelMode = isModelMode(process.env.BERNARD_MODEL_MODE)
+    ? (process.env.BERNARD_MODEL_MODE as
+        | 'off'
+        | 'optimize-tokens'
+        | 'balanced'
+        | 'optimize-performance')
+    : undefined;
+  const modelMode = prefs.modelMode ?? envModelMode ?? DEFAULT_MODEL_MODE;
+
   // Sub-agent PAC pipeline runs by default; users can opt out with BERNARD_SUBAGENT_PAC=false.
   const rawSubagentPac = process.env.BERNARD_SUBAGENT_PAC;
   const subagentPac =
@@ -891,6 +926,7 @@ export function loadConfig(overrides?: {
     ragEnabled,
     theme,
     coordinatorMode,
+    modelMode,
     subagentPac,
     toolDetails,
     autoCreateSpecialists,

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,9 +102,7 @@ function isCoordinatorMode(v: unknown): v is 'on' | 'off' | 'auto' {
 export function isModelMode(
   v: unknown,
 ): v is 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance' {
-  return (
-    v === 'off' || v === 'optimize-tokens' || v === 'balanced' || v === 'optimize-performance'
-  );
+  return v === 'off' || v === 'optimize-tokens' || v === 'balanced' || v === 'optimize-performance';
 }
 
 /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,7 @@
 import { generateText, type CoreMessage } from 'ai';
-import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
+import { resolveSiteModel } from './model-policy.js';
 import type { RAGStore } from './rag.js';
 import { DOMAIN_REGISTRY, getDomainIds } from './domains.js';
 import { estimateContentPartTokens } from './image.js';
@@ -158,13 +158,14 @@ export async function extractDomainFacts(
 
   const domainIds = getDomainIds();
 
+  const site = resolveSiteModel(config, 'compressor');
   const results = await Promise.allSettled(
     domainIds.map(async (domainId) => {
       const domain = DOMAIN_REGISTRY[domainId];
 
       const result = await generateText({
-        model: getModelForConfig(config, config.provider, config.model),
-        providerOptions: getProviderOptionsForConfig(config, config.provider),
+        model: site.model,
+        providerOptions: site.providerOptions,
         maxTokens: 2048,
         system: domain.extractionPrompt,
         messages: [
@@ -256,9 +257,10 @@ export async function compressHistory(
 
   try {
     // Run summarization and domain-specific fact extraction in parallel
+    const summarizerSite = resolveSiteModel(config, 'compressor');
     const summarizePromise = generateText({
-      model: getModelForConfig(config, config.provider, config.model),
-      providerOptions: getProviderOptionsForConfig(config, config.provider),
+      model: summarizerSite.model,
+      providerOptions: summarizerSite.providerOptions,
       maxTokens: 2048,
       system: SUMMARIZATION_PROMPT,
       messages: [{ role: 'user', content: `Summarize this conversation:\n\n${serialized}` }],

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -161,6 +161,7 @@ export function buildMainContextMessages(
  */
 export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
   id: 'main',
+  site: 'main',
   historyMode: 'persistent',
   repairLabel: 'main',
 

--- a/src/framework/agents/pac-actor.ts
+++ b/src/framework/agents/pac-actor.ts
@@ -46,6 +46,7 @@ export interface PacActorInput {
 
 export const pacActorDefinition: AgentDefinition<PacActorInput, string> = {
   id: 'pac-actor',
+  site: 'specialist',
   historyMode: 'ephemeral',
   repairLabel: 'subagent',
   prefix: (input) => `sub:${input.slotId}/act`,

--- a/src/framework/agents/pac-critic.ts
+++ b/src/framework/agents/pac-critic.ts
@@ -77,6 +77,7 @@ function buildCriticTools(ctx: import('../context.js').AgentContext): Record<str
 
 export const pacCriticDefinition: AgentDefinition<PacCriticInput, PacCriticVerdict> = {
   id: 'pac-critic',
+  site: 'specialist',
   historyMode: 'ephemeral',
   repairLabel: 'subagent',
   prefix: (input) => `sub:${input.slotId}/critic`,

--- a/src/framework/agents/pac-planner.ts
+++ b/src/framework/agents/pac-planner.ts
@@ -73,6 +73,7 @@ function buildPlannerTools(ctx: import('../context.js').AgentContext): Record<st
 
 export const pacPlannerDefinition: AgentDefinition<PacPlannerInput, string> = {
   id: 'pac-planner',
+  site: 'specialist',
   historyMode: 'ephemeral',
   repairLabel: 'subagent',
   prefix: (input) => `sub:${input.slotId}/plan`,

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -1,7 +1,6 @@
 import type { CoreMessage } from 'ai';
-import { defaultProviderErrorMessage, resolveProviderAndModel } from '../../config.js';
 import { buildContextMessage, type ContextMessageInputs } from '../../context-message.js';
-import { getModelForConfig, getProviderOptionsForConfig } from '../../providers/index.js';
+import { resolveSiteModel } from '../../model-policy.js';
 import { makeRepairHook } from '../../tool-call-repair.js';
 import type { AgentContext } from '../context.js';
 import { runAgent, type AgentResult, type AgentSpec } from '../runner.js';
@@ -179,22 +178,12 @@ function resolveModel<TInput, TFormatted>(
   if (def.resolveModel) {
     return def.resolveModel(ctx, input, overrides);
   }
-  const { config } = ctx;
-  const resolution = resolveProviderAndModel({
-    provider: overrides?.provider,
-    model: overrides?.model,
-    config,
-  });
-  if (!resolution.ok) {
-    throw new Error(
-      defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom),
-    );
-  }
+  const site = resolveSiteModel(ctx.config, def.site ?? 'main', { overrides });
   return {
-    model: getModelForConfig(config, resolution.provider, resolution.model),
-    providerOptions: getProviderOptionsForConfig(config, resolution.provider),
-    provider: resolution.provider,
-    modelName: resolution.model,
+    model: site.model,
+    providerOptions: site.providerOptions,
+    provider: site.provider,
+    modelName: site.modelName,
   };
 }
 

--- a/src/framework/agents/specialist.ts
+++ b/src/framework/agents/specialist.ts
@@ -1,6 +1,5 @@
 import type { CoreMessage, Tool } from 'ai';
-import { defaultProviderErrorMessage, resolveProviderAndModel } from '../../config.js';
-import { getModelForConfig, getProviderOptionsForConfig } from '../../providers/index.js';
+import { resolveSiteModel } from '../../model-policy.js';
 import { debugLog } from '../../logger.js';
 import { PlanStore } from '../../plan-store.js';
 import { capSubagentResult } from '../../tools/result-cap.js';
@@ -125,23 +124,12 @@ export const specialistDefinition: AgentDefinition<SpecialistInput, string> = {
 
   resolveModel(ctx, input, overrides): ResolvedModel {
     const specialist = ctx.stores.specialists.get(input.specialistId);
-    const resolution = resolveProviderAndModel({
-      provider: overrides?.provider,
-      model: overrides?.model,
-      specialistProvider: specialist?.provider,
-      specialistModel: specialist?.model,
-      config: ctx.config,
-    });
-    if (!resolution.ok) {
-      throw new Error(
-        defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom),
-      );
-    }
+    const site = resolveSiteModel(ctx.config, 'specialist', { overrides, specialist });
     return {
-      model: getModelForConfig(ctx.config, resolution.provider, resolution.model),
-      providerOptions: getProviderOptionsForConfig(ctx.config, resolution.provider),
-      provider: resolution.provider,
-      modelName: resolution.model,
+      model: site.model,
+      providerOptions: site.providerOptions,
+      provider: site.provider,
+      modelName: site.modelName,
     };
   },
 

--- a/src/framework/agents/sub.ts
+++ b/src/framework/agents/sub.ts
@@ -51,6 +51,7 @@ export interface SubAgentInput {
  */
 export const subAgentDefinition: AgentDefinition<SubAgentInput, string> = {
   id: 'sub',
+  site: 'specialist',
   historyMode: 'ephemeral',
   repairLabel: 'subagent',
   prefix: (input) => `sub:${input.slotId}`,

--- a/src/framework/agents/task.ts
+++ b/src/framework/agents/task.ts
@@ -127,6 +127,7 @@ export interface TaskInput {
  */
 export const taskDefinition: AgentDefinition<TaskInput, TaskResult> = {
   id: 'task',
+  site: 'specialist',
   historyMode: 'ephemeral',
   prefix: (input) => `task:${input.slotId}`,
 

--- a/src/framework/agents/tool-wrapper.ts
+++ b/src/framework/agents/tool-wrapper.ts
@@ -1,6 +1,5 @@
 import type { CoreMessage, Tool } from 'ai';
-import { defaultProviderErrorMessage, resolveProviderAndModel } from '../../config.js';
-import { getModelForConfig, getProviderOptionsForConfig } from '../../providers/index.js';
+import { resolveSiteModel } from '../../model-policy.js';
 import { osPromptBlock } from '../../os-info.js';
 import {
   STRUCTURED_OUTPUT_RULES,
@@ -108,23 +107,12 @@ export const toolWrapperDefinition: AgentDefinition<ToolWrapperInput, WrapperRes
 
   resolveModel(ctx, input, overrides): ResolvedModel {
     const specialist = ctx.stores.specialists.get(input.specialistId);
-    const resolution = resolveProviderAndModel({
-      provider: overrides?.provider,
-      model: overrides?.model,
-      specialistProvider: specialist?.provider,
-      specialistModel: specialist?.model,
-      config: ctx.config,
-    });
-    if (!resolution.ok) {
-      throw new Error(
-        defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom),
-      );
-    }
+    const site = resolveSiteModel(ctx.config, 'tool-wrapper', { overrides, specialist });
     return {
-      model: getModelForConfig(ctx.config, resolution.provider, resolution.model),
-      providerOptions: getProviderOptionsForConfig(ctx.config, resolution.provider),
-      provider: resolution.provider,
-      modelName: resolution.model,
+      model: site.model,
+      providerOptions: site.providerOptions,
+      provider: site.provider,
+      modelName: site.modelName,
     };
   },
 

--- a/src/framework/agents/types.ts
+++ b/src/framework/agents/types.ts
@@ -58,6 +58,14 @@ export interface AgentDefinition<TInput = unknown, TFormatted = unknown> {
   /** Stable kind id used by dispatch + logs. */
   id: string;
 
+  /**
+   * Logical site this definition belongs to for the multi-model assignment
+   * policy (#170). The default `resolveModel` in {@link runDefinition} passes
+   * this to {@link resolveSiteModel}; definitions that supply their own
+   * `resolveModel` may ignore it. Defaults to `'main'` when omitted.
+   */
+  site?: import('../../model-policy.js').ModelSite;
+
   /** Whether the caller persists conversation history (main only) or rebuilds it. */
   historyMode: HistoryMode;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,10 +312,16 @@ program
     }
     try {
       const prefs = loadPreferences();
+      // savePreferences requires provider/model. When prefs don't carry them,
+      // fall back to the active env (BERNARD_PROVIDER/BERNARD_MODEL) so this
+      // command doesn't silently override a user who configured their provider
+      // via env vars only. Anthropic remains the last-resort default.
+      const provider = prefs.provider || process.env.BERNARD_PROVIDER || 'anthropic';
+      const model = prefs.model || process.env.BERNARD_MODEL || getDefaultModel(provider);
       savePreferences({
         ...prefs,
-        provider: prefs.provider || 'anthropic',
-        model: prefs.model || getDefaultModel(prefs.provider || 'anthropic'),
+        provider,
+        model,
         modelMode: mode,
       });
       printInfo(`Model mode set to "${mode}".`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   resetAllOptions,
   getDefaultModel,
   providerEnvVar,
+  isModelMode,
 } from './config.js';
 import {
   loadCustomProviders,
@@ -295,6 +296,34 @@ program
       }
       rl.close();
     });
+  });
+
+program
+  .command('set-model-mode <mode>')
+  .description(
+    'Set multi-model assignment policy: off | optimize-tokens | balanced | optimize-performance',
+  )
+  .action((mode: string) => {
+    if (!isModelMode(mode)) {
+      printError(
+        `Unknown model mode "${mode}". Valid values: off, optimize-tokens, balanced, optimize-performance.`,
+      );
+      process.exit(1);
+    }
+    try {
+      const prefs = loadPreferences();
+      savePreferences({
+        ...prefs,
+        provider: prefs.provider || 'anthropic',
+        model: prefs.model || getDefaultModel(prefs.provider || 'anthropic'),
+        modelMode: mode,
+      });
+      printInfo(`Model mode set to "${mode}".`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      printError(message);
+      process.exit(1);
+    }
   });
 
 program

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BernardConfig } from './config.js';
+import type { Specialist } from './specialists.js';
+import { resolveSiteModel, _resetModelPolicyLogCacheForTests, type ModelMode } from './model-policy.js';
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  anthropic: vi.fn((m: string) => ({ modelId: `anthropic:${m}` })),
+  createAnthropic: vi.fn(() => (m: string) => ({ modelId: `anthropic:${m}` })),
+}));
+vi.mock('@ai-sdk/openai', () => ({
+  openai: { responses: vi.fn((m: string) => ({ modelId: `openai:${m}` })) },
+  createOpenAI: vi.fn(() => ({ responses: (m: string) => ({ modelId: `openai:${m}` }) })),
+}));
+vi.mock('@ai-sdk/xai', () => ({
+  xai: vi.fn((m: string) => ({ modelId: `xai:${m}` })),
+  createXai: vi.fn(() => (m: string) => ({ modelId: `xai:${m}` })),
+}));
+
+function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
+  return {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5-20250929',
+    maxTokens: 4096,
+    shellTimeout: 30000,
+    tokenWindow: 0,
+    ragEnabled: true,
+    theme: 'bernard',
+    maxSteps: 25,
+    coordinatorMode: 'auto',
+    modelMode: 'off',
+    subagentPac: true,
+    toolDetails: false,
+    autoCreateSpecialists: false,
+    autoCreateThreshold: 0.8,
+    correctionEnabled: true,
+    promptRewriter: true,
+    referenceLookup: true,
+    referenceLookupTools: [],
+    scratchSubjectThreshold: 0.15,
+    anthropicApiKey: 'sk-ant',
+    openaiApiKey: 'sk-openai',
+    xaiApiKey: 'xai-key',
+    apiKeys: { anthropic: 'sk-ant', openai: 'sk-openai', xai: 'xai-key' },
+    customProviders: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  _resetModelPolicyLogCacheForTests();
+});
+
+describe('resolveSiteModel — mode off (passthrough)', () => {
+  it('returns config.provider/model for every site', () => {
+    const config = makeConfig({ modelMode: 'off' });
+    for (const site of [
+      'main',
+      'specialist',
+      'rewriter',
+      'tool-wrapper',
+      'reference-resolver',
+    ] as const) {
+      const r = resolveSiteModel(config, site);
+      expect(r.provider).toBe('anthropic');
+      expect(r.modelName).toBe('claude-sonnet-4-5-20250929');
+      expect(r.source).toBe('config');
+      expect(r.tier).toBeUndefined();
+    }
+  });
+});
+
+describe('resolveSiteModel — tier mapping per mode (anthropic)', () => {
+  it('optimize-tokens uses mid for main, cheap for rewriter', () => {
+    const config = makeConfig({ modelMode: 'optimize-tokens' });
+    expect(resolveSiteModel(config, 'main').modelName).toBe('claude-sonnet-4-5-20250929');
+    expect(resolveSiteModel(config, 'rewriter').modelName).toBe('claude-haiku-4-5-20251001');
+    expect(resolveSiteModel(config, 'specialist').modelName).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('balanced uses premium for main, mid for specialist, cheap for rewriter', () => {
+    const config = makeConfig({ modelMode: 'balanced' });
+    expect(resolveSiteModel(config, 'main').modelName).toBe('claude-opus-4-6');
+    expect(resolveSiteModel(config, 'specialist').modelName).toBe('claude-sonnet-4-5-20250929');
+    expect(resolveSiteModel(config, 'rewriter').modelName).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('optimize-performance uses premium everywhere', () => {
+    const config = makeConfig({ modelMode: 'optimize-performance' });
+    for (const site of ['main', 'specialist', 'rewriter', 'tool-wrapper'] as const) {
+      expect(resolveSiteModel(config, site).modelName).toBe('claude-opus-4-6');
+    }
+  });
+
+  it('records source = "policy" with tier metadata', () => {
+    const r = resolveSiteModel(makeConfig({ modelMode: 'balanced' }), 'main');
+    expect(r.source).toBe('policy');
+    expect(r.tier).toBe('premium');
+  });
+});
+
+describe('resolveSiteModel — tier mapping per mode (openai)', () => {
+  it('balanced picks gpt-5.2 / gpt-4.1 / gpt-4.1-mini', () => {
+    const config = makeConfig({
+      provider: 'openai',
+      model: 'gpt-5.2',
+      modelMode: 'balanced',
+    });
+    expect(resolveSiteModel(config, 'main').modelName).toBe('gpt-5.2');
+    expect(resolveSiteModel(config, 'specialist').modelName).toBe('gpt-4.1');
+    expect(resolveSiteModel(config, 'rewriter').modelName).toBe('gpt-4.1-mini');
+  });
+});
+
+describe('resolveSiteModel — tier mapping per mode (xai)', () => {
+  it('optimize-tokens picks fast-non-reasoning for main, grok-3-mini for rewriter', () => {
+    const config = makeConfig({
+      provider: 'xai',
+      model: 'grok-4-fast-non-reasoning',
+      modelMode: 'optimize-tokens',
+    });
+    expect(resolveSiteModel(config, 'main').modelName).toBe('grok-4-fast-non-reasoning');
+    expect(resolveSiteModel(config, 'rewriter').modelName).toBe('grok-3-mini');
+  });
+});
+
+describe('resolveSiteModel — precedence', () => {
+  it('invocation override beats policy tier', () => {
+    const config = makeConfig({ modelMode: 'balanced' });
+    const r = resolveSiteModel(config, 'main', {
+      overrides: { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
+    });
+    expect(r.modelName).toBe('claude-haiku-4-5-20251001');
+    expect(r.source).toBe('override');
+  });
+
+  it('specialist override beats policy tier', () => {
+    const config = makeConfig({ modelMode: 'optimize-performance' });
+    const specialist = {
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+    } as Specialist;
+    const r = resolveSiteModel(config, 'specialist', { specialist });
+    expect(r.modelName).toBe('claude-haiku-4-5-20251001');
+    expect(r.source).toBe('specialist');
+  });
+
+  it('invocation override beats specialist override', () => {
+    const config = makeConfig({ modelMode: 'balanced' });
+    const specialist = {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5-20250929',
+    } as Specialist;
+    const r = resolveSiteModel(config, 'specialist', {
+      specialist,
+      overrides: { model: 'claude-opus-4-6' },
+    });
+    expect(r.modelName).toBe('claude-opus-4-6');
+    expect(r.source).toBe('override');
+  });
+
+  it('blank/whitespace override falls through to policy', () => {
+    const config = makeConfig({ modelMode: 'balanced' });
+    const r = resolveSiteModel(config, 'rewriter', {
+      overrides: { provider: '', model: '   ' },
+    });
+    expect(r.modelName).toBe('claude-haiku-4-5-20251001');
+    expect(r.source).toBe('policy');
+  });
+});
+
+describe('resolveSiteModel — fallbacks', () => {
+  it('custom provider falls back to config.model regardless of mode', () => {
+    const config = makeConfig({
+      provider: 'ollama',
+      model: 'llama3.2',
+      modelMode: 'balanced',
+      customProviders: {
+        ollama: {
+          sdk: 'openai',
+          baseURL: 'http://localhost:11434/v1',
+          defaultModel: 'llama3.2',
+          models: ['llama3.2'],
+        },
+      },
+      apiKeys: { ollama: 'sk-ollama' },
+    });
+    const r = resolveSiteModel(config, 'rewriter');
+    expect(r.provider).toBe('ollama');
+    expect(r.modelName).toBe('llama3.2');
+    expect(r.source).toBe('fallback');
+  });
+
+  it('missing API key for active provider falls back to config.model', () => {
+    const config = makeConfig({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5-20250929',
+      modelMode: 'balanced',
+      anthropicApiKey: undefined,
+      apiKeys: {},
+    });
+    const r = resolveSiteModel(config, 'rewriter');
+    expect(r.modelName).toBe('claude-sonnet-4-5-20250929');
+    expect(r.source).toBe('fallback');
+  });
+});
+
+describe('resolveSiteModel — every mode is total', () => {
+  const sites = [
+    'main',
+    'specialist',
+    'tool-wrapper',
+    'rewriter',
+    'reference-resolver',
+    'reference-lookup',
+    'compressor',
+    'specialist-detector',
+  ] as const;
+  const modes: ModelMode[] = ['off', 'optimize-tokens', 'balanced', 'optimize-performance'];
+  for (const mode of modes) {
+    for (const site of sites) {
+      it(`mode=${mode} site=${site} resolves without throwing`, () => {
+        const r = resolveSiteModel(makeConfig({ modelMode: mode }), site);
+        expect(r.modelName).toBeTruthy();
+        expect(r.provider).toBe('anthropic');
+      });
+    }
+  }
+});

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { BernardConfig } from './config.js';
 import type { Specialist } from './specialists.js';
-import { resolveSiteModel, _resetModelPolicyLogCacheForTests, type ModelMode } from './model-policy.js';
+import {
+  resolveSiteModel,
+  _resetModelPolicyLogCacheForTests,
+  type ModelMode,
+} from './model-policy.js';
 
 vi.mock('@ai-sdk/anthropic', () => ({
   anthropic: vi.fn((m: string) => ({ modelId: `anthropic:${m}` })),

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,0 +1,236 @@
+import type { LanguageModel } from 'ai';
+import type { BernardConfig } from './config.js';
+import type { Specialist } from './specialists.js';
+import {
+  PROVIDER_MODELS,
+  defaultProviderErrorMessage,
+  hasProviderKey,
+  resolveProviderAndModel,
+  blankToUndefined,
+} from './config.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { debugLog } from './logger.js';
+
+/**
+ * Logical LLM call sites whose model can be tiered independently when
+ * `config.modelMode !== 'off'`. Every `generateText` call in Bernard maps to
+ * exactly one site.
+ */
+export type ModelSite =
+  | 'main'
+  | 'specialist'
+  | 'tool-wrapper'
+  | 'rewriter'
+  | 'reference-resolver'
+  | 'reference-lookup'
+  | 'compressor'
+  | 'specialist-detector';
+
+export type ModelMode = 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance';
+
+export type ModelTier = 'cheap' | 'mid' | 'premium';
+
+/**
+ * Per-site tier assignment for each `ModelMode`. The tier is mapped to a
+ * concrete model via `PROVIDER_TIERS` keyed by the active `config.provider`.
+ *
+ * `'off'` is intentionally absent here — when the mode is off we short-circuit
+ * to `config.provider/config.model` without consulting the tier table.
+ */
+const TIER_TABLE: Record<Exclude<ModelMode, 'off'>, Record<ModelSite, ModelTier>> = {
+  'optimize-tokens': {
+    main: 'mid',
+    specialist: 'cheap',
+    'tool-wrapper': 'cheap',
+    compressor: 'cheap',
+    'specialist-detector': 'cheap',
+    rewriter: 'cheap',
+    'reference-resolver': 'cheap',
+    'reference-lookup': 'cheap',
+  },
+  balanced: {
+    main: 'premium',
+    specialist: 'mid',
+    'tool-wrapper': 'mid',
+    compressor: 'mid',
+    'specialist-detector': 'cheap',
+    rewriter: 'cheap',
+    'reference-resolver': 'cheap',
+    'reference-lookup': 'cheap',
+  },
+  'optimize-performance': {
+    main: 'premium',
+    specialist: 'premium',
+    'tool-wrapper': 'premium',
+    compressor: 'premium',
+    'specialist-detector': 'premium',
+    rewriter: 'premium',
+    'reference-resolver': 'premium',
+    'reference-lookup': 'premium',
+  },
+};
+
+/**
+ * Per-provider concrete model for each tier. Model names match entries in
+ * `PROVIDER_MODELS` so the chosen value is always one the SDK knows.
+ *
+ * Custom providers don't appear here — they fall through to `config.model`.
+ */
+const PROVIDER_TIERS: Record<string, Record<ModelTier, string>> = {
+  anthropic: {
+    premium: 'claude-opus-4-6',
+    mid: 'claude-sonnet-4-5-20250929',
+    cheap: 'claude-haiku-4-5-20251001',
+  },
+  openai: {
+    premium: 'gpt-5.2',
+    mid: 'gpt-4.1',
+    cheap: 'gpt-4.1-mini',
+  },
+  xai: {
+    premium: 'grok-4-1-fast-reasoning',
+    mid: 'grok-4-fast-non-reasoning',
+    cheap: 'grok-3-mini',
+  },
+};
+
+/**
+ * Result of {@link resolveSiteModel}. `model`/`providerOptions` are ready to
+ * pass straight into `generateText({ model, providerOptions, ... })`.
+ */
+export interface SiteModel {
+  model: LanguageModel;
+  providerOptions: ReturnType<typeof getProviderOptionsForConfig>;
+  provider: string;
+  modelName: string;
+  /**
+   * Where the (provider, model) ultimately came from. `'override'` =
+   * invocation-level args; `'specialist'` = persisted specialist record;
+   * `'policy'` = tier-table lookup; `'config'` = session global; `'fallback'`
+   * = tier lookup attempted but bailed (custom provider, unknown tier, etc.).
+   */
+  source: 'override' | 'specialist' | 'policy' | 'config' | 'fallback';
+  tier?: ModelTier;
+}
+
+/** Per-session dedupe of `model-policy:resolve` debug log lines. */
+const RESOLVE_LOG_SEEN = new Set<string>();
+
+/**
+ * Resolves the effective (provider, model) for a given LLM call site (#170).
+ *
+ * Precedence (highest to lowest):
+ *  1. `opts.overrides.{provider,model}` — invocation-level args (parity with
+ *     {@link resolveProviderAndModel}).
+ *  2. `opts.specialist.{provider,model}` — persisted specialist record.
+ *  3. When `config.modelMode !== 'off'`, the tier table entry for
+ *     `(modelMode, site)` mapped through `PROVIDER_TIERS[config.provider]`.
+ *  4. `config.provider`/`config.model` — session global.
+ *
+ * Provider is never crossed automatically — the tier table only selects a
+ * model name within the user's active provider. Unknown providers and any
+ * other tier-lookup miss safely fall through to step 4 with
+ * `source: 'fallback'`.
+ */
+export function resolveSiteModel(
+  config: BernardConfig,
+  site: ModelSite,
+  opts?: {
+    overrides?: { provider?: string; model?: string };
+    specialist?: Specialist | undefined;
+  },
+): SiteModel {
+  const override = {
+    provider: blankToUndefined(opts?.overrides?.provider),
+    model: blankToUndefined(opts?.overrides?.model),
+  };
+  const specialist = {
+    provider: blankToUndefined(opts?.specialist?.provider),
+    model: blankToUndefined(opts?.specialist?.model),
+  };
+
+  // Steps 1 & 2 — let the existing 3-tier resolver handle override + specialist.
+  // If either fired, return that; the policy never overrides an explicit
+  // user-supplied or specialist-supplied (provider, model). When the explicit
+  // choice points at a provider with no key, throw — matches pre-#170 behavior
+  // (specialist.ts / tool-wrapper.ts both relied on this).
+  if (override.provider || override.model || specialist.provider || specialist.model) {
+    const resolution = resolveProviderAndModel({
+      provider: override.provider,
+      model: override.model,
+      specialistProvider: specialist.provider,
+      specialistModel: specialist.model,
+      config,
+    });
+    if (!resolution.ok) {
+      throw new Error(
+        defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom),
+      );
+    }
+    const source: SiteModel['source'] =
+      override.provider || override.model ? 'override' : 'specialist';
+    return buildSiteModel(config, resolution.provider, resolution.model, source);
+  }
+
+  // Step 3 — tier-table lookup when the policy is active.
+  if (config.modelMode && config.modelMode !== 'off') {
+    const tier = TIER_TABLE[config.modelMode][site];
+    const tierModel = PROVIDER_TIERS[config.provider]?.[tier];
+    if (tierModel && hasProviderKey(config, config.provider)) {
+      return buildSiteModel(config, config.provider, tierModel, 'policy', site, tier);
+    }
+    // Custom provider, unknown built-in, or missing key — fall through.
+    debugLog('model-policy:fallback', {
+      site,
+      mode: config.modelMode,
+      tier,
+      provider: config.provider,
+      reason: tierModel ? 'missing-key' : 'no-tier-mapping',
+    });
+    return buildSiteModel(config, config.provider, config.model, 'fallback', site, tier);
+  }
+
+  // Step 4 — passthrough.
+  return buildSiteModel(config, config.provider, config.model, 'config');
+}
+
+function buildSiteModel(
+  config: BernardConfig,
+  provider: string,
+  modelName: string,
+  source: SiteModel['source'],
+  site?: ModelSite,
+  tier?: ModelTier,
+): SiteModel {
+  const out: SiteModel = {
+    model: getModelForConfig(config, provider, modelName),
+    providerOptions: getProviderOptionsForConfig(config, provider),
+    provider,
+    modelName,
+    source,
+    tier,
+  };
+  if (site) {
+    const key = `${site}:${provider}:${modelName}:${source}`;
+    if (!RESOLVE_LOG_SEEN.has(key)) {
+      RESOLVE_LOG_SEEN.add(key);
+      debugLog('model-policy:resolve', {
+        site,
+        mode: config.modelMode,
+        tier,
+        provider,
+        model: modelName,
+        source,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Test-only helper to clear the per-session dedupe set so each test sees a
+ * fresh "first resolve" log entry.
+ */
+export function _resetModelPolicyLogCacheForTests(): void {
+  RESOLVE_LOG_SEEN.clear();
+}

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -2,7 +2,6 @@ import type { LanguageModel } from 'ai';
 import type { BernardConfig } from './config.js';
 import type { Specialist } from './specialists.js';
 import {
-  PROVIDER_MODELS,
   defaultProviderErrorMessage,
   hasProviderKey,
   resolveProviderAndModel,

--- a/src/policy/test-helpers.ts
+++ b/src/policy/test-helpers.ts
@@ -23,6 +23,7 @@ export function makePolicyInput(overrides?: {
     theme: 'bernard',
     maxSteps: 25,
     coordinatorMode: 'off',
+    modelMode: 'off',
     subagentPac: true,
     toolDetails: false,
     autoCreateSpecialists: false,

--- a/src/prompt-rewriter.ts
+++ b/src/prompt-rewriter.ts
@@ -1,8 +1,8 @@
 import { generateText } from 'ai';
-import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import type { ModelProfile } from './providers/profiles.js';
 import type { ResolvedEntry } from './reference-resolver.js';
 import type { BernardConfig } from './config.js';
+import { resolveSiteModel } from './model-policy.js';
 import { debugLog } from './logger.js';
 
 /**
@@ -142,9 +142,10 @@ export async function rewritePrompt(
   debugLog('prompt-rewriter:request', { family: profile.family, inputChars: input.length });
 
   try {
+    const site = resolveSiteModel(config, 'rewriter');
     const result = await generateText({
-      model: getModelForConfig(config, config.provider, config.model),
-      providerOptions: getProviderOptionsForConfig(config, config.provider),
+      model: site.model,
+      providerOptions: site.providerOptions,
       system: buildSystemPrompt(profile),
       messages: [{ role: 'user', content: buildUserMessage(input, resolvedEntries) }],
       maxSteps: 1,

--- a/src/reference-resolver.ts
+++ b/src/reference-resolver.ts
@@ -1,9 +1,9 @@
 import { generateText, type CoreMessage } from 'ai';
-import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import { sanitizeKey, REWRITER_HINTS_KEY, type MemoryStore } from './memory.js';
 import type { RAGStore, RAGSearchResult } from './rag.js';
 import type { BernardConfig } from './config.js';
+import { resolveSiteModel } from './model-policy.js';
 
 /** Sentinel sourceKey used for resolutions drawn from the RAG knowledge base. */
 export const RAG_SOURCE_KEY = 'rag';
@@ -303,9 +303,10 @@ export async function resolveReferences(
   });
 
   try {
+    const site = resolveSiteModel(config, 'reference-resolver');
     const result = await generateText({
-      model: getModelForConfig(config, config.provider, config.model),
-      providerOptions: getProviderOptionsForConfig(config, config.provider),
+      model: site.model,
+      providerOptions: site.providerOptions,
       system: RESOLVER_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: userMessage }],
       maxSteps: 1,

--- a/src/reference-tool-lookup.ts
+++ b/src/reference-tool-lookup.ts
@@ -1,8 +1,8 @@
 import { generateText } from 'ai';
-import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { readToolMeta } from './framework/tools/adapter.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
+import { resolveSiteModel } from './model-policy.js';
 
 /**
  * Pre-fallback module that runs only when the resolver returns
@@ -164,9 +164,10 @@ export async function selectLookupTool(
 ): Promise<SelectResult | null> {
   if (candidates.length === 0) return null;
   try {
+    const site = resolveSiteModel(config, 'reference-lookup');
     const result = await generateText({
-      model: getModelForConfig(config, config.provider, config.model),
-      providerOptions: getProviderOptionsForConfig(config, config.provider),
+      model: site.model,
+      providerOptions: site.providerOptions,
       system: SELECT_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: buildSelectUserMessage(reference, candidates) }],
       maxSteps: 1,
@@ -287,9 +288,10 @@ export async function interpretLookupResult(
   abortSignal?: AbortSignal,
 ): Promise<ReferenceLookupResult> {
   try {
+    const site = resolveSiteModel(config, 'reference-lookup');
     const result = await generateText({
-      model: getModelForConfig(config, config.provider, config.model),
-      providerOptions: getProviderOptionsForConfig(config, config.provider),
+      model: site.model,
+      providerOptions: site.providerOptions,
       system: INTERPRET_SYSTEM_PROMPT,
       messages: [
         {

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -1061,6 +1061,8 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
         'Reviews code',
         'You review code',
         ['Be thorough'],
+        undefined,
+        undefined,
       );
     });
 
@@ -1178,6 +1180,8 @@ describe('REPL /agent-options auto-create re-evaluation', () => {
         'Writes tests',
         'You write tests',
         ['Cover edge cases'],
+        undefined,
+        undefined,
       );
     });
 
@@ -1204,11 +1208,12 @@ describe('REPL /agent-options boolean toggles (rewriter)', () => {
 
   // Menu path: /agent-options → top-level selection:
   //   3. Coordinator (ReAct) mode  (3-way picker, covered in a separate suite below)
-  //   4. Prompt rewriter
+  //   4. Model mode                (4-way picker, covered in src/model-policy.test.ts behaviour)
+  //   5. Prompt rewriter
   const cases = [
     {
       name: 'Prompt rewriter',
-      topIndex: '4',
+      topIndex: '5',
       key: 'promptRewriter' as const,
       onFragment: '[REWRITER:ON]',
       offFragment: '[REWRITER:OFF]',

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -74,11 +74,8 @@ import { CronStore } from './cron/store.js';
 import { isDaemonRunning } from './cron/client.js';
 import { HistoryStore } from './history.js';
 import { generateText } from 'ai';
-import {
-  getModelForConfig,
-  getModelProfile,
-  getProviderOptionsForConfig,
-} from './providers/index.js';
+import { getModelProfile } from './providers/index.js';
+import { resolveSiteModel } from './model-policy.js';
 import { rewritePrompt } from './prompt-rewriter.js';
 import {
   serializeMessages,
@@ -1009,6 +1006,7 @@ export async function startRepl(
     candidateStore,
     specialistStore,
     config,
+    config,
   );
   if (contextBlock) {
     printInfo(
@@ -1308,10 +1306,11 @@ export async function startRepl(
             try {
               const serialized = serializeMessages(history);
 
+              const summarySite = resolveSiteModel(config, 'compressor');
               const [summaryResult, domainFacts, candidateResult] = await Promise.all([
                 generateText({
-                  model: getModelForConfig(config, config.provider, config.model),
-                  providerOptions: getProviderOptionsForConfig(config, config.provider),
+                  model: summarySite.model,
+                  providerOptions: summarySite.providerOptions,
                   maxTokens: 2048,
                   system: SUMMARIZATION_PROMPT,
                   messages: [
@@ -1372,6 +1371,7 @@ export async function startRepl(
                         specialistStore,
                         candidateStore,
                         config.autoCreateThreshold,
+                        config,
                       );
                     } else {
                       debugLog('repl:auto-create', {
@@ -2057,6 +2057,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
                   candidateStore,
                   specialistStore,
                   config.autoCreateThreshold,
+                  config,
                 );
               }
             },
@@ -2131,6 +2132,62 @@ Remember: the systemPrompt should read like a persona definition — who this sp
           console.log();
         }
 
+        async function runModelModePrompt(): Promise<void> {
+          const modes: Array<{
+            value: 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance';
+            label: string;
+            desc: string;
+          }> = [
+            {
+              value: 'off',
+              label: 'Off (single model)',
+              desc: 'Every site uses the active provider/model. Legacy behavior.',
+            },
+            {
+              value: 'balanced',
+              label: 'Balanced',
+              desc: 'Premium for main; mid-tier for sub-agents; cheap for rewriter/qualifier.',
+            },
+            {
+              value: 'optimize-tokens',
+              label: 'Optimize for token usage',
+              desc: 'Aggressive cost-saving: cheap for sub-agents and routing, mid-tier for main.',
+            },
+            {
+              value: 'optimize-performance',
+              label: 'Optimize for performance',
+              desc: 'Push every site to the strongest model in the provider lineup.',
+            },
+          ];
+          const entries: MenuEntry[] = modes.map((m) => ({
+            label: m.label,
+            description: m.desc,
+            active: config.modelMode === m.value,
+          }));
+          const signal = createMenuSignal();
+          try {
+            const result = await selectFromMenu(
+              rl,
+              entries,
+              { title: `Model mode: ${config.modelMode}` },
+              signal,
+            );
+            if (result.cancelled) return;
+            const chosen = modes[result.index].value;
+            config.modelMode = chosen;
+            savePreferences({
+              ...loadPreferences(),
+              provider: config.provider,
+              model: config.model,
+              modelMode: chosen,
+            });
+            printInfo(`  [MODEL-MODE:${chosen.toUpperCase()}] Site model assignment updated.`);
+          } finally {
+            clearMenuSignal();
+          }
+          console.log();
+        }
+
         async function runScratchThresholdPrompt(): Promise<void> {
           const signal = createMenuSignal();
           try {
@@ -2178,7 +2235,12 @@ Remember: the systemPrompt should read like a persona definition — who this sp
             });
             printInfo(`  Auto-create threshold: ${normalized} (${Math.round(normalized * 100)}%)`);
             if (config.autoCreateSpecialists) {
-              promotePendingCandidates(candidateStore, specialistStore, config.autoCreateThreshold);
+              promotePendingCandidates(
+                candidateStore,
+                specialistStore,
+                config.autoCreateThreshold,
+                config,
+              );
             }
           } finally {
             clearMenuSignal();
@@ -2223,6 +2285,16 @@ Remember: the systemPrompt should read like a persona definition — who this sp
                 'On = always coordinator; Off = always normal; Auto = per-turn qualifier.',
             },
             action: runCoordinatorModePrompt,
+          },
+          {
+            kind: 'item',
+            item: {
+              label: 'Model mode',
+              annotation: `= ${config.modelMode}`,
+              description:
+                'Off = single model. Balanced / Optimize-tokens / Optimize-performance pick a model per site.',
+            },
+            action: runModelModePrompt,
           },
           ...systemBools.slice(1).map(toggleRow),
           {

--- a/src/specialist-detector.ts
+++ b/src/specialist-detector.ts
@@ -1,7 +1,7 @@
 import { generateText } from 'ai';
-import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
+import { resolveSiteModel } from './model-policy.js';
 import type { Specialist, SpecialistSummary } from './specialists.js';
 import type { SpecialistCandidate } from './specialist-candidates.js';
 import { checkOverlaps, computeConfidence, OVERLAP_THRESHOLD } from './overlap-checker.js';
@@ -125,9 +125,10 @@ export async function detectSpecialistCandidate(
       : '';
 
   try {
+    const site = resolveSiteModel(config, 'specialist-detector');
     const result = await generateText({
-      model: getModelForConfig(config, config.provider, config.model),
-      providerOptions: getProviderOptionsForConfig(config, config.provider),
+      model: site.model,
+      providerOptions: site.providerOptions,
       maxTokens: 2048,
       system: DETECTION_SYSTEM_PROMPT,
       messages: [

--- a/src/tools/specialist.ts
+++ b/src/tools/specialist.ts
@@ -7,7 +7,12 @@ import {
   type SpecialistBadExample,
 } from '../specialists.js';
 import type { CandidateStoreReader } from '../specialist-candidates.js';
-import { type BernardConfig, PROVIDER_MODELS, isValidProvider } from '../config.js';
+import {
+  type BernardConfig,
+  PROVIDER_MODELS,
+  isValidProvider,
+  blankToUndefined,
+} from '../config.js';
 import { resolveSiteModel } from '../model-policy.js';
 import { attachMeta } from '../framework/tools/adapter.js';
 
@@ -179,25 +184,30 @@ export function createSpecialistTool(
             if (!name) return 'Error: name is required for create action.';
             if (!description) return 'Error: description is required for create action.';
             if (!systemPrompt) return 'Error: systemPrompt is required for create action.';
-            if (provider !== undefined) {
-              if (!isValidProvider(provider))
-                return `Error: Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_MODELS).join(', ')}`;
-              if (model !== undefined && !PROVIDER_MODELS[provider]?.includes(model))
-                return `Error: Unknown model "${model}" for provider "${provider}". Valid models: ${PROVIDER_MODELS[provider].join(', ')}`;
-            } else if (model !== undefined && config) {
+            // Normalize blanks ("", "   ") to undefined so an LLM emitting ""
+            // doesn't fail validation and so policy auto-assign still fires.
+            const normProvider = blankToUndefined(provider);
+            const normModel = blankToUndefined(model);
+            if (normProvider !== undefined) {
+              if (!isValidProvider(normProvider))
+                return `Error: Unknown provider "${normProvider}". Valid providers: ${Object.keys(PROVIDER_MODELS).join(', ')}`;
+              if (normModel !== undefined && !PROVIDER_MODELS[normProvider]?.includes(normModel))
+                return `Error: Unknown model "${normModel}" for provider "${normProvider}". Valid models: ${PROVIDER_MODELS[normProvider].join(', ')}`;
+            } else if (normModel !== undefined && config) {
               // Validate model against the global config's provider when no explicit provider given
-              if (!PROVIDER_MODELS[config.provider]?.includes(model))
-                return `Error: Unknown model "${model}" for provider "${config.provider}". Valid models: ${PROVIDER_MODELS[config.provider].join(', ')}`;
+              if (!PROVIDER_MODELS[config.provider]?.includes(normModel))
+                return `Error: Unknown model "${normModel}" for provider "${config.provider}". Valid models: ${PROVIDER_MODELS[config.provider].join(', ')}`;
             }
             // Auto-assign policy-resolved provider/model when multi-model
             // mode is active and the user didn't specify either (#170).
-            let resolvedProvider = provider;
-            let resolvedModel = model;
-            // Treat empty strings as "not set" so an LLM emitting "" doesn't
-            // bypass policy auto-assign and persist blanks on the record.
-            const explicitProvider = provider !== undefined && provider !== '';
-            const explicitModel = model !== undefined && model !== '';
-            if (!explicitProvider && !explicitModel && config && config.modelMode !== 'off') {
+            let resolvedProvider = normProvider;
+            let resolvedModel = normModel;
+            if (
+              normProvider === undefined &&
+              normModel === undefined &&
+              config &&
+              config.modelMode !== 'off'
+            ) {
               try {
                 const site = resolveSiteModel(config, 'specialist');
                 if (site.source === 'policy') {

--- a/src/tools/specialist.ts
+++ b/src/tools/specialist.ts
@@ -8,6 +8,7 @@ import {
 } from '../specialists.js';
 import type { CandidateStoreReader } from '../specialist-candidates.js';
 import { type BernardConfig, PROVIDER_MODELS, isValidProvider } from '../config.js';
+import { resolveSiteModel } from '../model-policy.js';
 import { attachMeta } from '../framework/tools/adapter.js';
 
 const goodExampleSchema = z.object({
@@ -188,6 +189,25 @@ export function createSpecialistTool(
               if (!PROVIDER_MODELS[config.provider]?.includes(model))
                 return `Error: Unknown model "${model}" for provider "${config.provider}". Valid models: ${PROVIDER_MODELS[config.provider].join(', ')}`;
             }
+            // Auto-assign policy-resolved provider/model when multi-model
+            // mode is active and the user didn't specify either (#170).
+            let resolvedProvider = provider;
+            let resolvedModel = model;
+            // Treat empty strings as "not set" so an LLM emitting "" doesn't
+            // bypass policy auto-assign and persist blanks on the record.
+            const explicitProvider = provider !== undefined && provider !== '';
+            const explicitModel = model !== undefined && model !== '';
+            if (!explicitProvider && !explicitModel && config && config.modelMode !== 'off') {
+              try {
+                const site = resolveSiteModel(config, 'specialist');
+                if (site.source === 'policy') {
+                  resolvedProvider = site.provider;
+                  resolvedModel = site.modelName;
+                }
+              } catch {
+                // Policy resolution is best-effort; fall through to no override.
+              }
+            }
             try {
               const specialist = store.createFull({
                 id,
@@ -195,8 +215,8 @@ export function createSpecialistTool(
                 description,
                 systemPrompt,
                 guidelines: guidelines ?? [],
-                provider,
-                model,
+                provider: resolvedProvider,
+                model: resolvedModel,
                 kind,
                 targetTools,
                 goodExamples: goodExamples as SpecialistExample[] | undefined,

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -74,7 +74,9 @@ export function createSubAgentTool(ctx: AgentContext): Tool {
       try {
         const runOpts = {
           abortSignal: execOptions.abortSignal,
-          overrides: { provider: resolution.provider, model: resolution.model },
+          // Forward only the user-supplied provider/model so resolveSiteModel
+          // can fall through to the modelMode tier table when neither is set.
+          overrides: { provider, model },
         };
         let formatted: string;
         if (ctx.config.subagentPac) {

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -163,7 +163,9 @@ export function createTaskTool(ctx: AgentContext): BernardTool<TaskArgs, TaskPay
           : { task: resolvedTask, slotId: id };
         const { formatted: taskResult } = await runDefinition(ctx, def, input, {
           abortSignal: execOptions.abortSignal,
-          overrides: { provider: resolution.provider, model: resolution.model },
+          // Forward only the user-supplied provider/model so resolveSiteModel
+          // can fall through to the modelMode tier table when neither is set.
+          overrides: { provider, model },
         });
 
         const envelope = ok<TaskPayload>(

--- a/src/tools/tool-wrapper-run.test.ts
+++ b/src/tools/tool-wrapper-run.test.ts
@@ -55,6 +55,14 @@ vi.mock('./agent-pool.js', async (importOriginal) => {
 
 vi.mock('../config.js', () => ({
   resolveProviderAndModel: vi.fn(),
+  blankToUndefined: (v: string | undefined) => {
+    if (v === undefined) return undefined;
+    const trimmed = v.trim();
+    return trimmed === '' ? undefined : trimmed;
+  },
+  PROVIDER_MODELS: {},
+  defaultProviderErrorMessage: (provider: string) => `Set ${provider.toUpperCase()}_API_KEY`,
+  hasProviderKey: () => true,
 }));
 
 vi.mock('../os-info.js', () => ({


### PR DESCRIPTION
## Summary

- Introduces `config.modelMode` (`off | optimize-tokens | balanced | optimize-performance`) that tiers the (provider, model) used per LLM call site within the active provider's lineup.
- New central resolver `resolveSiteModel(config, site, opts?)` in `src/model-policy.ts` — precedence: invocation override > specialist record > policy tier > config passthrough.
- Surfaces: `/agent-options → Model mode` (REPL), `bernard set-model-mode <mode>` (CLI), `BERNARD_MODEL_MODE` env var.
- Wired sites: main, specialist, tool-wrapper, rewriter, reference-resolver, reference-lookup, compressor, specialist-detector. `AgentDefinition` gained optional `site` field. Specialist creation auto-pins the policy-resolved model.

## Tier table (per provider)

| Provider  | premium                   | mid                          | cheap                       |
|-----------|---------------------------|------------------------------|-----------------------------|
| anthropic | claude-opus-4-6           | claude-sonnet-4-5-20250929   | claude-haiku-4-5-20251001   |
| openai    | gpt-5.2                   | gpt-4.1                      | gpt-4.1-mini                |
| xai       | grok-4-1-fast-reasoning   | grok-4-fast-non-reasoning    | grok-3-mini                 |

Custom providers fall back to `config.model` for every site. Cron is intentionally pinned to `config.provider`/`config.model` (existing behavior, comment in `framework/agents/cron.ts`).

## Notes from self-review

- `subagent.ts` and `task.ts` now forward only the user-supplied `provider`/`model` (not the pre-resolved defaults) as overrides so the tier table actually fires for sub-agent/task dispatches when no explicit override is set.
- Auto-assign guard in `specialist.ts` treats empty-string provider/model as "unset" to avoid persisting blanks when the LLM emits `""`.
- `enforcement` / `correction` / `qualifier` were dropped from `ModelSite` — enforcement reuses main's iterate closure, correction routes through `tool-wrapper`, and the qualifier is rule-based, so those tier entries were dead.

## Test plan

- [x] `npm run test` — 2422 / 2422 passing (new `src/model-policy.test.ts` covers precedence, every-mode-totality, per-provider mapping, custom-provider fallback)
- [x] `npm run build` — clean
- [ ] Manual smoke (Anthropic key): set `/agent-options → Model mode → Balanced`, ask a question, verify `BERNARD_DEBUG=1` shows `model-policy:resolve` for rewriter→haiku and main→opus.
- [ ] Manual smoke: `bernard set-model-mode optimize-tokens` from shell, restart REPL, confirm persisted.
- [ ] Manual smoke: create a specialist via `specialist_run` with mode balanced and no explicit provider/model → verify `~/.local/share/bernard/specialists/<id>.json` has a `model` field baked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)