### PR TITLE
feat(policy): concise-by-default response shaping (closes #175)

### DIFF
--- a/src/agent-prompt.ts
+++ b/src/agent-prompt.ts
@@ -21,6 +21,27 @@ export const REASONING_FAMILIES = new Set(['openai-reasoning', 'xai-grok-reasoni
  * `REASONING_FAMILIES` because their `systemSuffix` already constrains how
  * they may annotate their output. Issue #173.
  */
+/**
+ * Concise-by-default response shaping (issue #175). Injected by
+ * `buildMainSystemPrompt` when {@link PolicyDecision.concise.enabled} is true
+ * (the policy reads `config.conciseMode`). Token/latency optimization, not a
+ * style preference — fewer output tokens = lower cost + lower latency.
+ */
+export const CONCISE_PROMPT = `## Concise Mode
+Default to the smallest sufficient response. Concretely: at most 6 bullets or 12 lines unless one of the exceptions below applies. This is a token/latency optimization, not a style preference.
+
+- Lead with the answer or outcome. Skip preamble, recap of the question, and closing pleasantries.
+- Never echo or restate tool output. Surface only the delta the user needs (a path, a value, a one-line summary).
+- Strip filler ("I'll go ahead and…", "As you can see…", "Let me know if…").
+- Code, file paths, and command output are not counted toward the budget — quote them as needed for correctness.
+
+Expand only when:
+- The user explicitly asks for detail ("explain", "in detail", "long version", "walk me through").
+- The task inherently requires length (drafting an email body, issue/PR description, commit message, design doc, script, multi-file refactor summary).
+- Brevity would sacrifice correctness or safety (ambiguous instruction, destructive action, multiple plausible interpretations that need to be surfaced).
+
+When in doubt, ship the short version. The user can always ask for more.`;
+
 export const CITATIONS_PROMPT = `## Citations
 When a sentence states a fact you got from a registered source this turn (web_read, web_search, file_read_lines, memory.read, scratch.read, or recalled RAG context), END that sentence with a citation marker pointing at the source id, e.g. \`The README says X is the default. [^S1]\`. The available source ids and their labels are listed inside the \`<available_sources>\` subsection of \`<system_provided_context>\`, and each retrieval tool also prepends \`[Source: Sn …]\` to its return text. Use the \`cite\` tool (action: 'list' | 'get') to inspect the store before citing if you want to verify.
 
@@ -43,7 +64,6 @@ You exist only while processing a user message. Each response is a single turn: 
 # Instructions
 
 ## Communication
-- Default to concise responses. Expand only when asked, when the task is complex, or when brevity would sacrifice clarity.
 - Summarize command output to key points; do not echo raw output verbatim unless asked.
 - Tone: direct, technical, and collaborative. Match the user's level of formality.
 

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -6,6 +6,7 @@ import {
   computeEffectiveMaxSteps,
   REACT_MAX_STEPS_CEILING,
 } from './agent.js';
+import { CONCISE_PROMPT } from './agent-prompt.js';
 import { buildContextMessage } from './context-message.js';
 import type { BernardConfig } from './config.js';
 import { MemoryStore } from './memory.js';
@@ -102,6 +103,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     autoCreateSpecialists: false,
     autoCreateThreshold: 0.8,
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     ...overrides,
   };
@@ -158,6 +160,12 @@ describe('buildSystemPrompt', () => {
     const prompt = buildSystemPrompt(makeConfig());
     expect(prompt).toContain('Execution Model');
     expect(prompt).toContain('cease execution until the next message');
+  });
+
+  it('does not bake the concise heuristic into the base prompt (it is policy-gated)', () => {
+    const prompt = buildSystemPrompt(makeConfig());
+    expect(prompt).not.toContain('## Concise Mode');
+    expect(prompt).not.toContain('Default to concise responses');
   });
 
   it('frames the context block as data not instructions', () => {
@@ -279,6 +287,24 @@ describe('buildSystemPrompt', () => {
       expect(prompt).not.toContain('Saved routines the user can invoke');
       expect(prompt).not.toContain('### Specialist Match Advisory');
     });
+  });
+});
+
+describe('CONCISE_PROMPT (#175)', () => {
+  it('is a non-empty string with the expected heading', () => {
+    expect(typeof CONCISE_PROMPT).toBe('string');
+    expect(CONCISE_PROMPT).toContain('## Concise Mode');
+  });
+
+  it('documents the bullet/line caps that mirror the policy', () => {
+    expect(CONCISE_PROMPT).toContain('6 bullets');
+    expect(CONCISE_PROMPT).toContain('12 lines');
+  });
+
+  it('lists the documented expansion exceptions', () => {
+    expect(CONCISE_PROMPT).toMatch(/explain|in detail|long version/);
+    expect(CONCISE_PROMPT).toMatch(/email|issue|design doc|script/);
+    expect(CONCISE_PROMPT).toMatch(/correctness|safety/);
   });
 });
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -932,6 +932,7 @@ describe('resolveProviderAndModel', () => {
     referenceLookup: true,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-ant-test',
   };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,14 @@ export interface BernardConfig {
   correctionEnabled: boolean;
   /** Whether the model-specific prompt rewriter runs as a pre-turn LLM pass. */
   promptRewriter: boolean;
+  /**
+   * Whether concise-by-default response shaping is active (#175). When on, the
+   * Policy Engine emits `concise.enabled = true` and the main agent's system
+   * prompt receives a `## Concise Mode` block instructing the model to keep
+   * responses to the smallest sufficient size. Token/latency optimization, not
+   * a style preference.
+   */
+  conciseMode: boolean;
   /** Whether the resolver attempts a tool-based lookup before prompting the user for unknown references. */
   referenceLookup: boolean;
   /** Extra tool-name allowlist for the reference-lookup pass (additive over built-in patterns). */
@@ -92,6 +100,7 @@ const DEFAULT_AUTO_CREATE_THRESHOLD = 0.8;
 const DEFAULT_COORDINATOR_MODE: 'on' | 'off' | 'auto' = 'auto';
 const DEFAULT_MODEL_MODE: 'off' | 'optimize-tokens' | 'balanced' | 'optimize-performance' = 'off';
 const DEFAULT_SCRATCH_SUBJECT_THRESHOLD = 0.15;
+const DEFAULT_CONCISE_MODE = true;
 
 /** Type guard for `coordinatorMode` string values. */
 function isCoordinatorMode(v: unknown): v is 'on' | 'off' | 'auto' {
@@ -199,6 +208,7 @@ export function savePreferences(prefs: {
   promptRewriter?: boolean;
   referenceLookup?: boolean;
   scratchSubjectThreshold?: number;
+  conciseMode?: boolean;
 }): void {
   const dir = path.dirname(PREFS_PATH);
   if (!fs.existsSync(dir)) {
@@ -222,6 +232,7 @@ export function savePreferences(prefs: {
   if (prefs.referenceLookup !== undefined) data.referenceLookup = prefs.referenceLookup;
   if (prefs.scratchSubjectThreshold !== undefined)
     data.scratchSubjectThreshold = prefs.scratchSubjectThreshold;
+  if (prefs.conciseMode !== undefined) data.conciseMode = prefs.conciseMode;
 
   // Preserve autoUpdate, coordinatorMode, and auto-create settings from existing prefs when callers don't pass them
   let existing: Record<string, unknown> | undefined;
@@ -237,6 +248,7 @@ export function savePreferences(prefs: {
     'toolDetails',
     'promptRewriter',
     'referenceLookup',
+    'conciseMode',
   ] as const;
   for (const k of booleanKeys) {
     if (prefs[k] === undefined && existing && typeof existing[k] === 'boolean') {
@@ -321,6 +333,7 @@ export function loadPreferences(): {
   promptRewriter?: boolean;
   referenceLookup?: boolean;
   scratchSubjectThreshold?: number;
+  conciseMode?: boolean;
 } {
   try {
     const data = fs.readFileSync(PREFS_PATH, 'utf-8');
@@ -359,6 +372,7 @@ export function loadPreferences(): {
         typeof parsed.scratchSubjectThreshold === 'number'
           ? parsed.scratchSubjectThreshold
           : undefined,
+      conciseMode: typeof parsed.conciseMode === 'boolean' ? parsed.conciseMode : undefined,
     };
   } catch {
     return {};
@@ -875,6 +889,14 @@ export function loadConfig(overrides?: {
     prefs.promptRewriter ??
     (rawRewriter === undefined ? true : !(rawRewriter === 'false' || rawRewriter === '0'));
 
+  // Concise-by-default response shaping (#175); opt-out via BERNARD_CONCISE_MODE=false.
+  const rawConcise = process.env.BERNARD_CONCISE_MODE;
+  const conciseMode =
+    prefs.conciseMode ??
+    (rawConcise === undefined
+      ? DEFAULT_CONCISE_MODE
+      : !(rawConcise === 'false' || rawConcise === '0'));
+
   // Reference tool-lookup runs by default; users can opt out with BERNARD_REFERENCE_LOOKUP=false.
   const rawReferenceLookup = process.env.BERNARD_REFERENCE_LOOKUP;
   const referenceLookup =
@@ -934,6 +956,7 @@ export function loadConfig(overrides?: {
     referenceLookup,
     referenceLookupTools,
     scratchSubjectThreshold,
+    conciseMode,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
     openaiApiKey: process.env.OPENAI_API_KEY,
     xaiApiKey: process.env.XAI_API_KEY,

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -57,6 +57,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     autoCreateSpecialists: false,
     autoCreateThreshold: 0.8,
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     ...overrides,
   };

--- a/src/framework/agents/__tests__/run.test.ts
+++ b/src/framework/agents/__tests__/run.test.ts
@@ -53,6 +53,7 @@ function makeConfig(): BernardConfig {
     autoCreateSpecialists: false,
     autoCreateThreshold: 0.8,
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     customProviders: {},
   } as BernardConfig;

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -24,6 +24,7 @@ import {
   SHARE_REASONING_PROMPT,
   REASONING_FAMILIES,
   CITATIONS_PROMPT,
+  CONCISE_PROMPT,
 } from '../../agent-prompt.js';
 import { buildContextMessage } from '../../context-message.js';
 import type { RAGSearchResult } from '../../rag.js';
@@ -100,6 +101,11 @@ export function buildMainSystemPrompt(
     !REASONING_FAMILIES.has(profile.family)
   ) {
     systemPrompt += '\n\n' + CITATIONS_PROMPT;
+  }
+  // Concise-mode shaping: append the concise block when the policy enables it.
+  // Issue #175. No model-family gate — concision is universal.
+  if (ctx.policyDecision?.concise?.enabled) {
+    systemPrompt += '\n\n' + CONCISE_PROMPT;
   }
   const profilesBlock = buildToolProfilesPrompt(ctx.stores.toolProfiles);
   if (profilesBlock) {

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -41,6 +41,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     referenceLookup: true,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-ant',
     openaiApiKey: 'sk-openai',
     xaiApiKey: 'xai-key',

--- a/src/policy/concise.test.ts
+++ b/src/policy/concise.test.ts
@@ -3,9 +3,19 @@ import { concisePolicy } from './concise.js';
 import { makePolicyInput } from './test-helpers.js';
 
 describe('concisePolicy', () => {
-  it('is disabled by default and points at issue #175', () => {
-    const result = concisePolicy(makePolicyInput());
+  it('enables concise shaping with bullet/line caps when config.conciseMode is true', () => {
+    const result = concisePolicy(makePolicyInput({ config: { conciseMode: true } }));
+    expect(result.enabled).toBe(true);
+    expect(result.maxBullets).toBe(6);
+    expect(result.maxLines).toBe(12);
+    expect(result.reason).toBe('config-on');
+  });
+
+  it('disables concise shaping when config.conciseMode is false', () => {
+    const result = concisePolicy(makePolicyInput({ config: { conciseMode: false } }));
     expect(result.enabled).toBe(false);
-    expect(result.reason).toBe('pending-issue-175');
+    expect(result.maxBullets).toBeUndefined();
+    expect(result.maxLines).toBeUndefined();
+    expect(result.reason).toBe('config-off');
   });
 });

--- a/src/policy/concise.ts
+++ b/src/policy/concise.ts
@@ -3,11 +3,26 @@ import type { PolicyDecision, SubPolicy } from './types.js';
 type Concise = NonNullable<PolicyDecision['concise']>;
 
 /**
- * Stub sub-policy — issue #175 will gate concise-mode and pick max line /
- * bullet counts here. Today the agent's own `BASE_SYSTEM_PROMPT` carries the
- * concise guidance, so this sub-policy is inert.
+ * Concise-by-default response shaping (issue #175). Reads
+ * `config.conciseMode`; when on, `buildMainSystemPrompt` injects the
+ * `CONCISE_PROMPT` block instructing the model to keep responses to the
+ * smallest sufficient size. `maxBullets` / `maxLines` are advisory caps that
+ * appear in the prompt — the model self-enforces, with a tool-wrapper-side
+ * defense-in-depth cap on the `reasoning` array in `wrapWrapperResult`.
+ *
+ * Reason codes: `config-on` | `config-off`.
  */
-export const concisePolicy: SubPolicy<Concise> = () => ({
-  enabled: false,
-  reason: 'pending-issue-175',
-});
+export const concisePolicy: SubPolicy<Concise> = (input) => {
+  // Treat undefined as on so partially-constructed configs (legacy serialized
+  // prefs, scoped test fixtures) match `DEFAULT_CONCISE_MODE` instead of
+  // silently disabling concision.
+  if (input.config.conciseMode !== false) {
+    return {
+      enabled: true,
+      maxBullets: 6,
+      maxLines: 12,
+      reason: 'config-on',
+    };
+  }
+  return { enabled: false, reason: 'config-off' };
+};

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -17,7 +17,10 @@ describe('DefaultPolicyEngine', () => {
 
     expect(decision.strategyId).toBe('react');
     expect(Object.keys(decision.models ?? {}).sort()).toEqual([...MODEL_COMPONENTS].sort());
-    expect(decision.concise?.enabled).toBe(false);
+    // concisePolicy now reads config.conciseMode (default true in test helper).
+    expect(decision.concise?.enabled).toBe(true);
+    expect(decision.concise?.maxBullets).toBe(6);
+    expect(decision.concise?.maxLines).toBe(12);
     // First turn (no previousUserInput) → scratchPolicy clears everything.
     expect(decision.scratch).toEqual({
       resetAll: true,

--- a/src/policy/test-helpers.ts
+++ b/src/policy/test-helpers.ts
@@ -33,6 +33,7 @@ export function makePolicyInput(overrides?: {
     referenceLookup: true,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     customProviders: {},
   };
   return {

--- a/src/qualifier/default-qualifier.test.ts
+++ b/src/qualifier/default-qualifier.test.ts
@@ -23,6 +23,7 @@ function makeConfig(): BernardConfig {
     referenceLookup: true,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     customProviders: {},
   };
 }

--- a/src/reference-resolver.test.ts
+++ b/src/reference-resolver.test.ts
@@ -70,6 +70,7 @@ function makeConfig(): BernardConfig {
     referenceLookup: false,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
   };
 }
 

--- a/src/reference-tool-lookup.test.ts
+++ b/src/reference-tool-lookup.test.ts
@@ -47,6 +47,7 @@ function makeConfig(overrides: Partial<BernardConfig> = {}): BernardConfig {
     referenceLookup: true,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     ...overrides,
   };
 }

--- a/src/repl.test.ts
+++ b/src/repl.test.ts
@@ -292,6 +292,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     referenceLookup: false,
     referenceLookupTools: [],
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     ...overrides,
   };

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -269,7 +269,7 @@ export async function startRepl(
   }
 
   async function toggleBooleanPref(
-    key: 'toolDetails' | 'promptRewriter' | 'autoCreateSpecialists',
+    key: 'toolDetails' | 'promptRewriter' | 'autoCreateSpecialists' | 'conciseMode',
     label: string,
     onMsg: string,
     offMsg: string,
@@ -2035,7 +2035,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
 
       if (trimmed === '/agent-options') {
         type BooleanOpt = {
-          key: 'autoCreateSpecialists' | 'promptRewriter' | 'toolDetails';
+          key: 'autoCreateSpecialists' | 'promptRewriter' | 'toolDetails' | 'conciseMode';
           label: string;
           description: string;
           onMsg: string;
@@ -2077,6 +2077,16 @@ Remember: the systemPrompt should read like a persona definition — who this sp
             onMsg: '  [TOOL-DETAILS:ON] Full tool call args and results will be shown.',
             offMsg: '  [TOOL-DETAILS:OFF] Only tool names shown; args and results hidden.',
             onToggle: setToolDetailsVisible,
+          },
+          {
+            key: 'conciseMode',
+            label: 'Concise mode',
+            description:
+              'Default responses to the smallest sufficient size; expand only when asked or when the task needs length.',
+            onMsg:
+              '  [CONCISE:ON] Responses will be short by default; the model expands only when asked or when the task needs length.',
+            offMsg:
+              '  [CONCISE:OFF] Concision heuristic disabled; responses follow the base prompt without per-turn shaping.',
           },
         ];
 

--- a/src/structured-output.test.ts
+++ b/src/structured-output.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import {
+  capReasoning,
   extractJsonBlock,
   parseStructuredOutput,
+  REASONING_MAX_CHARS,
+  REASONING_MAX_ENTRIES,
   wrapWrapperResult,
   WrapperResultSchema,
   STRUCTURED_OUTPUT_RULES,
@@ -194,7 +197,38 @@ describe('wrapWrapperResult', () => {
     const longText = 'x'.repeat(600);
     const result = wrapWrapperResult(longText);
     expect(result.reasoning).toBeDefined();
-    expect(result.reasoning![0]).toHaveLength(500);
+    expect(result.reasoning![0]).toHaveLength(REASONING_MAX_CHARS);
+  });
+
+  it('caps reasoning to REASONING_MAX_ENTRIES on success', () => {
+    const reasoning = Array.from({ length: REASONING_MAX_ENTRIES + 4 }, (_, i) => `step ${i}`);
+    const text = JSON.stringify({ status: 'ok', result: 'done', reasoning });
+    const result = wrapWrapperResult(text);
+    expect(result.reasoning).toHaveLength(REASONING_MAX_ENTRIES);
+    expect(result.reasoning![0]).toBe('step 0');
+    expect(result.reasoning![REASONING_MAX_ENTRIES - 1]).toBe(`step ${REASONING_MAX_ENTRIES - 1}`);
+  });
+
+  it('trims each reasoning entry to REASONING_MAX_CHARS on success', () => {
+    const long = 'y'.repeat(REASONING_MAX_CHARS + 50);
+    const text = JSON.stringify({ status: 'ok', result: 'done', reasoning: [long] });
+    const result = wrapWrapperResult(text);
+    expect(result.reasoning![0]).toHaveLength(REASONING_MAX_CHARS);
+  });
+});
+
+describe('capReasoning', () => {
+  it('returns the input unchanged when already within bounds', () => {
+    const input = ['a', 'b'];
+    expect(capReasoning(input)).toEqual(['a', 'b']);
+  });
+
+  it('caps array length and entry size together', () => {
+    const long = 'z'.repeat(REASONING_MAX_CHARS + 10);
+    const input = Array.from({ length: REASONING_MAX_ENTRIES + 2 }, () => long);
+    const out = capReasoning(input);
+    expect(out).toHaveLength(REASONING_MAX_ENTRIES);
+    expect(out.every((s) => s.length === REASONING_MAX_CHARS)).toBe(true);
   });
 
   it('extracts valid JSON embedded in surrounding prose', () => {

--- a/src/structured-output.ts
+++ b/src/structured-output.ts
@@ -128,7 +128,9 @@ export function wrapWrapperResult(text: string): WrapperResult {
 export function capReasoning(reasoning: string[]): string[] {
   return reasoning
     .slice(0, REASONING_MAX_ENTRIES)
-    .map((entry) => (entry.length > REASONING_MAX_CHARS ? entry.slice(0, REASONING_MAX_CHARS) : entry));
+    .map((entry) =>
+      entry.length > REASONING_MAX_CHARS ? entry.slice(0, REASONING_MAX_CHARS) : entry,
+    );
 }
 
 /** Maximum number of `reasoning` entries kept after parsing (#175). */

--- a/src/structured-output.ts
+++ b/src/structured-output.ts
@@ -108,16 +108,33 @@ export function wrapWrapperResult(text: string): WrapperResult {
     const { status, result, error, reasoning } = parsed;
     const out: WrapperResult = { status, result };
     if (error !== undefined) out.error = error;
-    if (reasoning !== undefined) out.reasoning = reasoning;
+    if (reasoning !== undefined) out.reasoning = capReasoning(reasoning);
     return out;
   }
   return {
     status: 'error',
     result: 'Specialist did not produce valid structured output',
     error: 'parse_failed',
-    reasoning: [text.trim().slice(0, 500)],
+    reasoning: [text.trim().slice(0, REASONING_MAX_CHARS)],
   };
 }
+
+/**
+ * Defense-in-depth cap on the `reasoning` array (#175). Keeps at most
+ * {@link REASONING_MAX_ENTRIES} entries and trims each to
+ * {@link REASONING_MAX_CHARS} characters. The prompt asks the model to stay
+ * within these bounds; this enforces them when it doesn't.
+ */
+export function capReasoning(reasoning: string[]): string[] {
+  return reasoning
+    .slice(0, REASONING_MAX_ENTRIES)
+    .map((entry) => (entry.length > REASONING_MAX_CHARS ? entry.slice(0, REASONING_MAX_CHARS) : entry));
+}
+
+/** Maximum number of `reasoning` entries kept after parsing (#175). */
+export const REASONING_MAX_ENTRIES = 5;
+/** Maximum length of a single `reasoning` entry after parsing (#175). */
+export const REASONING_MAX_CHARS = 200;
 
 /**
  * Rules appended to a tool-wrapper specialist's system prompt. Instructs the
@@ -137,7 +154,10 @@ Your FINAL message MUST be a single valid JSON object with this shape and nothin
 }
 
 Rules:
+- Be minimal. The JSON IS the output — no narrative, no explanations, no apologies outside the JSON.
 - Emit the JSON only once, as your last message.
-- \`reasoning\` is an array of short strings. One entry per significant tool call explaining WHY you chose it (not what it returned).
+- \`result\` is the concrete outcome (a path, a value, a short summary). Do NOT restate the user's request, and do NOT echo raw tool output the caller already has.
+- \`reasoning\` is OPTIONAL. Include at most ${REASONING_MAX_ENTRIES} entries, each one short sentence (≤25 words / ~${REASONING_MAX_CHARS} characters). Omit \`reasoning\` entirely when \`status\` is "ok" and the call was straightforward. Excess entries / overlong entries are truncated downstream — keep them short to stay in control of what survives.
+- One reasoning entry per significant tool call, explaining WHY you chose it (not what it returned).
 - Never include confidence scores — the downstream pipeline ignores them.
-- If a tool call fails irrecoverably, set \`status\` to "error", put the cause in \`error\`, and still include your reasoning.`;
+- If a tool call fails irrecoverably, set \`status\` to "error", put the cause in \`error\`, and include a brief \`reasoning\` entry naming the failed step.`;

--- a/src/tools/specialist-run.test.ts
+++ b/src/tools/specialist-run.test.ts
@@ -95,6 +95,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     autoCreateSpecialists: false,
     autoCreateThreshold: 0.8,
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     ...overrides,
   };

--- a/src/tools/specialist.test.ts
+++ b/src/tools/specialist.test.ts
@@ -439,6 +439,7 @@ describe('createSpecialistTool', () => {
         autoCreateSpecialists: false,
         autoCreateThreshold: 0.8,
         scratchSubjectThreshold: 0.15,
+        conciseMode: true,
         anthropicApiKey: 'sk-test',
       };
       const toolWithConfig = createSpecialistTool(undefined, undefined, config);
@@ -472,6 +473,7 @@ describe('createSpecialistTool', () => {
         autoCreateSpecialists: false,
         autoCreateThreshold: 0.8,
         scratchSubjectThreshold: 0.15,
+        conciseMode: true,
         anthropicApiKey: 'sk-test',
       };
       const toolWithConfig = createSpecialistTool(undefined, undefined, config);
@@ -645,6 +647,7 @@ describe('createSpecialistTool', () => {
         autoCreateSpecialists: false,
         autoCreateThreshold: 0.8,
         scratchSubjectThreshold: 0.15,
+        conciseMode: true,
         anthropicApiKey: 'sk-test',
       };
       const toolWithConfig = createSpecialistTool(undefined, undefined, config);

--- a/src/tools/subagent.test.ts
+++ b/src/tools/subagent.test.ts
@@ -91,6 +91,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     autoCreateSpecialists: false,
     autoCreateThreshold: 0.8,
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     ...overrides,
   };

--- a/src/tools/task.test.ts
+++ b/src/tools/task.test.ts
@@ -94,6 +94,7 @@ function makeConfig(overrides?: Partial<BernardConfig>): BernardConfig {
     autoCreateSpecialists: false,
     autoCreateThreshold: 0.8,
     scratchSubjectThreshold: 0.15,
+    conciseMode: true,
     anthropicApiKey: 'sk-test',
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- Add `conciseMode` config (default true) + `BERNARD_CONCISE_MODE` env + prefs persistence + `/agent-options` toggle.
- Fill in the `concisePolicy` stub so the existing `PolicyDecision.concise` slot is driven by config; emits `{enabled, maxBullets: 6, maxLines: 12}` with reason `config-on`/`config-off`.
- Inject a new `CONCISE_PROMPT` block from `buildMainSystemPrompt` when the policy enables it (mirrors the `CITATIONS_PROMPT` pattern from #173). Removes the redundant one-line bullet from `BASE_SYSTEM_PROMPT`.
- Tighten tool-wrapper `STRUCTURED_OUTPUT_RULES` (be minimal, no narrative, `reasoning` ≤5 short entries) and add a defense-in-depth `capReasoning` cap (≤5 entries × ≤200 chars) inside `wrapWrapperResult` so models that ignore the prompt can't blow the token budget.

## Acceptance criteria (from #175)
- [x] `conciseMode` setting exists and defaults to enabled.
- [x] Main agent responses are short by default (≤6 bullets / ≤12 lines per the injected prompt) unless the user asks otherwise, the task inherently needs length, or brevity would sacrifice correctness.
- [x] Tool-wrapper specialists emit minimal structured output with no extra narrative (prompt + hard cap).
- [x] Tests cover default concision, user override (off branch), and wrapper minimal output / cap behavior.

## Test plan
- [x] `npx vitest run` — 2431/2431 pass.
- [x] `npm run build` — clean.
- [ ] Manual REPL smoke: `BERNARD_DEBUG=1 npm run dev` → ask a one-line question and confirm the response is short; ask "draft an email about X" and confirm it expands; check the `policy:decide` debug log shows `concise: { enabled: true, maxBullets: 6, maxLines: 12 }` with reason `config-on`. Toggle via `/agent-options` and confirm the decision flips on the next turn.
- [ ] Manual wrapper smoke: invoke `tool_wrapper_run` against `shell-wrapper` and verify the JSON return has `reasoning` ≤5 entries × ≤200 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)