### PR TITLE
feat(policy): evidence pointers for verified claims (closes #141)

### DIFF
--- a/src/agent-prompt.ts
+++ b/src/agent-prompt.ts
@@ -48,9 +48,22 @@ When a sentence states a fact you got from a registered source this turn (web_re
 Rules:
 - Only attach \`[^Sn]\` for an id that actually appears in this turn's source list.
 - If a claim has no matching registered source, either prefix it with \`[unverified]\` ("the build target is x86_64 [unverified]") or call \`ask_user\` to confirm. Do not invent a citation.
-- \`shell\` output and MCP tool results are NOT auto-registered. When you need to cite them, quote the relevant line inline instead of attaching a marker.
+- \`shell\` output and other tool results ARE auto-registered as \`kind: 'tool-result'\` sources — see the \`## Evidence Pointers\` section for how to cite them.
 - Opinions, recommendations, and high-level summaries don't need markers — citations are for factual / tool-derived claims.
 - One marker per claim is enough; don't spam multiple ids on the same sentence.`;
+
+export const EVIDENCE_PROMPT = `## Evidence Pointers
+Every successful tool call this turn (\`shell\`, \`file_*\`, \`web_*\`, MCP, etc.) is registered as a \`kind: 'tool-result'\` source in the same per-turn store as retrieval citations. Each entry captures **what was checked** (tool + args), **the key result snippet**, and **when** (timestamp). The ids appear in \`<available_sources>\` alongside \`web\` / \`file\` / \`memory\` sources.
+
+When you assert that something is **verified**, **confirmed**, **checked**, or otherwise grounded in a tool result you ran this turn, END that sentence with the \`[^Sn]\` marker for the tool call that proves it. Examples:
+- "Verified the commit landed on main. [^S3]"
+- "Confirmed the file no longer exists. [^S2]"
+- "Checked the endpoint — it returned 200. [^S4]"
+
+Rules:
+- Do not write "verified" / "confirmed" without a matching \`[^Sn]\` marker. If no tool call backs the claim, either run one (preferred) or prefix with \`[unverified]\`.
+- Use the marker for the tool call that produced the evidence — usually a read-only check after a mutation (e.g. \`git log\` after a commit, \`ls\` after a write).
+- Citations (\`web_read\` etc.) and evidence pointers share the same store and marker syntax; the \`kind\` field on each source disambiguates them.`;
 
 export const BASE_SYSTEM_PROMPT = `# Identity
 

--- a/src/agent-prompt.ts
+++ b/src/agent-prompt.ts
@@ -48,7 +48,6 @@ When a sentence states a fact you got from a registered source this turn (web_re
 Rules:
 - Only attach \`[^Sn]\` for an id that actually appears in this turn's source list.
 - If a claim has no matching registered source, either prefix it with \`[unverified]\` ("the build target is x86_64 [unverified]") or call \`ask_user\` to confirm. Do not invent a citation.
-- \`shell\` output and other tool results ARE auto-registered as \`kind: 'tool-result'\` sources — see the \`## Evidence Pointers\` section for how to cite them.
 - Opinions, recommendations, and high-level summaries don't need markers — citations are for factual / tool-derived claims.
 - One marker per claim is enough; don't spam multiple ids on the same sentence.`;
 

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -24,6 +24,7 @@ import {
   REASONING_FAMILIES,
   CITATIONS_PROMPT,
   CONCISE_PROMPT,
+  EVIDENCE_PROMPT,
 } from '../../agent-prompt.js';
 import { buildContextMessage } from '../../context-message.js';
 import type { RAGSearchResult } from '../../rag.js';
@@ -100,6 +101,15 @@ export function buildMainSystemPrompt(
     !REASONING_FAMILIES.has(profile.family)
   ) {
     systemPrompt += '\n\n' + CITATIONS_PROMPT;
+  }
+  // Evidence-pointer policy: append the `## Evidence Pointers` block when the
+  // policy engine has decided we require markers for verified claims and the
+  // active model family does not forbid inline annotations. Issue #141.
+  if (
+    ctx.policyDecision?.evidence?.requireForVerifiedClaims &&
+    !REASONING_FAMILIES.has(profile.family)
+  ) {
+    systemPrompt += '\n\n' + EVIDENCE_PROMPT;
   }
   // Concise-mode shaping: append the concise block when the policy enables it.
   // Issue #175. No model-family gate — concision is universal.

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -84,8 +84,12 @@ export async function runDefinition<TInput, TFormatted>(
     // Evidence-pointer registration (#141). Shared by reference into
     // sub-agent / tool-wrapper contexts so a `shell` call inside a wrapper
     // surfaces in the parent's Shift+Tab overlay alongside main-agent calls.
+    // Default-closed: cron and bare depsToCtx callers run without a
+    // policyDecision, so silently enabling evidence there would populate the
+    // shared store with entries the model running that context was never
+    // told to cite (cron + sub-agents/wrappers do not inject EVIDENCE_PROMPT).
     provenance: ctx.provenance,
-    evidenceEnabled: ctx.policyDecision?.evidence?.requireForVerifiedClaims ?? true,
+    evidenceEnabled: ctx.policyDecision?.evidence?.requireForVerifiedClaims === true,
   });
   const hooks = def.hooks(ctx, input);
   const baseMaxSteps = def.stepBudget(config, input);

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -81,6 +81,11 @@ export async function runDefinition<TInput, TFormatted>(
     blockAction: ctx.toolOptions.blockAction,
     sessionToolAllowlist: ctx.toolOptions.sessionToolAllowlist,
     cacheEnabled: config.cacheEnabled,
+    // Evidence-pointer registration (#141). Shared by reference into
+    // sub-agent / tool-wrapper contexts so a `shell` call inside a wrapper
+    // surfaces in the parent's Shift+Tab overlay alongside main-agent calls.
+    provenance: ctx.provenance,
+    evidenceEnabled: ctx.policyDecision?.evidence?.requireForVerifiedClaims ?? true,
   });
   const hooks = def.hooks(ctx, input);
   const baseMaxSteps = def.stepBudget(config, input);

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -30,6 +30,7 @@ describe('DefaultPolicyEngine', () => {
     });
     expect(decision.caching?.enabled).toBe(false);
     expect(decision.citations?.requireForFactualClaims).toBe(true);
+    expect(decision.evidence?.requireForVerifiedClaims).toBe(true);
     expect(decision.toolMode).toEqual({
       mode: 'read-only',
       requireConfirmForWrite: true,
@@ -41,7 +42,7 @@ describe('DefaultPolicyEngine', () => {
     const engine = new DefaultPolicyEngine();
     const { reasons } = engine.decide(makePolicyInput());
     expect(Object.keys(reasons).sort()).toEqual(
-      ['caching', 'citations', 'concise', 'models', 'scratch', 'strategy', 'toolMode'].sort(),
+      ['caching', 'citations', 'concise', 'evidence', 'models', 'scratch', 'strategy', 'toolMode'].sort(),
     );
     for (const value of Object.values(reasons)) {
       expect(value).toMatch(/^[a-z0-9-]+$/);

--- a/src/policy/engine.test.ts
+++ b/src/policy/engine.test.ts
@@ -42,7 +42,16 @@ describe('DefaultPolicyEngine', () => {
     const engine = new DefaultPolicyEngine();
     const { reasons } = engine.decide(makePolicyInput());
     expect(Object.keys(reasons).sort()).toEqual(
-      ['caching', 'citations', 'concise', 'evidence', 'models', 'scratch', 'strategy', 'toolMode'].sort(),
+      [
+        'caching',
+        'citations',
+        'concise',
+        'evidence',
+        'models',
+        'scratch',
+        'strategy',
+        'toolMode',
+      ].sort(),
     );
     for (const value of Object.values(reasons)) {
       expect(value).toMatch(/^[a-z0-9-]+$/);

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -2,6 +2,7 @@ import { debugLog } from '../logger.js';
 import { cachingPolicy } from './caching.js';
 import { citationsPolicy } from './citations.js';
 import { concisePolicy } from './concise.js';
+import { evidencePolicy } from './evidence.js';
 import { modelPolicy } from './model.js';
 import { scratchPolicy } from './scratch.js';
 import { strategyPolicy } from './strategy.js';
@@ -26,6 +27,7 @@ export class DefaultPolicyEngine implements PolicyEngine {
     const scratch = scratchPolicy(input);
     const caching = cachingPolicy(input);
     const citations = citationsPolicy(input);
+    const evidence = evidencePolicy(input);
     const toolMode = toolModePolicy(input);
 
     const decision: PolicyDecision = {
@@ -44,6 +46,7 @@ export class DefaultPolicyEngine implements PolicyEngine {
       },
       caching: { enabled: caching.enabled },
       citations: { requireForFactualClaims: citations.requireForFactualClaims },
+      evidence: { requireForVerifiedClaims: evidence.requireForVerifiedClaims },
       toolMode: {
         mode: toolMode.mode,
         requireConfirmForWrite: toolMode.requireConfirmForWrite,
@@ -58,6 +61,7 @@ export class DefaultPolicyEngine implements PolicyEngine {
       scratch: scratch.reason,
       caching: caching.reason,
       citations: citations.reason,
+      evidence: evidence.reason,
       toolMode: toolMode.reason,
     };
 

--- a/src/policy/evidence.test.ts
+++ b/src/policy/evidence.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { evidencePolicy } from './evidence.js';
+import { makePolicyInput } from './test-helpers.js';
+
+describe('evidencePolicy', () => {
+  it('is on by default once issue #141 lands', () => {
+    const result = evidencePolicy(makePolicyInput());
+    expect(result.requireForVerifiedClaims).toBe(true);
+    expect(result.reason).toBe('issue-141-default-on');
+  });
+});

--- a/src/policy/evidence.ts
+++ b/src/policy/evidence.ts
@@ -1,0 +1,16 @@
+import type { PolicyDecision, SubPolicy } from './types.js';
+
+type Evidence = NonNullable<PolicyDecision['evidence']>;
+
+/**
+ * Issue #141 sub-policy: require evidence pointers for verified claims by
+ * default. Tool calls register `kind: 'tool-result'` sources in the per-turn
+ * ProvenanceStore (via `augmentTools`); the SYSTEM prompt's `## Evidence
+ * Pointers` section is gated on this flag and on the model family
+ * (`REASONING_FAMILIES` skip the inline-marker instruction for the same
+ * reason citations do).
+ */
+export const evidencePolicy: SubPolicy<Evidence> = () => ({
+  requireForVerifiedClaims: true,
+  reason: 'issue-141-default-on',
+});

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -28,6 +28,14 @@ export interface PolicyDecision {
   scratch?: { resetAll: boolean; resetPlanOnly: boolean; deletePlanKey: boolean; reason: string };
   caching?: { enabled: boolean };
   citations?: { requireForFactualClaims: boolean };
+  /**
+   * Issue #141: when on, every successful tool call this turn is registered
+   * in the per-turn ProvenanceStore as `kind: 'tool-result'` and the SYSTEM
+   * prompt instructs the model to attach `[^Sn]` markers to "verified" /
+   * "confirmed" / "checked" claims. Mirrors the citations policy in shape;
+   * the augment layer reads this flag via `AugmentOptions.evidenceEnabled`.
+   */
+  evidence?: { requireForVerifiedClaims: boolean };
   toolMode?: {
     mode: 'read-only' | 'write';
     requireConfirmForWrite: boolean;

--- a/src/tools/augment.test.ts
+++ b/src/tools/augment.test.ts
@@ -4,6 +4,7 @@ import { augmentTools } from './augment.js';
 import { attachMeta, toolToAISDK } from '../framework/tools/adapter.js';
 import { ok, err, type BernardTool } from '../framework/tools/types.js';
 import { clearCache as clearResultCache } from '../framework/tools/result-cache.js';
+import { ProvenanceStore } from '../provenance.js';
 
 vi.mock('../tool-profiles.js', () => ({
   classifyShellCommand: vi.fn((cmd: string) => {
@@ -1295,6 +1296,109 @@ describe('augmentTools', () => {
       expect(r1).toBe('Error: boom');
       expect(r2).toEqual({ val: 99 });
       expect(exec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('evidence pointers (#141)', () => {
+    function makeEvidenceBernardTool(opts: {
+      name: string;
+      result: 'ok' | 'error';
+    }): BernardTool<{ x: number }, { val: number }> {
+      return {
+        meta: { name: opts.name, kind: 'read' },
+        description: opts.name,
+        parameters: z.object({ x: z.number() }),
+        execute: async () =>
+          opts.result === 'ok'
+            ? ok({ val: 1 })
+            : err({ type: 'exec_failed', message: 'boom', snippet: 'boom-snip' }),
+        serializeForModel: (r) => (r.status === 'ok' ? `model:${r.result.val}` : `Error: ${r.error.message}`),
+      };
+    }
+
+    it('envelope path: successful call registers a tool-result source', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools({ demo: aisdk }, { profileStore: store, provenance });
+
+      await augmented.demo.execute({ x: 42 }, {});
+
+      const items = provenance.list();
+      expect(items).toHaveLength(1);
+      expect(items[0].kind).toBe('tool-result');
+      expect(items[0].label).toContain('demo');
+      expect(items[0].label).toContain('42');
+      expect(items[0].contentPreview).toContain('model:1');
+      expect(items[0].rawRef).toMatch(/^tool:demo:/);
+    });
+
+    it('envelope path: errored call does NOT register evidence', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'error' }));
+      const augmented = augmentTools({ demo: aisdk }, { profileStore: store, provenance });
+
+      await augmented.demo.execute({ x: 1 }, {});
+
+      expect(provenance.list()).toHaveLength(0);
+    });
+
+    it('two identical successful calls dedup to one entry via ProvenanceStore', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools({ demo: aisdk }, { profileStore: store, provenance });
+
+      await augmented.demo.execute({ x: 1 }, {});
+      await augmented.demo.execute({ x: 1 }, {});
+
+      expect(provenance.list()).toHaveLength(1);
+    });
+
+    it('legacy path: successful call registers a tool-result source', async () => {
+      const provenance = new ProvenanceStore();
+      vi.mocked(detectToolError).mockReturnValue({ isError: false });
+      const tools = { legacy_tool: { execute: vi.fn(async () => 'plain string output') } };
+      const augmented = augmentTools(tools, { profileStore: store, provenance });
+
+      await augmented.legacy_tool.execute({ url: 'https://example.com' }, {});
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const items = provenance.list();
+      expect(items).toHaveLength(1);
+      expect(items[0].kind).toBe('tool-result');
+      expect(items[0].label).toContain('legacy_tool');
+      expect(items[0].contentPreview).toContain('plain string output');
+    });
+
+    it('legacy path: errored call does NOT register evidence', async () => {
+      const provenance = new ProvenanceStore();
+      vi.mocked(detectToolError).mockReturnValue({ isError: true, snippet: 'boom' });
+      const tools = { legacy_tool: { execute: vi.fn(async () => ({ error: 'boom' })) } };
+      const augmented = augmentTools(tools, { profileStore: store, provenance });
+
+      await augmented.legacy_tool.execute({ x: 1 }, {});
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(provenance.list()).toHaveLength(0);
+    });
+
+    it('evidenceEnabled: false short-circuits registration even with a store wired', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools(
+        { demo: aisdk },
+        { profileStore: store, provenance, evidenceEnabled: false },
+      );
+
+      await augmented.demo.execute({ x: 1 }, {});
+
+      expect(provenance.list()).toHaveLength(0);
+    });
+
+    it('no provenance store wired → no registration, no throw', async () => {
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools({ demo: aisdk }, store);
+
+      await expect(augmented.demo.execute({ x: 1 }, {})).resolves.toBeDefined();
     });
   });
 });

--- a/src/tools/augment.test.ts
+++ b/src/tools/augment.test.ts
@@ -1303,23 +1303,38 @@ describe('augmentTools', () => {
     function makeEvidenceBernardTool(opts: {
       name: string;
       result: 'ok' | 'error';
-    }): BernardTool<{ x: number }, { val: number }> {
+      sensitiveArgs?: string[];
+      sensitiveResult?: boolean;
+    }): BernardTool<Record<string, unknown>, { val: number }> {
       return {
-        meta: { name: opts.name, kind: 'read' },
+        meta: {
+          name: opts.name,
+          kind: 'read',
+          ...(opts.sensitiveArgs ? { sensitiveArgs: opts.sensitiveArgs } : {}),
+          ...(opts.sensitiveResult ? { sensitiveResult: true } : {}),
+        },
         description: opts.name,
-        parameters: z.object({ x: z.number() }),
+        parameters: z.object({}).passthrough(),
         execute: async () =>
           opts.result === 'ok'
             ? ok({ val: 1 })
             : err({ type: 'exec_failed', message: 'boom', snippet: 'boom-snip' }),
-        serializeForModel: (r) => (r.status === 'ok' ? `model:${r.result.val}` : `Error: ${r.error.message}`),
+        serializeForModel: (r) =>
+          r.status === 'ok' ? `model:${r.result.val}` : `Error: ${r.error.message}`,
       };
     }
+
+    /** Standard options enabling evidence registration. */
+    const evidenceOn = (provenance: ProvenanceStore) => ({
+      profileStore: store,
+      provenance,
+      evidenceEnabled: true,
+    });
 
     it('envelope path: successful call registers a tool-result source', async () => {
       const provenance = new ProvenanceStore();
       const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
-      const augmented = augmentTools({ demo: aisdk }, { profileStore: store, provenance });
+      const augmented = augmentTools({ demo: aisdk }, evidenceOn(provenance));
 
       await augmented.demo.execute({ x: 42 }, {});
 
@@ -1329,13 +1344,13 @@ describe('augmentTools', () => {
       expect(items[0].label).toContain('demo');
       expect(items[0].label).toContain('42');
       expect(items[0].contentPreview).toContain('model:1');
-      expect(items[0].rawRef).toMatch(/^tool:demo:/);
+      expect(items[0].rawRef).toMatch(/^tool:demo:[0-9a-z]+$/);
     });
 
     it('envelope path: errored call does NOT register evidence', async () => {
       const provenance = new ProvenanceStore();
       const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'error' }));
-      const augmented = augmentTools({ demo: aisdk }, { profileStore: store, provenance });
+      const augmented = augmentTools({ demo: aisdk }, evidenceOn(provenance));
 
       await augmented.demo.execute({ x: 1 }, {});
 
@@ -1345,7 +1360,7 @@ describe('augmentTools', () => {
     it('two identical successful calls dedup to one entry via ProvenanceStore', async () => {
       const provenance = new ProvenanceStore();
       const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
-      const augmented = augmentTools({ demo: aisdk }, { profileStore: store, provenance });
+      const augmented = augmentTools({ demo: aisdk }, evidenceOn(provenance));
 
       await augmented.demo.execute({ x: 1 }, {});
       await augmented.demo.execute({ x: 1 }, {});
@@ -1353,14 +1368,57 @@ describe('augmentTools', () => {
       expect(provenance.list()).toHaveLength(1);
     });
 
-    it('legacy path: successful call registers a tool-result source', async () => {
+    it('two calls whose first 120 args chars match still register as distinct sources (hashed rawRef)', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools({ demo: aisdk }, evidenceOn(provenance));
+
+      const sharedPrefix = 'x'.repeat(130);
+      await augmented.demo.execute({ path: sharedPrefix + 'a' }, {});
+      await augmented.demo.execute({ path: sharedPrefix + 'b' }, {});
+
+      expect(provenance.list()).toHaveLength(2);
+    });
+
+    it('sensitiveArgs are redacted in the label/rawRef', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(
+        makeEvidenceBernardTool({ name: 'demo', result: 'ok', sensitiveArgs: ['apiKey'] }),
+      );
+      const augmented = augmentTools({ demo: aisdk }, evidenceOn(provenance));
+
+      await augmented.demo.execute({ apiKey: 'sk-very-secret-12345', q: 'hello' }, {});
+
+      const items = provenance.list();
+      expect(items).toHaveLength(1);
+      expect(items[0].label).not.toContain('sk-very-secret');
+      expect(items[0].label).toContain('REDACTED');
+    });
+
+    it('sensitiveResult replaces the contentPreview with REDACTED', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(
+        makeEvidenceBernardTool({ name: 'demo', result: 'ok', sensitiveResult: true }),
+      );
+      const augmented = augmentTools({ demo: aisdk }, evidenceOn(provenance));
+
+      await augmented.demo.execute({ x: 1 }, {});
+
+      const items = provenance.list();
+      expect(items).toHaveLength(1);
+      expect(items[0].contentPreview).toBe('[REDACTED]');
+      expect(items[0].contentPreview).not.toContain('model:1');
+    });
+
+    it('legacy path: successful call registers a tool-result source (synchronous)', async () => {
       const provenance = new ProvenanceStore();
       vi.mocked(detectToolError).mockReturnValue({ isError: false });
       const tools = { legacy_tool: { execute: vi.fn(async () => 'plain string output') } };
-      const augmented = augmentTools(tools, { profileStore: store, provenance });
+      const augmented = augmentTools(tools, evidenceOn(provenance));
 
       await augmented.legacy_tool.execute({ url: 'https://example.com' }, {});
-      await new Promise((resolve) => setImmediate(resolve));
+      // No `await setImmediate` — legacy-path registration is synchronous so
+      // it can't race with the next turn's `provenance.clear()`.
 
       const items = provenance.list();
       expect(items).toHaveLength(1);
@@ -1369,14 +1427,77 @@ describe('augmentTools', () => {
       expect(items[0].contentPreview).toContain('plain string output');
     });
 
-    it('legacy path: errored call does NOT register evidence', async () => {
+    it('legacy path: result with is_error: true does NOT register evidence', async () => {
       const provenance = new ProvenanceStore();
-      vi.mocked(detectToolError).mockReturnValue({ isError: true, snippet: 'boom' });
-      const tools = { legacy_tool: { execute: vi.fn(async () => ({ error: 'boom' })) } };
-      const augmented = augmentTools(tools, { profileStore: store, provenance });
+      const tools = {
+        legacy_tool: { execute: vi.fn(async () => ({ output: 'oops', is_error: true })) },
+      };
+      const augmented = augmentTools(tools, evidenceOn(provenance));
 
       await augmented.legacy_tool.execute({ x: 1 }, {});
-      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(provenance.list()).toHaveLength(0);
+    });
+
+    it('legacy path: result with an `error` field does NOT register evidence', async () => {
+      const provenance = new ProvenanceStore();
+      const tools = { legacy_tool: { execute: vi.fn(async () => ({ error: 'boom' })) } };
+      const augmented = augmentTools(tools, evidenceOn(provenance));
+
+      await augmented.legacy_tool.execute({ x: 1 }, {});
+
+      expect(provenance.list()).toHaveLength(0);
+    });
+
+    it('legacy path: registration survives detectToolError throws (sync — outside the setImmediate catch)', async () => {
+      const provenance = new ProvenanceStore();
+      vi.mocked(detectToolError).mockImplementation(() => {
+        throw new Error('detector blew up');
+      });
+      const tools = { legacy_tool: { execute: vi.fn(async () => 'plain output') } };
+      const augmented = augmentTools(tools, evidenceOn(provenance));
+
+      await augmented.legacy_tool.execute({ x: 1 }, {});
+
+      expect(provenance.list()).toHaveLength(1);
+    });
+
+    it('cache hit re-registers evidence (survives cross-turn provenance.clear)', async () => {
+      const provenance = new ProvenanceStore();
+      // Cacheable BernardTool (deterministic + sideEffect:'none').
+      const tool: BernardTool<{ x: number }, { val: number }> = {
+        meta: {
+          name: 'cacheable',
+          kind: 'read',
+          deterministic: true,
+          sideEffect: 'none',
+          cacheable: true,
+        },
+        description: 'cacheable',
+        parameters: z.object({ x: z.number() }),
+        execute: vi.fn(async () => ok({ val: 99 })),
+        serializeForModel: (r) => (r.status === 'ok' ? `val:${r.result.val}` : 'err'),
+      };
+      const aisdk = toolToAISDK(tool);
+      const augmented = augmentTools({ cacheable: aisdk }, evidenceOn(provenance));
+
+      await augmented.cacheable.execute({ x: 1 }, {});
+      expect(provenance.list()).toHaveLength(1);
+
+      provenance.clear();
+      await augmented.cacheable.execute({ x: 1 }, {}); // cache hit
+      expect(provenance.list()).toHaveLength(1);
+    });
+
+    it('evidenceEnabled defaults to false when omitted, even with a store wired', async () => {
+      const provenance = new ProvenanceStore();
+      const aisdk = toolToAISDK(makeEvidenceBernardTool({ name: 'demo', result: 'ok' }));
+      const augmented = augmentTools(
+        { demo: aisdk },
+        { profileStore: store, provenance }, // no evidenceEnabled
+      );
+
+      await augmented.demo.execute({ x: 1 }, {});
 
       expect(provenance.list()).toHaveLength(0);
     });

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -8,7 +8,9 @@ import type { BlockActionInput, BlockOutcome, ConfirmActionInput, ToolOptions } 
 import type { ConfirmThreshold } from '../risk.js';
 import { riskFromMeta, shouldBlockInReadOnly, shouldConfirm } from '../risk.js';
 import { CACHE_MISS, getCachedResult, setCachedResult } from '../framework/tools/result-cache.js';
+import { redactArgs, REDACTED } from '../framework/tools/redact.js';
 import type { ProvenanceStore } from '../provenance.js';
+import type { ToolMeta } from '../framework/tools/types.js';
 
 /**
  * The wrapper shim prepends `[failure: <category>] <playbook.model>` to
@@ -269,21 +271,52 @@ export function augmentTools(
   // is wired AND the policy hasn't disabled it. Errors during `add` are
   // swallowed so a malformed source never aborts a real tool call.
   const provenance = opts.provenance;
-  const evidenceEnabled = provenance ? opts.evidenceEnabled !== false : false;
+  // Default closed: registration only runs when the policy engine explicitly
+  // opts in. The previous `?? true` fallback silently enabled evidence in
+  // contexts that never consult the policy (cron, bare depsToCtx callers),
+  // populating the shared store with entries the model was never told about.
+  const evidenceEnabled = provenance ? opts.evidenceEnabled === true : false;
+
+  /**
+   * Stable 53-bit djb2 hash for an args string. Used to derive an evidence
+   * `rawRef` that uniquely identifies the call. Truncating the raw args in
+   * the rawRef caused long-prefix collisions (two `shell` commands with the
+   * same first 120 chars deduped to one source) which silently dropped the
+   * second call's evidence.
+   */
+  const hashArgs = (s: string): string => {
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) {
+      h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+    }
+    return (h >>> 0).toString(36);
+  };
 
   const registerEvidence = (
     toolName: string,
-    argsSnippet: string,
-    preview: string,
+    args: unknown,
+    meta: ToolMeta | undefined,
+    resultText: string,
   ): void => {
     if (!evidenceEnabled || !provenance) return;
     try {
-      const argTail = argsSnippet ? `: ${argsSnippet.slice(0, 80)}` : '';
+      // Redact declared-sensitive arg fields before they reach label/rawRef,
+      // matching the contract result-cache.ts / cron-step-recorder.ts /
+      // tool-wrapper-run.ts already follow. Without this, an MCP tool that
+      // declares `sensitiveArgs: ['apiKey']` would leak its key into the
+      // <available_sources> block the LLM sees every turn.
+      const safeArgs = redactArgs(args, meta?.sensitiveArgs);
+      const argsSnippet = safeSerialize(safeArgs);
+      // Same contract for result content: when the tool's output itself is
+      // sensitive (sensitiveResult: true) we never let it reach the model
+      // via <available_sources>.
+      const previewSrc = meta?.sensitiveResult ? REDACTED : resultText;
+      const labelTail = argsSnippet ? `: ${argsSnippet.slice(0, 80)}` : '';
       provenance.add({
         kind: 'tool-result',
-        label: `${toolName}${argTail}`,
-        contentPreview: preview,
-        rawRef: `tool:${toolName}:${argsSnippet.slice(0, 120)}`,
+        label: `${toolName}${labelTail}`,
+        contentPreview: previewSrc,
+        rawRef: `tool:${toolName}:${hashArgs(argsSnippet)}`,
       });
     } catch (err) {
       debugLog(
@@ -429,6 +462,16 @@ export function augmentTools(
                     undefined,
                   ),
                 );
+                // Evidence pointer (#141) for cache hits: without this, a
+                // cacheable tool whose TTL outlives a turn boundary returns
+                // a cached result the model is told (by EVIDENCE_PROMPT) it
+                // can cite — but the per-turn ProvenanceStore was cleared at
+                // turn start so no `[^Sn]` is available. Re-register so the
+                // post-clear turn has the source. ProvenanceStore dedups by
+                // (kind, rawRef), so intra-turn repeats are a no-op.
+                const cachedPreview =
+                  typeof cached === 'string' ? cached : safeSerialize(cached);
+                registerEvidence(toolName, args, source.meta, cachedPreview);
                 return cached;
               }
               debugLog(`cache:tool:miss`, { tool: toolName });
@@ -471,7 +514,7 @@ export function augmentTools(
             if (envelope.status === 'ok') {
               const previewSrc =
                 typeof serialized === 'string' ? serialized : safeSerialize(serialized);
-              registerEvidence(toolName, argsSnippet, previewSrc);
+              registerEvidence(toolName, args, source.meta, previewSrc);
             }
             return serialized;
           },
@@ -511,21 +554,31 @@ export function augmentTools(
           const profileKey = resolveProfileKey(toolName, args);
           const argsSnippet = safeSerialize(args);
           const capturedResult = result;
+          // Evidence pointer (#141), synchronous: deferring this inside the
+          // setImmediate below races with `provenance.clear()` at the start
+          // of the next turn (back-to-back processInput, /task path, tests),
+          // and a throw from detectToolError would silently skip it. We use
+          // a cheap inline check for the legacy error shapes instead of
+          // calling detectToolError synchronously, which would also break
+          // the "result returned before recording" invariant the legacy
+          // path tests assert.
+          const looksLikeError =
+            capturedResult !== null &&
+            typeof capturedResult === 'object' &&
+            ((capturedResult as Record<string, unknown>).is_error === true ||
+              'error' in (capturedResult as Record<string, unknown>));
+          if (!looksLikeError) {
+            const previewSrc =
+              typeof capturedResult === 'string'
+                ? capturedResult
+                : safeSerialize(capturedResult);
+            registerEvidence(toolName, args, readToolMeta(toolDef), previewSrc);
+          }
           setImmediate(() => {
             try {
               const errorInfo = detectToolError(toolName, capturedResult);
               const errSnippet = errorInfo.isError ? errorInfo.snippet : undefined;
               recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet);
-              // Evidence pointer (#141): deferred to setImmediate alongside
-              // profile recording so the "result returned before recording"
-              // invariant from the legacy-path tests still holds.
-              if (!errorInfo.isError) {
-                const previewSrc =
-                  typeof capturedResult === 'string'
-                    ? capturedResult
-                    : safeSerialize(capturedResult);
-                registerEvidence(toolName, argsSnippet, previewSrc);
-              }
             } catch {
               // detectToolError throws are swallowed; recording must never propagate.
             }

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -469,8 +469,7 @@ export function augmentTools(
                 // turn start so no `[^Sn]` is available. Re-register so the
                 // post-clear turn has the source. ProvenanceStore dedups by
                 // (kind, rawRef), so intra-turn repeats are a no-op.
-                const cachedPreview =
-                  typeof cached === 'string' ? cached : safeSerialize(cached);
+                const cachedPreview = typeof cached === 'string' ? cached : safeSerialize(cached);
                 registerEvidence(toolName, args, source.meta, cachedPreview);
                 return cached;
               }
@@ -569,9 +568,7 @@ export function augmentTools(
               'error' in (capturedResult as Record<string, unknown>));
           if (!looksLikeError) {
             const previewSrc =
-              typeof capturedResult === 'string'
-                ? capturedResult
-                : safeSerialize(capturedResult);
+              typeof capturedResult === 'string' ? capturedResult : safeSerialize(capturedResult);
             registerEvidence(toolName, args, readToolMeta(toolDef), previewSrc);
           }
           setImmediate(() => {

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -8,6 +8,7 @@ import type { BlockActionInput, BlockOutcome, ConfirmActionInput, ToolOptions } 
 import type { ConfirmThreshold } from '../risk.js';
 import { riskFromMeta, shouldBlockInReadOnly, shouldConfirm } from '../risk.js';
 import { CACHE_MISS, getCachedResult, setCachedResult } from '../framework/tools/result-cache.js';
+import type { ProvenanceStore } from '../provenance.js';
 
 /**
  * The wrapper shim prepends `[failure: <category>] <playbook.model>` to
@@ -145,6 +146,22 @@ export interface AugmentOptions {
    * always call `execute`. Defaults to enabled.
    */
   cacheEnabled?: boolean;
+  /**
+   * Per-turn ProvenanceStore for evidence-pointer registration (#141). When
+   * provided and {@link evidenceEnabled} is not `false`, every successful
+   * tool call is added as a `kind: 'tool-result'` source so the model can
+   * cite it with `[^Sn]` markers in "verified" / "confirmed" claims. Errors,
+   * denies, and cancellations are skipped. Dedup is handled by the store
+   * (keyed on `kind` + `rawRef`).
+   */
+  provenance?: ProvenanceStore;
+  /**
+   * Toggle for evidence-pointer registration (#141). Defaults to `true` when
+   * a {@link provenance} store is passed; set `false` to short-circuit the
+   * add even when a store is wired (e.g. the policy engine disabled the
+   * `evidence` sub-policy for this turn).
+   */
+  evidenceEnabled?: boolean;
 }
 
 function isProfileStore(v: AugmentOptions | ToolProfileStore): v is ToolProfileStore {
@@ -248,6 +265,33 @@ export function augmentTools(
   // allowlist on the confirm gate means a repeat call with the same args
   // doesn't re-prompt, so the extra gate trip is essentially free.
   const cacheEnabled = opts.cacheEnabled !== false;
+  // Evidence-pointer registration (#141). Active only when a ProvenanceStore
+  // is wired AND the policy hasn't disabled it. Errors during `add` are
+  // swallowed so a malformed source never aborts a real tool call.
+  const provenance = opts.provenance;
+  const evidenceEnabled = provenance ? opts.evidenceEnabled !== false : false;
+
+  const registerEvidence = (
+    toolName: string,
+    argsSnippet: string,
+    preview: string,
+  ): void => {
+    if (!evidenceEnabled || !provenance) return;
+    try {
+      const argTail = argsSnippet ? `: ${argsSnippet.slice(0, 80)}` : '';
+      provenance.add({
+        kind: 'tool-result',
+        label: `${toolName}${argTail}`,
+        contentPreview: preview,
+        rawRef: `tool:${toolName}:${argsSnippet.slice(0, 120)}`,
+      });
+    } catch (err) {
+      debugLog(
+        `augment:${toolName}:evidence:failed`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  };
 
   const augmented: Record<string, any> = {};
 
@@ -421,6 +465,14 @@ export function augmentTools(
             if (toolIsCacheable && envelope.status === 'ok') {
               setCachedResult(source.meta, args, serialized);
             }
+            // Evidence pointer (#141): register every successful tool call so
+            // the model can cite it for verified claims. Errored / denied /
+            // cancelled envelopes never become evidence.
+            if (envelope.status === 'ok') {
+              const previewSrc =
+                typeof serialized === 'string' ? serialized : safeSerialize(serialized);
+              registerEvidence(toolName, argsSnippet, previewSrc);
+            }
             return serialized;
           },
         },
@@ -464,6 +516,16 @@ export function augmentTools(
               const errorInfo = detectToolError(toolName, capturedResult);
               const errSnippet = errorInfo.isError ? errorInfo.snippet : undefined;
               recordOutcome(profileStore, toolName, profileKey, argsSnippet, errSnippet);
+              // Evidence pointer (#141): deferred to setImmediate alongside
+              // profile recording so the "result returned before recording"
+              // invariant from the legacy-path tests still holds.
+              if (!errorInfo.isError) {
+                const previewSrc =
+                  typeof capturedResult === 'string'
+                    ? capturedResult
+                    : safeSerialize(capturedResult);
+                registerEvidence(toolName, argsSnippet, previewSrc);
+              }
             } catch {
               // detectToolError throws are swallowed; recording must never propagate.
             }


### PR DESCRIPTION
## Summary

- Auto-register every successful tool call in the per-turn `ProvenanceStore` as `kind: 'tool-result'`, so the model can attach `[^Sn]` markers to "verified" / "confirmed" / "checked" claims — the action-side complement to issue #173's retrieval citations.
- New `evidencePolicy` (default-on, reason `issue-141-default-on`) mirrors `citationsPolicy` and gates a new `EVIDENCE_PROMPT` in the system prompt. `CITATIONS_PROMPT`'s "shell/MCP not auto-registered" line is reversed.
- `augmentTools` extended with `provenance` + `evidenceEnabled`; both the BernardTool envelope path and the legacy/MCP path register on success. Errors, denies, and cancels are skipped. Store-level dedup keeps repeat identical calls to one entry.

## Why

Closes #141. Today Bernard says "verified X" without a structured pointer to the tool call that proves it — proofs are buried in raw output. `SourceKind` already reserved `'tool-result'` from #173 but no tool emitted it. This wires that kind end-to-end so the existing Shift+Tab overlay, `cite` tool, and `<available_sources>` block all surface tool evidence next to web/file/memory citations with zero UI changes.

## Test plan

- [x] `npm run build` — green
- [x] `npx vitest run` — 2546/2546 pass
- [x] New `src/policy/evidence.test.ts` — sub-policy defaults
- [x] Updated `src/policy/engine.test.ts` — `evidence` key present in decision + reasons
- [x] New cases in `src/tools/augment.test.ts` (7) — envelope success, error skip, dedup, legacy success/error, `evidenceEnabled: false`, missing-store fallthrough
- [ ] Manual REPL smoke: "create /tmp/bernard-evidence.txt with the word hello, then verify it exists." Expect model to call `file_write` + `shell ls`, then output `Verified — the file exists. [^Sn]`. Confirm via Shift+Tab overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)