### PR TITLE
feat(repl): first-class Agent Status overlay (closes #140)

### DIFF
--- a/src/agent-status.ts
+++ b/src/agent-status.ts
@@ -181,12 +181,29 @@ export function buildAgentStatusPanel(inputs: AgentStatusInputs, t: Theme): stri
 /**
  * Plain-text variant of {@link buildAgentStatusPanel} for log files, cron
  * runs, and non-TTY contexts. Identical layout but without ANSI escapes.
+ *
+ * Implemented as a fully-typed Theme with identity style functions so that
+ * any future renderer call to a color helper (e.g. `accent`, `muted`)
+ * compiles and degrades to plain text instead of throwing.
  */
 export function renderAgentStatusPlain(inputs: AgentStatusInputs): string {
-  const noopTheme = {
-    dim: (s: string) => s,
-    success: (s: string) => s,
-    error: (s: string) => s,
-  } as unknown as Theme;
-  return buildAgentStatusPanel(inputs, noopTheme).join('\n');
+  return buildAgentStatusPanel(inputs, IDENTITY_THEME).join('\n');
 }
+
+const identity = (s: string) => s;
+
+const IDENTITY_THEME: Theme = {
+  name: 'plain',
+  accent: identity,
+  accentBold: identity,
+  muted: identity,
+  text: identity,
+  toolCall: identity,
+  error: identity,
+  success: identity,
+  dim: identity,
+  dimItalic: identity,
+  warning: identity,
+  prefixColors: [identity, identity, identity, identity],
+  ansi: { prompt: '', hintCmd: '', hintDesc: '', warning: '', reset: '' },
+};

--- a/src/agent-status.ts
+++ b/src/agent-status.ts
@@ -1,0 +1,192 @@
+import type { Theme } from './theme.js';
+import type { PolicyDecision } from './policy/types.js';
+import type { ResolvedEntry } from './reference-resolver.js';
+import type { Step } from './plan-store.js';
+
+/**
+ * Snapshot of "what Bernard believes its operating state is" for one turn.
+ *
+ * Every field is derived from data that already flows through the agent loop
+ * — there is no `set_status` tool and no agent-prompt change. The Agent class
+ * caches each piece as it passes through `processInput`; the REPL aggregates
+ * them on demand when the user opens the Shift+Tab viewer. Issue #140.
+ */
+export interface AgentStatusInputs {
+  /** The user's most recent turn (raw, pre-rewrite). `null` before any turn. */
+  goal: string | null;
+  permissions: {
+    /** Mirrors `BernardConfig.toolMode`. */
+    toolMode: 'read-only' | 'write';
+    /** Mirrors `BernardConfig.confirmMode`. */
+    confirmMode: 'off' | 'auto' | 'strict';
+    /** Number of tools the user opted into via "Enable for this tool, this session". */
+    sessionAllowedCount: number;
+  };
+  /** Last `PolicyResult.decision`. Drives Strategy + Response shape rows. */
+  constraints: PolicyDecision | null;
+  /** Reference-resolver entries this turn (resolved phrases). */
+  assumptions: ResolvedEntry[];
+  /** Active plan step: `in_progress` if any, else the first `pending`, else null. */
+  planStep: Step | null;
+  planSummary: { done: number; total: number };
+  /** Result of the most recent PAC critic. `null` if no sub-agent has run. */
+  lastVerification: VerificationEntry | null;
+}
+
+export interface VerificationEntry {
+  verdict: 'pass' | 'fail';
+  reason: string;
+  /** Free-form label of what was verified (e.g. sub-agent task summary). */
+  source: string;
+}
+
+/**
+ * Small per-session store for the most recent PAC critic verdict.
+ *
+ * Lives on `AgentContext.verification` so sub-agent dispatch sites can write
+ * back without holding an Agent reference. Last-write-wins (this is a
+ * snapshot, not a log). The Agent clears it at the top of each `processInput`
+ * so a stale verdict from a prior turn doesn't show up in the status panel.
+ */
+export class VerificationStore {
+  private last: VerificationEntry | null = null;
+
+  setLast(entry: VerificationEntry): void {
+    this.last = entry;
+  }
+
+  getLast(): VerificationEntry | null {
+    return this.last;
+  }
+
+  clear(): void {
+    this.last = null;
+  }
+}
+
+/**
+ * Picks the most informative plan step to display: the first `in_progress`,
+ * else the first `pending`, else null (everything is terminal).
+ */
+export function pickActiveStep(steps: Step[]): Step | null {
+  return (
+    steps.find((s) => s.status === 'in_progress') ??
+    steps.find((s) => s.status === 'pending') ??
+    null
+  );
+}
+
+export function summarizePlan(steps: Step[]): { done: number; total: number } {
+  return {
+    done: steps.filter((s) => s.status === 'done').length,
+    total: steps.length,
+  };
+}
+
+const LABEL_WIDTH = 15;
+const MAX_VALUE_CHARS = 200;
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+function row(label: string, value: string, t: Theme): string {
+  const padded = label.padEnd(LABEL_WIDTH);
+  return `${t.dim(padded)}${value}`;
+}
+
+function continuation(value: string): string {
+  return `${' '.repeat(LABEL_WIDTH)}${value}`;
+}
+
+function strategyValue(d: PolicyDecision | null): string {
+  if (!d) return '(none)';
+  return d.strategyId ?? 'normal';
+}
+
+function responseShapeValue(d: PolicyDecision | null): string {
+  if (!d) return '(none)';
+  const parts: string[] = [];
+  if (d.concise?.enabled) parts.push('concise');
+  if (d.citations?.requireForFactualClaims) parts.push('citations: required');
+  if (d.evidence?.requireForVerifiedClaims) parts.push('evidence: required');
+  return parts.length > 0 ? parts.join(' · ') : 'default';
+}
+
+function permissionsValue(p: AgentStatusInputs['permissions']): string {
+  const base = `tools: ${p.toolMode} · confirm: ${p.confirmMode}`;
+  if (p.sessionAllowedCount > 0) {
+    return `${base} (${p.sessionAllowedCount} session-allowed)`;
+  }
+  return base;
+}
+
+/**
+ * Renders the Agent Status panel as themed ANSI lines suitable for
+ * {@link setPinnedRegion}.
+ *
+ * Empty sections render as `(none)` rather than hiding — predictability
+ * over compactness for an inspection tool. Callers are responsible for
+ * adding a tab strip header above this output (the REPL does this so the
+ * same builder can drive cron logs).
+ */
+export function buildAgentStatusPanel(inputs: AgentStatusInputs, t: Theme): string[] {
+  const lines: string[] = [];
+
+  lines.push(row('Goal', inputs.goal ? truncate(inputs.goal, MAX_VALUE_CHARS) : '(none)', t));
+
+  lines.push(row('Permissions', permissionsValue(inputs.permissions), t));
+
+  lines.push(row('Strategy', strategyValue(inputs.constraints), t));
+  lines.push(row('Response shape', responseShapeValue(inputs.constraints), t));
+
+  if (inputs.assumptions.length === 0) {
+    lines.push(row('Assumptions', '(none)', t));
+  } else {
+    inputs.assumptions.forEach((a, i) => {
+      const text = `"${a.phrase}" → ${truncate(a.resolvedTo, 80)} (${a.sourceKey})`;
+      lines.push(i === 0 ? row('Assumptions', text, t) : continuation(text));
+    });
+  }
+
+  if (inputs.planStep) {
+    const { id, status, description, verification } = inputs.planStep;
+    const { done, total } = inputs.planSummary;
+    const header = `[${status}] ${id} of ${total} — ${truncate(description, 120)}`;
+    lines.push(row('Plan step', header, t));
+    if (verification) {
+      lines.push(continuation(t.dim(`verify: ${truncate(verification, 120)}`)));
+    }
+    if (done > 0 && done < total) {
+      lines.push(continuation(t.dim(`(${done}/${total} done)`)));
+    }
+  } else {
+    lines.push(row('Plan step', '(none)', t));
+  }
+
+  if (inputs.lastVerification) {
+    const v = inputs.lastVerification;
+    const tag = v.verdict === 'pass' ? t.success('PASS') : t.error('FAIL');
+    const body = ` — ${truncate(v.reason, 120)}`;
+    const tail = v.source ? t.dim(`  (${truncate(v.source, 60)})`) : '';
+    lines.push(row('Last verify', `${tag}${body}${tail}`, t));
+  } else {
+    lines.push(row('Last verify', '(none)', t));
+  }
+
+  return lines;
+}
+
+/**
+ * Plain-text variant of {@link buildAgentStatusPanel} for log files, cron
+ * runs, and non-TTY contexts. Identical layout but without ANSI escapes.
+ */
+export function renderAgentStatusPlain(inputs: AgentStatusInputs): string {
+  const noopTheme = {
+    dim: (s: string) => s,
+    success: (s: string) => s,
+    error: (s: string) => s,
+  } as unknown as Theme;
+  return buildAgentStatusPanel(inputs, noopTheme).join('\n');
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -47,6 +47,8 @@ import type { AgentContext } from './framework/context.js';
 import { DefaultPolicyEngine, isReactEffective } from './policy/index.js';
 import type { PolicyEngine, PolicyResult } from './policy/index.js';
 import { extractCitationMarkers, type SourceItem } from './provenance.js';
+import type { Step } from './plan-store.js';
+import type { VerificationEntry } from './agent-status.js';
 
 // `buildSystemPrompt` lives in agent-prompt.ts (extracted to avoid a circular
 // import with framework/agents/main.ts). Re-exported here so existing imports
@@ -112,6 +114,8 @@ export class Agent {
   private planStore: PlanStore = new PlanStore();
   private policyEngine: PolicyEngine = new DefaultPolicyEngine();
   private lastPolicyResult?: PolicyResult;
+  private lastUserInput: string | null = null;
+  private lastResolvedReferences: ResolvedEntry[] = [];
 
   private ctx: AgentContext;
 
@@ -179,6 +183,26 @@ export class Agent {
     return this.lastPolicyResult;
   }
 
+  /** Most recent raw user input. `null` before any turn. Issue #140. */
+  getLastUserInput(): string | null {
+    return this.lastUserInput;
+  }
+
+  /** Reference-resolver entries from the most recent turn. Issue #140. */
+  getLastResolvedReferences(): ResolvedEntry[] {
+    return this.lastResolvedReferences;
+  }
+
+  /** Most recent PAC critic verdict (or null). Issue #140. */
+  getLastVerification(): VerificationEntry | null {
+    return this.ctx.verification.getLast();
+  }
+
+  /** Snapshot of the current plan (in-memory, per-turn). Issue #140. */
+  getPlanSnapshot(): Step[] {
+    return this.planStore.view();
+  }
+
   /**
    * Returns the live `AgentContext` (with the most recent `policyDecision`
    * threaded in by `processInput`). The Agent class re-points `this.ctx`
@@ -220,6 +244,11 @@ export class Agent {
     resolvedReferences?: ResolvedEntry[],
   ): Promise<void> {
     this.lastStepLimitHit = false;
+    // Cache per-turn snapshot inputs for the Agent Status overlay (#140).
+    // Last-write-wins — the overlay is a snapshot, not a log.
+    this.lastUserInput = userInput;
+    this.lastResolvedReferences = resolvedReferences ?? [];
+    this.ctx.verification.clear();
 
     // Resolve every cross-cutting heuristic for this turn in one place.
     // Sub-systems read the decision off `this.ctx.policyDecision` (e.g.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -190,7 +190,7 @@ export class Agent {
 
   /** Reference-resolver entries from the most recent turn. Issue #140. */
   getLastResolvedReferences(): ResolvedEntry[] {
-    return this.lastResolvedReferences;
+    return [...this.lastResolvedReferences];
   }
 
   /** Most recent PAC critic verdict (or null). Issue #140. */
@@ -627,6 +627,14 @@ export class Agent {
     this.lastStepLimitHit = false;
     this.planStore.clear();
     this.lastPolicyResult = undefined;
+    // Drop per-turn snapshots so the Shift+Tab viewer doesn't show prior-
+    // session goal / assumptions / sources / verification after a reset.
+    this.lastUserInput = null;
+    this.lastResolvedReferences = [];
+    this.lastSources = [];
+    this.lastCitedSources = [];
+    this.ctx.verification.clear();
+    this.ctx.provenance.clear();
     if (this.ctx.policyDecision) {
       this.ctx = { ...this.ctx, policyDecision: undefined };
     }

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -18,6 +18,7 @@ import {
   type CronInput,
 } from '../framework/agents/index.js';
 import { runDefinition } from '../framework/agents/run.js';
+import { renderAgentStatusPlain, type AgentStatusInputs } from '../agent-status.js';
 
 export {
   /** Re-exported so existing imports against the runner module keep working. */
@@ -136,6 +137,26 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
     };
     const { formatted: output } = await runDefinition(ctx, def, input);
 
+    // Agent Status snapshot for cron parity with the interactive Shift+Tab
+    // viewer (#140). Cron doesn't run the Policy Engine and doesn't expose a
+    // plan store, so only the fields cron actually populates carry data;
+    // everything else renders as `(none)`. Appended after the run's own output
+    // so existing log readers still parse `finalOutput` cleanly.
+    const statusInputs: AgentStatusInputs = {
+      goal: job.prompt,
+      permissions: {
+        toolMode: config.toolMode,
+        confirmMode: config.confirmMode,
+        sessionAllowedCount: 0,
+      },
+      constraints: null,
+      assumptions: [],
+      planStep: null,
+      planSummary: { done: 0, total: 0 },
+      lastVerification: ctx.verification.getLast(),
+    };
+    const finalOutputWithStatus = `${output}\n\n--- Agent Status ---\n${renderAgentStatusPlain(statusInputs)}`;
+
     try {
       const totalUsage = steps.reduce(
         (acc, s) => ({
@@ -154,7 +175,7 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
         completedAt: new Date().toISOString(),
         durationMs: Date.now() - startMs,
         success: true,
-        finalOutput: output,
+        finalOutput: finalOutputWithStatus,
         steps,
         totalUsage,
       });

--- a/src/framework/context.ts
+++ b/src/framework/context.ts
@@ -9,6 +9,7 @@ import type { RAGStore } from '../rag.js';
 import type { PolicyDecision } from '../policy/types.js';
 import type { ToolOptions } from '../tools/types.js';
 import { ProvenanceStore } from '../provenance.js';
+import { VerificationStore } from '../agent-status.js';
 
 export interface AgentContextStores {
   memory: MemoryStore;
@@ -43,6 +44,14 @@ export interface AgentContext {
    * visible in the parent's viewer. Issue #173.
    */
   provenance: ProvenanceStore;
+  /**
+   * Per-session snapshot of the most recent PAC critic verdict. Written by
+   * sub-agent dispatch sites (`tools/subagent.ts`) and read by the Agent
+   * Status overlay (issue #140). Shared by reference with sub-agent /
+   * tool-wrapper contexts so a nested PAC run still updates the parent's
+   * snapshot.
+   */
+  verification: VerificationStore;
 }
 
 export interface AssembleContextInput {
@@ -52,6 +61,7 @@ export interface AssembleContextInput {
   rag?: RAGStore;
   stores?: Partial<AgentContextStores>;
   provenance?: ProvenanceStore;
+  verification?: VerificationStore;
 }
 
 export function assembleContext(input: AssembleContextInput): AgentContext {
@@ -74,5 +84,6 @@ export function assembleContext(input: AssembleContextInput): AgentContext {
     rag: input.rag,
     toolOptions: input.toolOptions,
     provenance: input.provenance ?? new ProvenanceStore(),
+    verification: input.verification ?? new VerificationStore(),
   };
 }

--- a/src/framework/context.ts
+++ b/src/framework/context.ts
@@ -45,11 +45,13 @@ export interface AgentContext {
    */
   provenance: ProvenanceStore;
   /**
-   * Per-session snapshot of the most recent PAC critic verdict. Written by
-   * sub-agent dispatch sites (`tools/subagent.ts`) and read by the Agent
-   * Status overlay (issue #140). Shared by reference with sub-agent /
-   * tool-wrapper contexts so a nested PAC run still updates the parent's
-   * snapshot.
+   * Per-turn snapshot of the most recent PAC critic verdict. Cleared at the
+   * top of every `Agent.processInput` (and on `Agent.clearHistory`) so a
+   * stale verdict never shows up in the Status panel after a new turn or
+   * session reset. Written by sub-agent dispatch sites (`tools/subagent.ts`)
+   * and read by the Agent Status overlay (issue #140). Shared by reference
+   * with sub-agent / tool-wrapper contexts so a nested PAC run still
+   * updates the parent's snapshot.
    */
   verification: VerificationStore;
 }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -76,6 +76,12 @@ import {
 import type { SupportedSdk } from './providers/types.js';
 import { getTheme, setTheme, getThemeKeys, getActiveThemeKey, THEMES } from './theme.js';
 import type { SourceItem } from './provenance.js';
+import {
+  buildAgentStatusPanel,
+  pickActiveStep,
+  summarizePlan,
+  type AgentStatusInputs,
+} from './agent-status.js';
 import { interactiveUpdate, getLocalVersion } from './update.js';
 import { CronStore } from './cron/store.js';
 import { isDaemonRunning } from './cron/client.js';
@@ -714,21 +720,40 @@ export async function startRepl(
   }
 
   /**
-   * Shift+Tab toggles the sources viewer for the last response. Issue #173.
+   * Shift+Tab cycles a pinned inspection viewer above the prompt. Issue #140
+   * extended the original `<sources>`-only viewer (#173) into a tab strip so
+   * we can add more panels (Agent Status now, room for more later).
    *
    * `\x1b[Z` is the canonical Shift+Tab CSI; Node's readline usually emits
    * `{ name: 'tab', shift: true }` for it but a few terminals deliver the
    * raw sequence without the shift flag — we check both.
    *
-   * The first press pins a `<sources>` region above the prompt; the second
-   * press clears it. Esc also clears (handled by an existing escape branch).
-   * If the last turn registered no citations, the keystroke is a no-op.
+   * Order: closed → status → sources → closed. Esc also closes (handled by an
+   * existing escape branch). A new turn invalidates whichever tab was open.
+   * Only one tab is pinned at a time, under the region id `'viewer'`.
    */
-  let sourcesViewerOpen = false;
+  type ViewerTab = 'status' | 'sources';
+  const VIEWER_TABS: ViewerTab[] = ['status', 'sources'];
+  const VIEWER_LABELS: Record<ViewerTab, string> = {
+    status: 'Agent Status',
+    sources: 'Sources',
+  };
+  let viewerTab: ViewerTab | null = null;
+
+  function buildViewerHeader(active: ViewerTab, title: string): string[] {
+    const t = getTheme();
+    const strip = VIEWER_TABS.map((tab) =>
+      tab === active ? t.accentBold(`[${VIEWER_LABELS[tab]}]`) : t.dim(VIEWER_LABELS[tab]),
+    ).join('  ');
+    return [`${t.accentBold(`▼ ${title}`)}  ${t.dim('·')}  ${strip}`];
+  }
+
   function buildSourcesPanel(sources: SourceItem[], title: string): string[] {
     const t = getTheme();
-    const lines: string[] = [];
-    lines.push(t.accentBold(`▼ ${title}`));
+    const lines: string[] = buildViewerHeader('sources', title);
+    if (sources.length === 0) {
+      lines.push(t.dim('(no sources from the last turn)'));
+    }
     for (const s of sources) {
       const head = `${t.accent(`[^${s.id}]`)} ${t.dim(`(${s.kind})`)} ${s.label}`;
       lines.push(head);
@@ -740,44 +765,79 @@ export async function startRepl(
         lines.push(`    ${t.dim(preview)}`);
       }
     }
-    lines.push(t.dim('Shift+Tab or Esc to close'));
+    lines.push(t.dim('Shift+Tab to cycle · Esc to close'));
     return lines;
   }
-  function renderSourcesViewer(): void {
-    const cited = agent.getLastCitedSources();
-    if (cited.length === 0) {
-      // No cited sources — fall back to "all available" if any, so the user
-      // can still see what was retrieved this turn.
+
+  function buildStatusPanel(): string[] {
+    const t = getTheme();
+    const planSteps = agent.getPlanSnapshot();
+    const inputs: AgentStatusInputs = {
+      goal: agent.getLastUserInput(),
+      permissions: {
+        toolMode: config.toolMode,
+        confirmMode: config.confirmMode,
+        sessionAllowedCount: sessionToolAllowlist.size,
+      },
+      constraints: agent.getLastPolicyDecision()?.decision ?? null,
+      assumptions: agent.getLastResolvedReferences(),
+      planStep: pickActiveStep(planSteps),
+      planSummary: summarizePlan(planSteps),
+      lastVerification: agent.getLastVerification(),
+    };
+    const lines = buildViewerHeader('status', 'Agent Status');
+    lines.push(...buildAgentStatusPanel(inputs, t));
+    lines.push(t.dim('Shift+Tab to cycle · Esc to close'));
+    return lines;
+  }
+
+  function renderViewer(tab: ViewerTab): void {
+    if (tab === 'status') {
+      setPinnedRegion('viewer', buildStatusPanel());
+    } else {
+      const cited = agent.getLastCitedSources();
       const all = agent.getLastSources();
-      if (all.length === 0) {
-        sourcesViewerOpen = false;
-        return;
-      }
-      setPinnedRegion(
-        'sources',
-        buildSourcesPanel(all, 'Available sources (last turn — none cited)'),
-      );
-      sourcesViewerOpen = true;
+      const sources = cited.length > 0 ? cited : all;
+      const title =
+        cited.length > 0
+          ? 'Cited sources (last response)'
+          : all.length > 0
+            ? 'Available sources (last turn — none cited)'
+            : 'Sources';
+      setPinnedRegion('viewer', buildSourcesPanel(sources, title));
+    }
+    viewerTab = tab;
+  }
+
+  function closeViewer(): void {
+    if (viewerTab === null) return;
+    clearPinnedRegion('viewer');
+    viewerTab = null;
+  }
+
+  function cycleViewer(): void {
+    // null → status → sources → null
+    if (viewerTab === null) {
+      renderViewer(VIEWER_TABS[0]);
       return;
     }
-    setPinnedRegion('sources', buildSourcesPanel(cited, 'Cited sources (last response)'));
-    sourcesViewerOpen = true;
-  }
-  function closeSourcesViewer(): void {
-    if (!sourcesViewerOpen) return;
-    clearPinnedRegion('sources');
-    sourcesViewerOpen = false;
+    const idx = VIEWER_TABS.indexOf(viewerTab);
+    const next = VIEWER_TABS[idx + 1];
+    if (!next) {
+      closeViewer();
+      return;
+    }
+    renderViewer(next);
   }
 
   process.stdin.on('keypress', (_str: string, key: any) => {
     if (!key) return;
 
-    // Shift+Tab → toggle the sources viewer. Check first so Esc/processing
+    // Shift+Tab → cycle the viewer tabs. Check first so Esc/processing
     // branches below don't intercept it.
     const isShiftTab = (key.name === 'tab' && key.shift) || key.sequence === '\x1b[Z';
     if (isShiftTab && !processing && !menuAbortController) {
-      if (sourcesViewerOpen) closeSourcesViewer();
-      else renderSourcesViewer();
+      cycleViewer();
       return;
     }
 
@@ -786,8 +846,8 @@ export async function startRepl(
       return;
     }
 
-    if (key.name === 'escape' && sourcesViewerOpen && !processing) {
-      closeSourcesViewer();
+    if (key.name === 'escape' && viewerTab !== null && !processing) {
+      closeViewer();
       return;
     }
 
@@ -2683,8 +2743,8 @@ Remember: the systemPrompt should read like a persona definition — who this sp
 
     processing = true;
     interrupted = false;
-    // A new turn invalidates any pinned sources viewer from the previous one.
-    closeSourcesViewer();
+    // A new turn invalidates any pinned viewer tab from the previous one.
+    closeViewer();
     try {
       initSpinner();
       await agent.processInput(agentInput, inlineImages, resolvedEntries);

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -84,6 +84,14 @@ export function createSubAgentTool(ctx: AgentContext): Tool {
           // footer); re-capping here would risk truncating that footer away.
           const pacResult = await runPAC(ctx, { task, context, slotId: id }, runOpts);
           formatted = pacResult.formatted;
+          // Snapshot the verdict for the Agent Status overlay (#140). Last
+          // write wins across nested / parallel sub-agents — fine, this is a
+          // user-facing peek, not a log.
+          ctx.verification.setLast({
+            verdict: pacResult.verdict,
+            reason: pacResult.reason,
+            source: task.slice(0, 80),
+          });
         } else {
           const def = definitions.get<SubAgentInput, string>('sub');
           const result = await runDefinition(ctx, def, { task, context, slotId: id }, runOpts);

--- a/src/tools/tool-wrapper-provenance.test.ts
+++ b/src/tools/tool-wrapper-provenance.test.ts
@@ -23,6 +23,7 @@ vi.mock('./specialist-run.js', () => ({ createSpecialistRunTool: vi.fn(() => ({}
 
 import { ctxToToolWrapperDeps, depsToCtx } from './tool-wrapper-run.js';
 import { ProvenanceStore } from '../provenance.js';
+import { VerificationStore } from '../agent-status.js';
 import type { AgentContext } from '../framework/context.js';
 
 function makeCtx(overrides: Partial<AgentContext> = {}): AgentContext {
@@ -40,6 +41,7 @@ function makeCtx(overrides: Partial<AgentContext> = {}): AgentContext {
     rag: undefined,
     toolOptions: {} as any,
     provenance: new ProvenanceStore(),
+    verification: new VerificationStore(),
   };
   return { ...base, ...overrides } as AgentContext;
 }
@@ -79,5 +81,37 @@ describe('ToolWrapperDeps provenance round-trip (issue #173)', () => {
     const innerCtx = depsToCtx(deps);
     expect(innerCtx.provenance).toBeInstanceOf(ProvenanceStore);
     expect(innerCtx.provenance.size()).toBe(0);
+  });
+});
+
+describe('ToolWrapperDeps verification round-trip (issue #140)', () => {
+  it('ctxToToolWrapperDeps forwards the same VerificationStore reference', () => {
+    const ctx = makeCtx();
+    const deps = ctxToToolWrapperDeps(ctx);
+    expect(deps.verification).toBe(ctx.verification);
+  });
+
+  it('depsToCtx preserves the original store reference (shared by reference)', () => {
+    const ctx = makeCtx();
+    const deps = ctxToToolWrapperDeps(ctx);
+    const innerCtx = depsToCtx(deps);
+    expect(innerCtx.verification).toBe(ctx.verification);
+    // A PAC verdict written inside the inner ctx must be visible to the
+    // parent's getLast() — that's the whole point of sharing the store.
+    innerCtx.verification.setLast({
+      verdict: 'pass',
+      reason: 'looks good',
+      source: 'nested sub-agent',
+    });
+    expect(ctx.verification.getLast()?.verdict).toBe('pass');
+    expect(ctx.verification.getLast()?.reason).toBe('looks good');
+  });
+
+  it('depsToCtx supplies a fresh store when deps.verification is absent', () => {
+    const deps = ctxToToolWrapperDeps(makeCtx());
+    delete (deps as any).verification;
+    const innerCtx = depsToCtx(deps);
+    expect(innerCtx.verification).toBeInstanceOf(VerificationStore);
+    expect(innerCtx.verification.getLast()).toBeNull();
   });
 });

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -20,6 +20,7 @@ import { ToolProfileStore } from '../tool-profiles.js';
 import type { AgentContext } from '../framework/context.js';
 import type { PolicyDecision } from '../policy/types.js';
 import { ProvenanceStore } from '../provenance.js';
+import { VerificationStore } from '../agent-status.js';
 import { type WrapperResult } from '../structured-output.js';
 import { appendReasoningLog } from '../reasoning-log.js';
 import { capSubagentResult, SUBAGENT_RESULT_MAX_CHARS } from './result-cap.js';
@@ -114,6 +115,12 @@ export interface ToolWrapperDeps {
    */
   provenance?: ProvenanceStore;
   /**
+   * Parent turn's VerificationStore. Forwarded so a PAC run dispatched from
+   * inside a tool-wrapper still updates the parent agent's Agent Status
+   * overlay. Issue #140.
+   */
+  verification?: VerificationStore;
+  /**
    * Parent turn's policy decision. Forwarded so the inner wrapper
    * inherits the user's `toolMode` (#179) — otherwise the augment layer
    * defaults to `'write'` and any write tool the wrapper calls bypasses
@@ -138,6 +145,7 @@ export function ctxToToolWrapperDeps(ctx: AgentContext): ToolWrapperDeps {
     candidateStore: ctx.stores.candidates,
     toolProfileStore: ctx.stores.toolProfiles,
     provenance: ctx.provenance,
+    verification: ctx.verification,
     policyDecision: ctx.policyDecision,
   };
 }
@@ -158,6 +166,7 @@ export function depsToCtx(deps: ToolWrapperDeps): AgentContext {
     rag: deps.ragStore,
     toolOptions: deps.options,
     provenance: deps.provenance ?? new ProvenanceStore(),
+    verification: deps.verification ?? new VerificationStore(),
     ...(deps.policyDecision ? { policyDecision: deps.policyDecision } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- Shift+Tab now cycles a pinned inspection viewer above the prompt: `closed → Agent Status → Sources → closed`. Adds a tab strip header so the active tab is obvious and more panels can be added later.
- New Agent Status panel exposes goal, permissions (toolMode + confirmMode + session-allowed count), strategy + response shape (from the last policy decision), resolved assumptions, the active plan step + verification, and the most recent PAC critic verdict — all derived from data that already flows through the agent loop. No new agent prompts, no `set_status` tool.
- A small `VerificationStore` lives on `AgentContext` (shared by reference into sub-agent / tool-wrapper contexts, matching the existing `provenance` pattern) so PAC verdicts emitted deep in the dispatch stack still update the parent overlay. Cron appends the same panel to `finalOutput` for parity with interactive runs.

## Files
- `src/agent-status.ts` (new) — `AgentStatusInputs`, `VerificationStore`, themed + plain renderers, plan-step picker.
- `src/agent.ts` — caches `lastUserInput` / `lastResolvedReferences` per turn, clears verification at turn start, exposes new getters.
- `src/framework/context.ts` — `verification: VerificationStore` on `AgentContext` + `assembleContext` default.
- `src/tools/subagent.ts` — writes the PAC verdict into `ctx.verification` after each `runPAC`.
- `src/tools/tool-wrapper-run.ts` — forwards `verification` through `ToolWrapperDeps` ↔ `depsToCtx`.
- `src/repl.ts` — Shift+Tab handler refactored into a cycling viewer; pinned region renamed `sources` → `viewer`.
- `src/cron/runner.ts` — appends `renderAgentStatusPlain(...)` to `finalOutput` on success.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 2553 tests pass across 112 files
- [x] `npm run lint` — no errors
- [x] Renderer smoke (populated + empty states) — labels align, `(none)` placeholders show predictably
- [ ] Manual: open REPL, press Shift+Tab pre-turn → Agent Status (mostly `(none)`); again → Sources; again → closed
- [ ] Manual: trigger a multi-step ReAct turn; Shift+Tab shows active plan step and strategy `react`
- [ ] Manual: dispatch a sub-agent so PAC runs; Shift+Tab shows `Last verify: PASS — …`
- [ ] Manual: run a cron job; `bernard cron logs <id>` tail contains the `--- Agent Status ---` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)