### PR TITLE
test(harness): fixture-driven eval harness for heuristics (closes #178)

### DIFF
--- a/src/__tests__/eval-harness.test.ts
+++ b/src/__tests__/eval-harness.test.ts
@@ -77,12 +77,16 @@ const MODEL_POLICY_KEYS = {
   apiKeys: { anthropic: 'sk-ant-test', openai: 'sk-openai-test', xai: 'xai-test' },
 } satisfies Partial<BernardConfig>;
 
-function tag(fixtureName: string, type: InvariantSpec['type']): string {
-  return `[fixture: ${fixtureName}] [invariant: ${type}]`;
+function tag(fixtureName: string, type: InvariantSpec['type'], idx: number): string {
+  return `[fixture: ${fixtureName}] [invariant: ${type}] [case: #${idx}]`;
 }
 
-function runInvariant(fixtureName: string, inv: InvariantSpec): void {
-  const t = tag(fixtureName, inv.type);
+function assertNever(x: never): never {
+  throw new Error(`eval-harness: unhandled invariant variant: ${JSON.stringify(x)}`);
+}
+
+function runInvariant(fixtureName: string, inv: InvariantSpec, idx: number): void {
+  const t = tag(fixtureName, inv.type, idx);
   switch (inv.type) {
     case 'system_prompt_excludes': {
       const prompt = buildSystemPrompt(BASE_CONFIG);
@@ -126,11 +130,6 @@ function runInvariant(fixtureName: string, inv: InvariantSpec): void {
       expect(resolved, t).toEqual(inv.expectResolved);
       return;
     }
-    case 'unverified_text_has_no_marker': {
-      const resolved = extractCitationMarkers(inv.text, new ProvenanceStore());
-      expect(resolved, `${t} unsupported text leaked a marker`).toEqual([]);
-      return;
-    }
     case 'tool_cache_excluded_when_write': {
       expect(isCacheable(inv.meta), `${t} write-effecting tool was marked cacheable`).toBe(false);
       return;
@@ -172,6 +171,8 @@ function runInvariant(fixtureName: string, inv: InvariantSpec): void {
       expect(decision.resetAll, t).toBe(inv.expectResetAll);
       return;
     }
+    default:
+      assertNever(inv);
   }
 }
 
@@ -182,7 +183,19 @@ describe.each(ALL_FIXTURES)('eval-harness — $name', (fixture) => {
     _resetModelPolicyLogCacheForTests();
   });
 
-  it.each(fixture.invariants.map((inv, idx) => ({ inv, idx })))('$inv.type [#$idx]', ({ inv }) => {
-    runInvariant(fixture.name, inv);
-  });
+  it.each(fixture.invariants.map((inv, idx) => ({ type: inv.type, idx, inv })))(
+    '$type [#$idx]',
+    ({ inv, idx }) => {
+      runInvariant(fixture.name, inv, idx);
+    },
+  );
+});
+
+describe('eval-harness — meta', () => {
+  it.each(ALL_FIXTURES.map((f) => ({ name: f.name, fixture: f })))(
+    '$name has at least one invariant',
+    ({ name, fixture }) => {
+      expect(fixture.invariants.length, `${name} declares no invariants`).toBeGreaterThan(0);
+    },
+  );
 });

--- a/src/__tests__/eval-harness.test.ts
+++ b/src/__tests__/eval-harness.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Eval/regression harness for Bernard heuristics (issue #178).
+ *
+ * Each fixture under `fixtures/transcripts/*.fixture.ts` declares a list of
+ * `InvariantSpec` entries from a closed discriminated union. This file
+ * dispatches each invariant to the matching pure-function call and asserts
+ * with a self-describing tag, so a failing Vitest line names exactly which
+ * fixture and which invariant regressed without scrolling logs.
+ *
+ * All assertions are pure — no LLM calls. AI SDK clients are mocked
+ * identically to `model-policy.test.ts` so `resolveSiteModel` works.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  anthropic: vi.fn((m: string) => ({ modelId: `anthropic:${m}` })),
+  createAnthropic: vi.fn(() => (m: string) => ({ modelId: `anthropic:${m}` })),
+}));
+vi.mock('@ai-sdk/openai', () => ({
+  openai: { responses: vi.fn((m: string) => ({ modelId: `openai:${m}` })) },
+  createOpenAI: vi.fn(() => ({ responses: (m: string) => ({ modelId: `openai:${m}` }) })),
+}));
+vi.mock('@ai-sdk/xai', () => ({
+  xai: vi.fn((m: string) => ({ modelId: `xai:${m}` })),
+  createXai: vi.fn(() => (m: string) => ({ modelId: `xai:${m}` })),
+}));
+
+import type { BernardConfig } from '../config.js';
+import { buildSystemPrompt } from '../agent-prompt.js';
+import { buildContextMessage } from '../context-message.js';
+import { concisePolicy } from '../policy/concise.js';
+import { scratchPolicy } from '../policy/scratch.js';
+import { makePolicyInput } from '../policy/test-helpers.js';
+import { ProvenanceStore, extractCitationMarkers } from '../provenance.js';
+import { isCacheable } from '../framework/tools/types.js';
+import {
+  CACHE_MISS,
+  clearCache,
+  getCachedResult,
+  setCachedResult,
+} from '../framework/tools/result-cache.js';
+import { clearLLMCache, getCachedLLM, setCachedLLM } from '../llm-cache.js';
+import { resolveSiteModel, _resetModelPolicyLogCacheForTests } from '../model-policy.js';
+
+import type { Fixture, InvariantSpec } from './fixtures/fixture-schema.js';
+import { promptBoundaryFixture } from './fixtures/transcripts/prompt-boundary.fixture.js';
+import { contextMessageFixture } from './fixtures/transcripts/context-message.fixture.js';
+import { conciseFixture } from './fixtures/transcripts/concise.fixture.js';
+import { citationsFixture } from './fixtures/transcripts/citations.fixture.js';
+import { cachingFixture } from './fixtures/transcripts/caching.fixture.js';
+import { modelPolicyFixture } from './fixtures/transcripts/model-policy.fixture.js';
+import { scratchFixture } from './fixtures/transcripts/scratch.fixture.js';
+
+const ALL_FIXTURES: Fixture[] = [
+  promptBoundaryFixture,
+  contextMessageFixture,
+  conciseFixture,
+  citationsFixture,
+  cachingFixture,
+  modelPolicyFixture,
+  scratchFixture,
+];
+
+const BASE_CONFIG: BernardConfig = makePolicyInput().config;
+
+/**
+ * Configs handed to `resolveSiteModel` need provider API keys present,
+ * otherwise the tier lookup falls through to `source: 'fallback'` and the
+ * `modelName` defaults to `config.model`. The model-policy fixture asserts
+ * tier picks, so seed the keys here.
+ */
+const MODEL_POLICY_KEYS = {
+  anthropicApiKey: 'sk-ant-test',
+  openaiApiKey: 'sk-openai-test',
+  xaiApiKey: 'xai-test',
+  apiKeys: { anthropic: 'sk-ant-test', openai: 'sk-openai-test', xai: 'xai-test' },
+} satisfies Partial<BernardConfig>;
+
+function tag(fixtureName: string, type: InvariantSpec['type']): string {
+  return `[fixture: ${fixtureName}] [invariant: ${type}]`;
+}
+
+function runInvariant(fixtureName: string, inv: InvariantSpec): void {
+  const t = tag(fixtureName, inv.type);
+  switch (inv.type) {
+    case 'system_prompt_excludes': {
+      const prompt = buildSystemPrompt(BASE_CONFIG);
+      for (const sub of inv.substrings) {
+        expect(prompt, `${t} must not contain "${sub}"`).not.toContain(sub);
+      }
+      return;
+    }
+    case 'system_prompt_includes_when': {
+      const prompt = buildSystemPrompt({ ...BASE_CONFIG, ...inv.condition });
+      expect(prompt, `${t} must contain "${inv.substring}"`).toContain(inv.substring);
+      return;
+    }
+    case 'context_message_role_is_user': {
+      const msg = buildContextMessage(inv.inputs);
+      expect(msg, `${t} buildContextMessage returned null`).not.toBeNull();
+      expect(msg!.role, t).toBe('user');
+      return;
+    }
+    case 'context_message_includes': {
+      const msg = buildContextMessage(inv.inputs);
+      expect(msg, `${t} buildContextMessage returned null`).not.toBeNull();
+      expect(String(msg!.content), `${t} must contain "${inv.substring}"`).toContain(inv.substring);
+      return;
+    }
+    case 'context_message_excludes': {
+      const msg = buildContextMessage(inv.inputs);
+      const content = msg ? String(msg.content) : '';
+      expect(content, `${t} must not contain "${inv.substring}"`).not.toContain(inv.substring);
+      return;
+    }
+    case 'concise_enabled_when': {
+      const decision = concisePolicy(makePolicyInput({ config: inv.config }));
+      expect(decision.enabled, t).toBe(inv.expected);
+      return;
+    }
+    case 'citation_markers_resolve': {
+      const store = new ProvenanceStore();
+      for (const item of inv.storeItems) store.add(item);
+      const resolved = extractCitationMarkers(inv.text, store);
+      expect(resolved, t).toEqual(inv.expectResolved);
+      return;
+    }
+    case 'unverified_text_has_no_marker': {
+      const resolved = extractCitationMarkers(inv.text, new ProvenanceStore());
+      expect(resolved, `${t} unsupported text leaked a marker`).toEqual([]);
+      return;
+    }
+    case 'tool_cache_excluded_when_write': {
+      expect(isCacheable(inv.meta), `${t} write-effecting tool was marked cacheable`).toBe(false);
+      return;
+    }
+    case 'tool_cache_deterministic': {
+      const sentinel = { value: `eval-harness:${inv.meta.name}` };
+      const before = getCachedResult(inv.meta, inv.args);
+      expect(before, `${t} cache should start empty for this key`).toBe(CACHE_MISS);
+      setCachedResult(inv.meta, inv.args, sentinel);
+      const after = getCachedResult(inv.meta, inv.args);
+      expect(after, `${t} round-trip mismatch`).toEqual(sentinel);
+      return;
+    }
+    case 'llm_cache_key_partitions': {
+      setCachedLLM(inv.keyA, 'value-a');
+      const hitA = getCachedLLM(inv.keyA);
+      const missB = getCachedLLM(inv.keyB);
+      expect(hitA, `${t} keyA write/read round-trip failed`).toBe('value-a');
+      expect(missB, `${t} keyB collided with keyA despite differing fields`).toBeUndefined();
+      return;
+    }
+    case 'model_site_resolves_to_tier': {
+      const config: BernardConfig = {
+        ...BASE_CONFIG,
+        ...MODEL_POLICY_KEYS,
+        ...inv.config,
+      };
+      const r = resolveSiteModel(config, inv.site);
+      expect(r.modelName, t).toBe(inv.expectedModelName);
+      return;
+    }
+    case 'scratch_clears_on_subject_change': {
+      const decision = scratchPolicy(
+        makePolicyInput({
+          userInput: inv.userInput,
+          previousUserInput: inv.previousUserInput,
+        }),
+      );
+      expect(decision.resetAll, t).toBe(inv.expectResetAll);
+      return;
+    }
+  }
+}
+
+describe.each(ALL_FIXTURES)('eval-harness — $name', (fixture) => {
+  beforeEach(() => {
+    clearCache();
+    clearLLMCache();
+    _resetModelPolicyLogCacheForTests();
+  });
+
+  it.each(fixture.invariants.map((inv, idx) => ({ inv, idx })))('$inv.type [#$idx]', ({ inv }) => {
+    runInvariant(fixture.name, inv);
+  });
+});

--- a/src/__tests__/fixtures/fixture-schema.ts
+++ b/src/__tests__/fixtures/fixture-schema.ts
@@ -43,7 +43,6 @@ export type InvariantSpec =
       storeItems: SourceItemInput[];
       expectResolved: string[];
     }
-  | { type: 'unverified_text_has_no_marker'; text: string }
   | { type: 'tool_cache_excluded_when_write'; meta: ToolMeta }
   | { type: 'tool_cache_deterministic'; meta: ToolMeta; args: unknown }
   | { type: 'llm_cache_key_partitions'; keyA: LLMCacheKey; keyB: LLMCacheKey }

--- a/src/__tests__/fixtures/fixture-schema.ts
+++ b/src/__tests__/fixtures/fixture-schema.ts
@@ -1,0 +1,81 @@
+import type { BernardConfig } from '../../config.js';
+import type { ContextMessageInputs } from '../../context-message.js';
+import type { ToolMeta } from '../../framework/tools/types.js';
+import type { LLMCacheKey } from '../../llm-cache.js';
+import type { ModelSite } from '../../model-policy.js';
+import type { SourceItemInput } from '../../provenance.js';
+
+/**
+ * Closed discriminated union of invariants the eval harness can assert.
+ * Each variant maps to exactly one pure-function call in the runner
+ * (`src/__tests__/eval-harness.test.ts`). Adding a new heuristic category
+ * means: add a variant here, add a case in the runner switch, add a
+ * fixture file that uses it.
+ *
+ * Issue #178.
+ */
+export type InvariantSpec =
+  | { type: 'system_prompt_excludes'; substrings: string[] }
+  | {
+      type: 'system_prompt_includes_when';
+      condition: Partial<BernardConfig>;
+      substring: string;
+    }
+  | { type: 'context_message_role_is_user'; inputs: ContextMessageInputs }
+  | {
+      type: 'context_message_includes';
+      inputs: ContextMessageInputs;
+      substring: string;
+    }
+  | {
+      type: 'context_message_excludes';
+      inputs: ContextMessageInputs;
+      substring: string;
+    }
+  | {
+      type: 'concise_enabled_when';
+      config: Partial<BernardConfig>;
+      expected: boolean;
+    }
+  | {
+      type: 'citation_markers_resolve';
+      text: string;
+      storeItems: SourceItemInput[];
+      expectResolved: string[];
+    }
+  | { type: 'unverified_text_has_no_marker'; text: string }
+  | { type: 'tool_cache_excluded_when_write'; meta: ToolMeta }
+  | { type: 'tool_cache_deterministic'; meta: ToolMeta; args: unknown }
+  | { type: 'llm_cache_key_partitions'; keyA: LLMCacheKey; keyB: LLMCacheKey }
+  | {
+      type: 'model_site_resolves_to_tier';
+      config: Partial<BernardConfig>;
+      site: ModelSite;
+      expectedModelName: string;
+    }
+  | {
+      type: 'scratch_clears_on_subject_change';
+      userInput: string;
+      previousUserInput: string | undefined;
+      expectResetAll: boolean;
+    };
+
+export type FixtureCategory =
+  | 'prompt-boundary'
+  | 'context-message'
+  | 'concise'
+  | 'citations'
+  | 'caching'
+  | 'model-policy'
+  | 'scratch';
+
+export interface Fixture {
+  name: string;
+  category: FixtureCategory;
+  invariants: InvariantSpec[];
+}
+
+/** Identity helper that lets each fixture file get full TypeScript narrowing on `invariants`. */
+export function defineFixture(f: Fixture): Fixture {
+  return f;
+}

--- a/src/__tests__/fixtures/transcripts/caching.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/caching.fixture.ts
@@ -1,0 +1,48 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #171 — write-effecting tools must never cache; deterministic +
+ * side-effect-free tools round-trip cleanly; LLM cache keys partition on
+ * `modelId` (so a model-mode #170 retier never poisons cache from a
+ * different tier).
+ */
+export const cachingFixture = defineFixture({
+  name: 'caching',
+  category: 'caching',
+  invariants: [
+    {
+      type: 'tool_cache_excluded_when_write',
+      meta: {
+        name: 'fake_shell',
+        kind: 'write',
+        sideEffect: 'local',
+        deterministic: false,
+      },
+    },
+    {
+      type: 'tool_cache_deterministic',
+      meta: {
+        name: 'fake_datetime',
+        kind: 'inert',
+        sideEffect: 'none',
+        deterministic: true,
+      },
+      args: { format: 'iso' },
+    },
+    {
+      type: 'llm_cache_key_partitions',
+      keyA: {
+        siteName: 'rewriter',
+        modelId: 'anthropic:claude-haiku-4-5-20251001',
+        system: 'sys',
+        userContent: 'u',
+      },
+      keyB: {
+        siteName: 'rewriter',
+        modelId: 'anthropic:claude-sonnet-4-5-20250929',
+        system: 'sys',
+        userContent: 'u',
+      },
+    },
+  ],
+});

--- a/src/__tests__/fixtures/transcripts/caching.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/caching.fixture.ts
@@ -16,7 +16,7 @@ export const cachingFixture = defineFixture({
         name: 'fake_shell',
         kind: 'write',
         sideEffect: 'local',
-        deterministic: false,
+        deterministic: true,
       },
     },
     {

--- a/src/__tests__/fixtures/transcripts/citations.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/citations.fixture.ts
@@ -1,0 +1,36 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #173 — `[^Sn]` markers must map to registered ProvenanceStore ids,
+ * and an empty store filters all markers out (so an "unsupported claim with
+ * a fake marker" never registers as cited).
+ */
+export const citationsFixture = defineFixture({
+  name: 'citations',
+  category: 'citations',
+  invariants: [
+    {
+      type: 'citation_markers_resolve',
+      text: 'The README says X. [^S1] And per the notes file, Y. [^S2]',
+      storeItems: [
+        {
+          kind: 'web',
+          label: 'README',
+          contentPreview: 'X is the default',
+          rawRef: 'https://example.com/readme',
+        },
+        {
+          kind: 'file',
+          label: 'notes.md',
+          contentPreview: 'Y is the answer',
+          rawRef: 'notes.md:1-5',
+        },
+      ],
+      expectResolved: ['S1', 'S2'],
+    },
+    {
+      type: 'unverified_text_has_no_marker',
+      text: 'The sky is blue. [^S99] is a fake marker that points nowhere.',
+    },
+  ],
+});

--- a/src/__tests__/fixtures/transcripts/citations.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/citations.fixture.ts
@@ -29,8 +29,10 @@ export const citationsFixture = defineFixture({
       expectResolved: ['S1', 'S2'],
     },
     {
-      type: 'unverified_text_has_no_marker',
+      type: 'citation_markers_resolve',
       text: 'The sky is blue. [^S99] is a fake marker that points nowhere.',
+      storeItems: [],
+      expectResolved: [],
     },
   ],
 });

--- a/src/__tests__/fixtures/transcripts/concise.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/concise.fixture.ts
@@ -1,0 +1,15 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #175 — concise-by-default is on unless explicitly disabled.
+ * `undefined` treats as on (matches `DEFAULT_CONCISE_MODE`).
+ */
+export const conciseFixture = defineFixture({
+  name: 'concise',
+  category: 'concise',
+  invariants: [
+    { type: 'concise_enabled_when', config: { conciseMode: true }, expected: true },
+    { type: 'concise_enabled_when', config: { conciseMode: false }, expected: false },
+    { type: 'concise_enabled_when', config: {}, expected: true },
+  ],
+});

--- a/src/__tests__/fixtures/transcripts/context-message.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/context-message.fixture.ts
@@ -1,0 +1,39 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #172 — the per-turn context message must be a `role:'user'` payload
+ * containing all dynamic data wrapped in `<system_provided_context>`. The
+ * header escapes the wrapper tag as `&lt;system_provided_context&gt;` so a
+ * naive substring scan against the literal open-tag finds exactly one
+ * occurrence (the real wrapper), not two.
+ */
+export const contextMessageFixture = defineFixture({
+  name: 'context-message',
+  category: 'context-message',
+  invariants: [
+    {
+      type: 'context_message_role_is_user',
+      inputs: { mcpServerNames: ['sentinel-mcp'] },
+    },
+    {
+      type: 'context_message_includes',
+      inputs: { mcpServerNames: ['sentinel-mcp'] },
+      substring: 'sentinel-mcp',
+    },
+    {
+      type: 'context_message_includes',
+      inputs: { mcpServerNames: ['sentinel-mcp'] },
+      substring: '<connected_mcp_servers>',
+    },
+    {
+      type: 'context_message_includes',
+      inputs: { mcpServerNames: ['sentinel-mcp'] },
+      substring: '&lt;system_provided_context&gt;',
+    },
+    {
+      type: 'context_message_excludes',
+      inputs: { mcpServerNames: ['<inject>nope</inject>'] },
+      substring: '<inject>',
+    },
+  ],
+});

--- a/src/__tests__/fixtures/transcripts/model-policy.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/model-policy.fixture.ts
@@ -1,0 +1,31 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #170 — per-site model assignment under modelMode. Concrete model
+ * strings come from `PROVIDER_TIERS` in `src/model-policy.ts`; if those
+ * names change, update here too.
+ */
+export const modelPolicyFixture = defineFixture({
+  name: 'model-policy',
+  category: 'model-policy',
+  invariants: [
+    {
+      type: 'model_site_resolves_to_tier',
+      config: { provider: 'anthropic', modelMode: 'optimize-tokens' },
+      site: 'rewriter',
+      expectedModelName: 'claude-haiku-4-5-20251001',
+    },
+    {
+      type: 'model_site_resolves_to_tier',
+      config: { provider: 'anthropic', modelMode: 'balanced' },
+      site: 'main',
+      expectedModelName: 'claude-opus-4-6',
+    },
+    {
+      type: 'model_site_resolves_to_tier',
+      config: { provider: 'anthropic', modelMode: 'off' },
+      site: 'main',
+      expectedModelName: 'claude-sonnet-4-5-20250929',
+    },
+  ],
+});

--- a/src/__tests__/fixtures/transcripts/model-policy.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/model-policy.fixture.ts
@@ -23,9 +23,13 @@ export const modelPolicyFixture = defineFixture({
     },
     {
       type: 'model_site_resolves_to_tier',
-      config: { provider: 'anthropic', modelMode: 'off' },
+      config: {
+        provider: 'anthropic',
+        modelMode: 'off',
+        model: 'claude-some-custom-model',
+      },
       site: 'main',
-      expectedModelName: 'claude-sonnet-4-5-20250929',
+      expectedModelName: 'claude-some-custom-model',
     },
   ],
 });

--- a/src/__tests__/fixtures/transcripts/prompt-boundary.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/prompt-boundary.fixture.ts
@@ -1,0 +1,38 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #172 — the SYSTEM prompt must never carry per-turn dynamic data
+ * (memory, scratch, recalled RAG context, MCP server lists, etc.). Those
+ * arrive as a `role:'user'` message built by `buildContextMessage`.
+ *
+ * If `buildSystemPrompt` ever starts injecting one of these substrings,
+ * `system_prompt_excludes` fires immediately and names exactly what leaked.
+ */
+export const promptBoundaryFixture = defineFixture({
+  name: 'prompt-boundary',
+  category: 'prompt-boundary',
+  invariants: [
+    {
+      type: 'system_prompt_excludes',
+      substrings: [
+        '## Persistent Memory',
+        '## Scratch Notes',
+        '## Recalled Context',
+        '## Resolved References',
+        'Currently connected MCP servers:',
+        'Available specialist agents',
+        'Saved routines the user can invoke',
+      ],
+    },
+    {
+      type: 'system_prompt_includes_when',
+      condition: {},
+      substring: '## MCP Servers',
+    },
+    {
+      type: 'system_prompt_includes_when',
+      condition: { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
+      substring: 'claude-sonnet-4-5-20250929',
+    },
+  ],
+});

--- a/src/__tests__/fixtures/transcripts/scratch.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/scratch.fixture.ts
@@ -1,0 +1,38 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #169 — scratch is wiped on first turn, on `/CLEAR`-style explicit
+ * markers, and when Jaccard token similarity against the previous user
+ * input drops below `config.scratchSubjectThreshold` (0.15 by default).
+ * Same-topic follow-ups keep scratch.
+ */
+export const scratchFixture = defineFixture({
+  name: 'scratch',
+  category: 'scratch',
+  invariants: [
+    {
+      type: 'scratch_clears_on_subject_change',
+      userInput: 'anything',
+      previousUserInput: undefined,
+      expectResetAll: true,
+    },
+    {
+      type: 'scratch_clears_on_subject_change',
+      userInput: '/CLEAR',
+      previousUserInput: 'something we were doing',
+      expectResetAll: true,
+    },
+    {
+      type: 'scratch_clears_on_subject_change',
+      userInput: 'now help me write a poem about lemons',
+      previousUserInput: 'debug the failing test in agent.test.ts please',
+      expectResetAll: true,
+    },
+    {
+      type: 'scratch_clears_on_subject_change',
+      userInput: 'and also rename the variable in agent.test.ts',
+      previousUserInput: 'debug the failing test in agent.test.ts please',
+      expectResetAll: false,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds a declarative eval/regression harness for Bernard's load-bearing heuristics so silent drift gets caught in CI (issue #178).
- One fixture per category — prompt boundary (#172), context-message channel, concise mode (#175), citations (#173), caching (#171), model policy (#170), scratch (#169) — each a list of `InvariantSpec` entries from a closed discriminated union.
- A single Vitest runner (`src/__tests__/eval-harness.test.ts`) dispatches each invariant to an existing pure function. Failure messages embed `[fixture: <name>] [invariant: <type>]` so a regression names exactly what drifted without log diving.
- No LLM calls, no new dependencies — AI SDK clients are mocked the same way `model-policy.test.ts` already does.
- CI picks it up automatically through the existing `src/**/*.test.ts` vitest glob.

## Test plan
- [x] `npm test` — 114 files / 2606 tests pass (23 new invariants)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (no new warnings)
- [x] `npm run format:check` clean
- [ ] Regression-surface check: temporarily flip an `expected` in a fixture, confirm the failing line names `[fixture: …] [invariant: …]`, revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)