### PR TITLE
feat(eval): machine-checkable evaluation rubric (closes #145)

### DIFF
--- a/src/__tests__/eval-harness.test.ts
+++ b/src/__tests__/eval-harness.test.ts
@@ -51,6 +51,9 @@ import { citationsFixture } from './fixtures/transcripts/citations.fixture.js';
 import { cachingFixture } from './fixtures/transcripts/caching.fixture.js';
 import { modelPolicyFixture } from './fixtures/transcripts/model-policy.fixture.js';
 import { scratchFixture } from './fixtures/transcripts/scratch.fixture.js';
+import { evaluationRubricFixture } from './fixtures/transcripts/evaluation-rubric.fixture.js';
+import { verdictOf } from '../rubric.js';
+import { PlanStore } from '../plan-store.js';
 
 const ALL_FIXTURES: Fixture[] = [
   promptBoundaryFixture,
@@ -60,6 +63,7 @@ const ALL_FIXTURES: Fixture[] = [
   cachingFixture,
   modelPolicyFixture,
   scratchFixture,
+  evaluationRubricFixture,
 ];
 
 const BASE_CONFIG: BernardConfig = makePolicyInput().config;
@@ -169,6 +173,45 @@ function runInvariant(fixtureName: string, inv: InvariantSpec, idx: number): voi
         }),
       );
       expect(decision.resetAll, t).toBe(inv.expectResetAll);
+      return;
+    }
+    case 'rubric_verdict_of': {
+      expect(verdictOf(inv.checks), t).toBe(inv.expected);
+      return;
+    }
+    case 'rubric_plan_evaluates_to': {
+      const store = new PlanStore();
+      // Seed via the public API: add() then update() into the target status so
+      // the store's invariants stay intact. Signoff/note are passed through.
+      for (const s of inv.steps) {
+        store.add({ description: s.description, verification: s.verification });
+      }
+      for (const s of inv.steps) {
+        if (s.status !== 'pending') {
+          store.update(s.id, s.status, { note: s.note, signoff: s.signoff });
+        }
+      }
+      const rubric = store.evaluateRubric();
+      expect(rubric.verdict, `${t} verdict`).toBe(inv.expectedVerdict);
+      if (inv.expectChecks) {
+        for (const want of inv.expectChecks) {
+          const actual = rubric.checks.find((c) => c.id === want.id);
+          expect(actual, `${t} missing check ${want.id}`).toBeDefined();
+          expect(actual!.status, `${t} check ${want.id} status`).toBe(want.status);
+        }
+      }
+      return;
+    }
+    case 'rubric_post_write_hook': {
+      const hook = inv.meta.verifyOutput;
+      expect(hook, `${t} fixture meta missing verifyOutput`).toBeDefined();
+      const outcome = hook!(inv.args, inv.result);
+      if (inv.expected === null) {
+        expect(outcome, `${t} expected null skip`).toBeNull();
+      } else {
+        expect(outcome, `${t} got null but expected outcome`).not.toBeNull();
+        expect(outcome!.status, `${t} outcome status`).toBe(inv.expected.status);
+      }
       return;
     }
     default:

--- a/src/__tests__/fixtures/fixture-schema.ts
+++ b/src/__tests__/fixtures/fixture-schema.ts
@@ -4,6 +4,8 @@ import type { ToolMeta } from '../../framework/tools/types.js';
 import type { LLMCacheKey } from '../../llm-cache.js';
 import type { ModelSite } from '../../model-policy.js';
 import type { SourceItemInput } from '../../provenance.js';
+import type { Check, Verdict } from '../../rubric.js';
+import type { Step } from '../../plan-store.js';
 
 /**
  * Closed discriminated union of invariants the eval harness can assert.
@@ -57,6 +59,24 @@ export type InvariantSpec =
       userInput: string;
       previousUserInput: string | undefined;
       expectResetAll: boolean;
+    }
+  | {
+      type: 'rubric_verdict_of';
+      checks: Check[];
+      expected: Verdict;
+    }
+  | {
+      type: 'rubric_plan_evaluates_to';
+      steps: Array<Pick<Step, 'id' | 'description' | 'status'> & Partial<Step>>;
+      expectedVerdict: Verdict;
+      expectChecks?: Array<{ id: string; status: Check['status'] }>;
+    }
+  | {
+      type: 'rubric_post_write_hook';
+      meta: ToolMeta;
+      args: unknown;
+      result: unknown;
+      expected: { status: 'pass' | 'warn' | 'fail' } | null;
     };
 
 export type FixtureCategory =
@@ -66,7 +86,8 @@ export type FixtureCategory =
   | 'citations'
   | 'caching'
   | 'model-policy'
-  | 'scratch';
+  | 'scratch'
+  | 'evaluation-rubric';
 
 export interface Fixture {
   name: string;

--- a/src/__tests__/fixtures/transcripts/evaluation-rubric.fixture.ts
+++ b/src/__tests__/fixtures/transcripts/evaluation-rubric.fixture.ts
@@ -1,0 +1,176 @@
+import { defineFixture } from '../fixture-schema.js';
+
+/**
+ * Issue #145 — measurable evaluation rubric. Invariants here pin the
+ * `verdictOf` worst-of aggregation, the `PlanStore.evaluateRubric` derivation,
+ * and the `ToolMeta.verifyOutput` post-write hook contract end-to-end. Long-
+ * term safety net so changes to any of the three surfaces fail loudly here.
+ */
+export const evaluationRubricFixture = defineFixture({
+  name: 'evaluation-rubric',
+  category: 'evaluation-rubric',
+  invariants: [
+    // verdictOf — worst-of aggregation
+    {
+      type: 'rubric_verdict_of',
+      checks: [],
+      expected: 'pass',
+    },
+    {
+      type: 'rubric_verdict_of',
+      checks: [
+        { id: 'a', label: 'a', status: 'pass' },
+        { id: 'b', label: 'b', status: 'pass' },
+      ],
+      expected: 'pass',
+    },
+    {
+      type: 'rubric_verdict_of',
+      checks: [
+        { id: 'a', label: 'a', status: 'pass' },
+        { id: 'b', label: 'b', status: 'warn' },
+        { id: 'c', label: 'c', status: 'skip' },
+      ],
+      expected: 'warn',
+    },
+    {
+      type: 'rubric_verdict_of',
+      checks: [
+        { id: 'a', label: 'a', status: 'pass' },
+        { id: 'b', label: 'b', status: 'warn' },
+        { id: 'c', label: 'c', status: 'fail' },
+      ],
+      expected: 'fail',
+    },
+    {
+      type: 'rubric_verdict_of',
+      checks: [
+        { id: 'a', label: 'a', status: 'skip' },
+        { id: 'b', label: 'b', status: 'skip' },
+      ],
+      expected: 'pass',
+    },
+
+    // PlanStore.evaluateRubric — derivation
+    {
+      type: 'rubric_plan_evaluates_to',
+      steps: [],
+      expectedVerdict: 'pass',
+      expectChecks: [
+        { id: 'steps_terminal', status: 'skip' },
+        { id: 'signoffs_present', status: 'skip' },
+        { id: 'no_error_steps', status: 'pass' },
+      ],
+    },
+    {
+      type: 'rubric_plan_evaluates_to',
+      steps: [
+        {
+          id: 1,
+          description: 'do thing',
+          verification: 'check thing',
+          status: 'in_progress',
+        },
+      ],
+      expectedVerdict: 'fail',
+      expectChecks: [{ id: 'steps_terminal', status: 'fail' }],
+    },
+    {
+      type: 'rubric_plan_evaluates_to',
+      steps: [
+        {
+          id: 1,
+          description: 'do thing',
+          verification: 'check thing',
+          status: 'done',
+          signoff: 'confirmed via re-read of file',
+        },
+      ],
+      expectedVerdict: 'pass',
+      expectChecks: [
+        { id: 'steps_terminal', status: 'pass' },
+        { id: 'signoffs_present', status: 'pass' },
+        { id: 'no_error_steps', status: 'pass' },
+      ],
+    },
+    {
+      type: 'rubric_plan_evaluates_to',
+      steps: [
+        {
+          id: 1,
+          description: 'do thing',
+          verification: 'check thing',
+          status: 'done',
+          signoff: 'ok',
+        },
+      ],
+      expectedVerdict: 'warn',
+      expectChecks: [{ id: 'signoffs_present', status: 'warn' }],
+    },
+    {
+      type: 'rubric_plan_evaluates_to',
+      steps: [
+        {
+          id: 1,
+          description: 'a',
+          verification: 'va',
+          status: 'error',
+          note: 'boom',
+        },
+        {
+          id: 2,
+          description: 'b',
+          verification: 'vb',
+          status: 'error',
+          note: 'boom2',
+        },
+      ],
+      expectedVerdict: 'fail',
+      expectChecks: [{ id: 'no_error_steps', status: 'fail' }],
+    },
+
+    // ToolMeta.verifyOutput — post-write hook contract
+    {
+      type: 'rubric_post_write_hook',
+      meta: {
+        name: 'fake_writer',
+        kind: 'write',
+        sideEffect: 'local',
+        verifyOutput: (_args, result) => {
+          const r = result as { ok?: boolean };
+          return r.ok ? { status: 'pass', evidence: 'wrote' } : { status: 'fail', evidence: 'no' };
+        },
+      },
+      args: {},
+      result: { ok: true },
+      expected: { status: 'pass' },
+    },
+    {
+      type: 'rubric_post_write_hook',
+      meta: {
+        name: 'fake_writer',
+        kind: 'write',
+        sideEffect: 'local',
+        verifyOutput: (_args, result) => {
+          const r = result as { ok?: boolean };
+          return r.ok ? { status: 'pass', evidence: 'wrote' } : { status: 'fail', evidence: 'no' };
+        },
+      },
+      args: {},
+      result: { ok: false },
+      expected: { status: 'fail' },
+    },
+    {
+      type: 'rubric_post_write_hook',
+      meta: {
+        name: 'fake_writer',
+        kind: 'write',
+        sideEffect: 'local',
+        verifyOutput: () => null,
+      },
+      args: {},
+      result: { ok: true },
+      expected: null,
+    },
+  ],
+});

--- a/src/agent-status.ts
+++ b/src/agent-status.ts
@@ -2,6 +2,7 @@ import type { Theme } from './theme.js';
 import type { PolicyDecision } from './policy/types.js';
 import type { ResolvedEntry } from './reference-resolver.js';
 import type { Step } from './plan-store.js';
+import type { Check, Verdict } from './rubric.js';
 
 /**
  * Snapshot of "what Bernard believes its operating state is" for one turn.
@@ -34,10 +35,16 @@ export interface AgentStatusInputs {
 }
 
 export interface VerificationEntry {
-  verdict: 'pass' | 'fail';
+  verdict: Verdict;
   reason: string;
   /** Free-form label of what was verified (e.g. sub-agent task summary). */
   source: string;
+  /**
+   * Structured checks behind the verdict (issue #145). Present when the verdict
+   * was produced by a rubric-aware site (PAC critic, the `evaluate` tool with
+   * structured checks). Absent for legacy callers.
+   */
+  checks?: Check[];
 }
 
 /**
@@ -167,7 +174,12 @@ export function buildAgentStatusPanel(inputs: AgentStatusInputs, t: Theme): stri
 
   if (inputs.lastVerification) {
     const v = inputs.lastVerification;
-    const tag = v.verdict === 'pass' ? t.success('PASS') : t.error('FAIL');
+    const tag =
+      v.verdict === 'pass'
+        ? t.success('PASS')
+        : v.verdict === 'warn'
+          ? t.warning('WARN')
+          : t.error('FAIL');
     const body = ` — ${truncate(v.reason, 120)}`;
     const tail = v.source ? t.dim(`  (${truncate(v.source, 60)})`) : '';
     lines.push(row('Last verify', `${tag}${body}${tail}`, t));

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -261,12 +261,15 @@ export class Agent {
     this.lastUserInput = userInput;
     this.lastResolvedReferences = resolvedReferences ?? [];
     this.ctx.verification.clear();
-    // Reset per-turn rubric inputs (#145): post-write hooks and tool-attestation
-    // tracker. Both are shared by reference into sub-agent / tool-wrapper
-    // contexts via `runDefinition`, so clearing here also clears for nested
-    // dispatches at the start of the turn.
+    // Reset per-turn rubric inputs (#145): post-write hooks, tool-attestation
+    // tracker, and the cached snapshot. Both sinks are shared by reference
+    // into sub-agent / tool-wrapper contexts via `runDefinition`, so clearing
+    // here also clears for nested dispatches. `lastRubric` is reset here too
+    // — if the turn throws before composition, callers should see `null`
+    // rather than the previous turn's verdict.
     this.ctx.postWriteChecks.length = 0;
     this.ctx.verificationTracker.clear();
+    this.lastRubric = null;
 
     // Resolve every cross-cutting heuristic for this turn in one place.
     // Sub-systems read the decision off `this.ctx.policyDecision` (e.g.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -49,6 +49,7 @@ import type { PolicyEngine, PolicyResult } from './policy/index.js';
 import { extractCitationMarkers, type SourceItem } from './provenance.js';
 import type { Step } from './plan-store.js';
 import type { VerificationEntry } from './agent-status.js';
+import { verdictOf, renderRubricLine, type Check, type Rubric } from './rubric.js';
 
 // `buildSystemPrompt` lives in agent-prompt.ts (extracted to avoid a circular
 // import with framework/agents/main.ts). Re-exported here so existing imports
@@ -100,6 +101,8 @@ export class Agent {
   private lastRAGResults: RAGSearchResult[] = [];
   private lastSources: SourceItem[] = [];
   private lastCitedSources: SourceItem[] = [];
+  /** Most recent per-turn rubric (#145). Composed at end of `processInput`. */
+  private lastRubric: Rubric | null = null;
   private abortController: AbortController | null = null;
   private lastPromptTokens: number = 0;
   // Public so tokenStatsHook (an external module) can mutate these in place
@@ -171,6 +174,15 @@ export class Agent {
    */
   getLastCitedSources(): SourceItem[] {
     return this.lastCitedSources;
+  }
+
+  /**
+   * Most recent per-turn evaluation rubric — the composed pass/warn/fail
+   * verdict + the list of contributing checks. Null before the first turn or
+   * after `clearHistory`. Issue #145.
+   */
+  getLastRubric(): Rubric | null {
+    return this.lastRubric;
   }
 
   /** Cancels the in-flight LLM request, if any. Safe to call when no request is active. */
@@ -249,6 +261,12 @@ export class Agent {
     this.lastUserInput = userInput;
     this.lastResolvedReferences = resolvedReferences ?? [];
     this.ctx.verification.clear();
+    // Reset per-turn rubric inputs (#145): post-write hooks and tool-attestation
+    // tracker. Both are shared by reference into sub-agent / tool-wrapper
+    // contexts via `runDefinition`, so clearing here also clears for nested
+    // dispatches at the start of the turn.
+    this.ctx.postWriteChecks.length = 0;
+    this.ctx.verificationTracker.clear();
 
     // Resolve every cross-cutting heuristic for this turn in one place.
     // Sub-systems read the decision off `this.ctx.policyDecision` (e.g.
@@ -588,6 +606,30 @@ export class Agent {
         coordinatorMode: this.config.coordinatorMode,
       });
 
+      // Compose per-turn rubric (#145). Combines:
+      //   - PlanStore.evaluateRubric (steps-terminal, signoffs, error-step count)
+      //   - Post-write hook results recorded by augmentTools
+      //   - Attestation: did the model run something matching each step's
+      //     declared `verification` text?
+      //   - The most recent `evaluate` tool's structured checks, if any
+      // Worst-of aggregation: any fail → fail, any warn → warn, else pass.
+      const planRubric = this.planStore.evaluateRubric();
+      const attestationChecks = this.ctx.verificationTracker.attestAll(this.planStore.view());
+      const evalChecks = this.ctx.verification.getLast()?.checks ?? [];
+      const allChecks: Check[] = [
+        ...planRubric.checks,
+        ...this.ctx.postWriteChecks,
+        ...attestationChecks,
+        ...evalChecks,
+      ];
+      const turnVerdict = verdictOf(allChecks);
+      this.lastRubric = { verdict: turnVerdict, checks: allChecks };
+      debugLog('rubric:turn', {
+        verdict: turnVerdict,
+        checks: allChecks.length,
+        summary: renderRubricLine(this.lastRubric),
+      });
+
       // Truncate large tool results before adding to history
       const truncatedMessages = truncateToolResults(result.response.messages as CoreMessage[]);
       this.history.push(...truncatedMessages);
@@ -635,6 +677,9 @@ export class Agent {
     this.lastCitedSources = [];
     this.ctx.verification.clear();
     this.ctx.provenance.clear();
+    this.ctx.postWriteChecks.length = 0;
+    this.ctx.verificationTracker.clear();
+    this.lastRubric = null;
     if (this.ctx.policyDecision) {
       this.ctx = { ...this.ctx, policyDecision: undefined };
     }

--- a/src/cron/log-store.ts
+++ b/src/cron/log-store.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { LOGS_DIR } from '../paths.js';
 import type { ToolErrorType } from '../framework/tools/types.js';
+import type { Verdict, Check } from '../rubric.js';
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const DEFAULT_KEEP = 500;
 
@@ -32,6 +33,15 @@ export interface CronLogEntry {
   finalOutput: string;
   steps: CronLogStep[];
   totalUsage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  /**
+   * Composed turn verdict (#145). Set on both success and exception branches.
+   * `'pass'` = all rubric checks passed; `'warn'` = at least one warned but
+   * none failed; `'fail'` = at least one check failed (or the run threw).
+   * Optional so older logs continue to parse cleanly.
+   */
+  verdict?: Verdict;
+  /** Individual checks that contributed to {@link verdict}. */
+  rubricChecks?: Check[];
 }
 
 /**

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -19,6 +19,7 @@ import {
 } from '../framework/agents/index.js';
 import { runDefinition } from '../framework/agents/run.js';
 import { renderAgentStatusPlain, type AgentStatusInputs } from '../agent-status.js';
+import { verdictOf, type Check, type Verdict } from '../rubric.js';
 
 export {
   /** Re-exported so existing imports against the runner module keep working. */
@@ -166,6 +167,15 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
         }),
         { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
       );
+      // Per-run rubric (#145). Cron has no plan store and no attestation
+      // tracker target (no per-step `verification` strings), so we compose from
+      // what the run actually produced: post-write hook outcomes + the most
+      // recent `evaluate` tool's structured checks. Logged whether or not any
+      // checks were recorded — older readers tolerate missing fields.
+      const evalChecks = ctx.verification.getLast()?.checks ?? [];
+      const rubricChecks: Check[] = [...ctx.postWriteChecks, ...evalChecks];
+      const verdict: Verdict | undefined =
+        rubricChecks.length > 0 ? verdictOf(rubricChecks) : undefined;
       logStore.appendEntry({
         runId,
         jobId: job.id,
@@ -178,7 +188,15 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
         finalOutput: finalOutputWithStatus,
         steps,
         totalUsage,
+        verdict,
+        rubricChecks: rubricChecks.length > 0 ? rubricChecks : undefined,
       });
+      // A clean-running job that nevertheless trips at least one warn-grade
+      // check is invisible to today's success/error alert routing. Log a
+      // structured warn line so the daemon log surfaces it.
+      if (verdict === 'warn') {
+        log(`Warning: job '${job.name}' completed but rubric verdict is WARN.`);
+      }
     } catch (logErr: unknown) {
       const logMsg = logErr instanceof Error ? logErr.message : String(logErr);
       log(`Warning: failed to write execution log: ${logMsg}`);
@@ -198,6 +216,21 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
         }),
         { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
       );
+      // Failure branch always emits a `fail` verdict — the run threw, which
+      // is itself the strongest signal that something is unverified.
+      // Whatever post-write checks / evaluate checks accumulated before the
+      // throw still ride along so the log has the partial picture.
+      const evalChecksOnFail = ctx.verification.getLast()?.checks ?? [];
+      const failChecks: Check[] = [
+        ...ctx.postWriteChecks,
+        ...evalChecksOnFail,
+        {
+          id: 'run_threw',
+          label: 'job raised an exception',
+          status: 'fail',
+          evidence: cls.category,
+        },
+      ];
       logStore.appendEntry({
         runId,
         jobId: job.id,
@@ -212,6 +245,8 @@ export async function runJob(job: CronJob, log: (msg: string) => void): Promise<
         finalOutput: '',
         steps,
         totalUsage,
+        verdict: 'fail',
+        rubricChecks: failChecks,
       });
     } catch {
       // best-effort logging

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -235,7 +235,7 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
                 reason: 'plan-replaced',
               });
             }),
-            evaluate: createEvaluateTool(),
+            evaluate: createEvaluateTool(ctx.verification),
           }
         : {}),
     };

--- a/src/framework/agents/pac-critic.ts
+++ b/src/framework/agents/pac-critic.ts
@@ -27,13 +27,13 @@ Rules:
 - You may use ONLY read-only verification tools (file_read_lines, memory.read, scratch.read, web_read, web_search, datetime, evaluate). DO NOT call shell, write to memory, edit files, or take any action that changes state.
 - Check the Actor's claims against actual observable state. If the Actor said "wrote file X with content Y" — read file X and confirm. If the Actor said "command returned Z" — re-run only if it is a safe read-only command, otherwise trust the Actor's transcript.
 - Use \`evaluate\` to publish a short verdict reasoning visible to the user.
-- Be strict but fair. PASS when every success criterion is met. FAIL when any success criterion is unmet, the Actor's evidence is missing, or the Actor reported unrecoverable errors.
+- Be strict but fair. PASS when every success criterion is met. WARN when the success criteria were met but there are caveats worth surfacing (partial coverage, unexpected output that did not block success, missing post-write check). FAIL when any success criterion is unmet, the Actor's evidence is missing, or the Actor reported unrecoverable errors.
 
 Output format (STRICT):
 Your FINAL message MUST be a single valid JSON object with this shape and nothing else — no prose before or after, no markdown code fences:
 
 {
-  "verdict": "pass" | "fail",
+  "verdict": "pass" | "warn" | "fail",
   "reason": "<one or two sentences explaining the verdict, citing specific criteria>"
 }
 
@@ -52,20 +52,20 @@ export interface PacCriticInput {
 
 /** Parsed verdict returned to the orchestrator. */
 export interface PacCriticVerdict {
-  verdict: 'pass' | 'fail';
+  verdict: 'pass' | 'warn' | 'fail';
   reason: string;
   raw: string;
 }
 
 const VerdictSchema = z.object({
-  verdict: z.enum(['pass', 'fail']),
+  verdict: z.enum(['pass', 'warn', 'fail']),
   reason: z.string(),
 });
 
 function buildCriticTools(ctx: import('../context.js').AgentContext): Record<string, Tool> {
   const fileTools = createFileTools();
   return {
-    evaluate: createEvaluateTool(),
+    evaluate: createEvaluateTool(ctx.verification),
     memory: toolToAISDK(createReadOnlyMemoryTool(ctx.stores.memory)),
     scratch: toolToAISDK(createReadOnlyScratchTool(ctx.stores.memory)),
     file_read_lines: fileTools.file_read_lines,

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -90,6 +90,11 @@ export async function runDefinition<TInput, TFormatted>(
     // told to cite (cron + sub-agents/wrappers do not inject EVIDENCE_PROMPT).
     provenance: ctx.provenance,
     evidenceEnabled: ctx.policyDecision?.evidence?.requireForVerifiedClaims === true,
+    // Rubric wiring (#145). Shared by reference into sub-agent / tool-wrapper
+    // contexts so post-write hooks fire and attestation tokens accumulate
+    // regardless of which level made the call.
+    verificationTracker: ctx.verificationTracker,
+    postWriteChecks: ctx.postWriteChecks,
   });
   const hooks = def.hooks(ctx, input);
   const baseMaxSteps = def.stepBudget(config, input);

--- a/src/framework/agents/specialist.ts
+++ b/src/framework/agents/specialist.ts
@@ -92,7 +92,9 @@ export const specialistDefinition: AgentDefinition<SpecialistInput, string> = {
       ...baseTools,
       plan: createPlanTool(input.planStore),
       think: createThinkTool(),
-      ...(ctx.config.coordinatorMode === 'on' ? { evaluate: createEvaluateTool() } : {}),
+      ...(ctx.config.coordinatorMode === 'on'
+        ? { evaluate: createEvaluateTool(ctx.verification) }
+        : {}),
     };
     return specialistTools;
   },

--- a/src/framework/context.ts
+++ b/src/framework/context.ts
@@ -10,6 +10,8 @@ import type { PolicyDecision } from '../policy/types.js';
 import type { ToolOptions } from '../tools/types.js';
 import { ProvenanceStore } from '../provenance.js';
 import { VerificationStore } from '../agent-status.js';
+import { VerificationTracker } from '../verification-tracker.js';
+import type { Check } from '../rubric.js';
 
 export interface AgentContextStores {
   memory: MemoryStore;
@@ -54,6 +56,20 @@ export interface AgentContext {
    * updates the parent's snapshot.
    */
   verification: VerificationStore;
+  /**
+   * Per-turn tracker that records every tool call (name, args, result preview)
+   * and answers `did the agent actually run a verification matching this step's
+   * `verification` text?` via token overlap. Cleared at the top of every
+   * `Agent.processInput`. Issue #145 check 1.
+   */
+  verificationTracker: VerificationTracker;
+  /**
+   * Per-turn sink for post-write schema/state checks produced by
+   * `ToolMeta.verifyOutput` hooks. Appended by `augmentTools`; consumed when
+   * composing the turn rubric. Cleared at the top of every
+   * `Agent.processInput`. Issue #145 check 3.
+   */
+  postWriteChecks: Check[];
 }
 
 export interface AssembleContextInput {
@@ -64,6 +80,8 @@ export interface AssembleContextInput {
   stores?: Partial<AgentContextStores>;
   provenance?: ProvenanceStore;
   verification?: VerificationStore;
+  verificationTracker?: VerificationTracker;
+  postWriteChecks?: Check[];
 }
 
 export function assembleContext(input: AssembleContextInput): AgentContext {
@@ -87,5 +105,7 @@ export function assembleContext(input: AssembleContextInput): AgentContext {
     toolOptions: input.toolOptions,
     provenance: input.provenance ?? new ProvenanceStore(),
     verification: input.verification ?? new VerificationStore(),
+    verificationTracker: input.verificationTracker ?? new VerificationTracker(),
+    postWriteChecks: input.postWriteChecks ?? [],
   };
 }

--- a/src/framework/pac/run-pac.ts
+++ b/src/framework/pac/run-pac.ts
@@ -26,8 +26,12 @@ export interface PacRunInput {
 export interface PacRunResult {
   /** The (possibly footer-augmented) Actor output passed back to the caller. */
   formatted: string;
-  /** Final critic verdict at the end of the pipeline. */
-  verdict: 'pass' | 'fail';
+  /**
+   * Final critic verdict at the end of the pipeline. `'warn'` means the
+   * pipeline completed without retrying — caveats are surfaced in `formatted`
+   * via a `## Critic Verdict: WARN` footer.
+   */
+  verdict: 'pass' | 'warn' | 'fail';
   /** Critic's reason for the final verdict. */
   reason: string;
   /** How many retry cycles were used (0 = single pass). */
@@ -106,6 +110,20 @@ export async function runPAC(
       return {
         formatted: capSubagentResult(actorOutput),
         verdict: 'pass',
+        reason: verdict.reason,
+        retries: attempt,
+      };
+    }
+
+    if (verdict.verdict === 'warn') {
+      // Warn means "completed but with caveats" — surface the caveat as a
+      // footer but do not retry. Reserve footer space inside the cap so the
+      // signal isn't truncated away.
+      const warnFooter = `\n\n## Critic Verdict: WARN\n${verdict.reason}`;
+      const warnBudget = Math.max(0, SUBAGENT_RESULT_MAX_CHARS - warnFooter.length);
+      return {
+        formatted: capSubagentResult(actorOutput, warnBudget) + warnFooter,
+        verdict: 'warn',
         reason: verdict.reason,
         retries: attempt,
       };

--- a/src/framework/tools/types.ts
+++ b/src/framework/tools/types.ts
@@ -63,6 +63,21 @@ export interface ToolMeta {
    * tools keep the static `kind`-based behavior.
    */
   isWriteAction?: (args: unknown) => boolean;
+  /**
+   * Optional post-write schema/state check (issue #145). Runs after the tool
+   * returns `status: 'ok'` and contributes a structured `Check` to the turn's
+   * rubric. Used for "did we mutate external state, and did we confirm it
+   * post-write?" — e.g. `file_edit_lines` re-stats the path, `mcp_config`
+   * re-reads the config file. Return `null` to skip (not applicable for this
+   * call). Synchronous; should be fast and side-effect-free.
+   */
+  verifyOutput?: (args: unknown, result: unknown) => VerifyOutcome | null;
+}
+
+/** Outcome of a `ToolMeta.verifyOutput` check. */
+export interface VerifyOutcome {
+  status: 'pass' | 'warn' | 'fail';
+  evidence?: string;
 }
 
 /**

--- a/src/framework/tools/types.ts
+++ b/src/framework/tools/types.ts
@@ -67,9 +67,9 @@ export interface ToolMeta {
    * Optional post-write schema/state check (issue #145). Runs after the tool
    * returns `status: 'ok'` and contributes a structured `Check` to the turn's
    * rubric. Used for "did we mutate external state, and did we confirm it
-   * post-write?" — e.g. `file_edit_lines` re-stats the path, `mcp_config`
-   * re-reads the config file. Return `null` to skip (not applicable for this
-   * call). Synchronous; should be fast and side-effect-free.
+   * post-write?" — e.g. `file_edit_lines` re-stats the path and compares its
+   * hash to the declared `new_hash`. Return `null` to skip (not applicable
+   * for this call). Synchronous; should be fast and side-effect-free.
    */
   verifyOutput?: (args: unknown, result: unknown) => VerifyOutcome | null;
 }

--- a/src/plan-store.test.ts
+++ b/src/plan-store.test.ts
@@ -142,4 +142,68 @@ describe('PlanStore', () => {
     expect(rendered).toContain('2. [error] second');
     expect(rendered).toContain('note: file missing');
   });
+
+  describe('evaluateRubric', () => {
+    it('returns skip + skip + pass on empty plan (no signal either way)', () => {
+      const r = store.evaluateRubric();
+      expect(r.verdict).toBe('pass');
+      const byId = Object.fromEntries(r.checks.map((c) => [c.id, c]));
+      expect(byId.steps_terminal.status).toBe('skip');
+      expect(byId.signoffs_present.status).toBe('skip');
+      expect(byId.no_error_steps.status).toBe('pass');
+    });
+
+    it('FAIL when any step is still non-terminal', () => {
+      store.create([s('a'), s('b')]);
+      store.update(1, 'done', { signoff: 'verified output exists' });
+      // step 2 remains pending
+      const r = store.evaluateRubric();
+      expect(r.verdict).toBe('fail');
+      const terminal = r.checks.find((c) => c.id === 'steps_terminal');
+      expect(terminal?.status).toBe('fail');
+      expect(terminal?.evidence).toContain('1 unresolved');
+    });
+
+    it('PASS when all steps done with substantive signoffs', () => {
+      store.create([s('a'), s('b')]);
+      store.update(1, 'done', { signoff: 'tests pass locally' });
+      store.update(2, 'done', { signoff: 'file written and re-read' });
+      expect(store.evaluateRubric().verdict).toBe('pass');
+    });
+
+    it('WARN on weak signoff (under MIN_SIGNOFF_LEN)', () => {
+      store.create([s('a')]);
+      store.update(1, 'done', { signoff: 'ok' });
+      const r = store.evaluateRubric();
+      expect(r.verdict).toBe('warn');
+      expect(r.checks.find((c) => c.id === 'signoffs_present')?.status).toBe('warn');
+    });
+
+    it('WARN on exactly one error step', () => {
+      store.create([s('a'), s('b')]);
+      store.update(1, 'done', { signoff: 'fully verified output' });
+      store.update(2, 'error', { note: 'network failure' });
+      const r = store.evaluateRubric();
+      expect(r.verdict).toBe('warn');
+      expect(r.checks.find((c) => c.id === 'no_error_steps')?.status).toBe('warn');
+    });
+
+    it('FAIL on ≥2 error steps (worst-of beats warn-only signoff issue)', () => {
+      store.create([s('a'), s('b'), s('c')]);
+      store.update(1, 'done', { signoff: 'fully verified output' });
+      store.update(2, 'error', { note: 'net' });
+      store.update(3, 'error', { note: 'auth' });
+      const r = store.evaluateRubric();
+      expect(r.verdict).toBe('fail');
+      expect(r.checks.find((c) => c.id === 'no_error_steps')?.status).toBe('fail');
+    });
+
+    it('cancelled counts as terminal but not as error', () => {
+      store.create([s('a'), s('b')]);
+      store.update(1, 'done', { signoff: 'fully verified output' });
+      store.update(2, 'cancelled', { note: 'no longer needed' });
+      const r = store.evaluateRubric();
+      expect(r.verdict).toBe('pass');
+    });
+  });
 });

--- a/src/plan-store.ts
+++ b/src/plan-store.ts
@@ -1,3 +1,6 @@
+import type { Check, Rubric } from './rubric.js';
+import { verdictOf } from './rubric.js';
+
 /**
  * Status lifecycle for a plan step.
  *
@@ -5,6 +8,12 @@
  * Terminal: `done`, `cancelled`, `error`.
  */
 export type StepStatus = 'pending' | 'in_progress' | 'done' | 'cancelled' | 'error';
+
+/**
+ * Minimum signoff length for a `done` step to count as "really verified."
+ * Anything shorter (e.g. "ok", "done") downgrades the rubric to warn.
+ */
+const MIN_SIGNOFF_LEN = 10;
 
 export interface Step {
   id: number;
@@ -109,6 +118,89 @@ export class PlanStore {
       }
     }
     return count;
+  }
+
+  /**
+   * Derive a machine-checkable rubric from the current plan state (issue #145).
+   * Pure over the existing fields — no new step state required.
+   */
+  evaluateRubric(): Rubric {
+    const checks: Check[] = [];
+    const unresolved = this.unresolvedCount();
+    if (this.steps.length === 0) {
+      checks.push({
+        id: 'steps_terminal',
+        label: 'plan steps in terminal state',
+        status: 'skip',
+        evidence: 'no plan recorded',
+      });
+    } else if (unresolved === 0) {
+      checks.push({
+        id: 'steps_terminal',
+        label: 'plan steps in terminal state',
+        status: 'pass',
+        evidence: `${this.steps.length} step(s) terminal`,
+      });
+    } else {
+      checks.push({
+        id: 'steps_terminal',
+        label: 'plan steps in terminal state',
+        status: 'fail',
+        evidence: `${unresolved} unresolved`,
+      });
+    }
+
+    const doneSteps = this.steps.filter((s) => s.status === 'done');
+    if (doneSteps.length === 0) {
+      checks.push({
+        id: 'signoffs_present',
+        label: 'done steps have substantive signoff',
+        status: 'skip',
+        evidence: 'no done steps',
+      });
+    } else {
+      const weak = doneSteps.filter((s) => (s.signoff ?? '').trim().length < MIN_SIGNOFF_LEN);
+      if (weak.length === 0) {
+        checks.push({
+          id: 'signoffs_present',
+          label: 'done steps have substantive signoff',
+          status: 'pass',
+          evidence: `${doneSteps.length} signoff(s) ≥ ${MIN_SIGNOFF_LEN} chars`,
+        });
+      } else {
+        checks.push({
+          id: 'signoffs_present',
+          label: 'done steps have substantive signoff',
+          status: 'warn',
+          evidence: `${weak.length} weak signoff(s): step(s) ${weak.map((s) => s.id).join(',')}`,
+        });
+      }
+    }
+
+    const errored = this.steps.filter((s) => s.status === 'error');
+    if (errored.length === 0) {
+      checks.push({
+        id: 'no_error_steps',
+        label: 'no step ended in error',
+        status: 'pass',
+      });
+    } else if (errored.length === 1) {
+      checks.push({
+        id: 'no_error_steps',
+        label: 'no step ended in error',
+        status: 'warn',
+        evidence: `step ${errored[0].id}: ${errored[0].note ?? ''}`.trim(),
+      });
+    } else {
+      checks.push({
+        id: 'no_error_steps',
+        label: 'no step ended in error',
+        status: 'fail',
+        evidence: `${errored.length} errored: step(s) ${errored.map((s) => s.id).join(',')}`,
+      });
+    }
+
+    return { verdict: verdictOf(checks), checks };
   }
 
   /** Renders the plan as a human-readable list for re-prompts. */

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -77,6 +77,7 @@ import {
 import type { SupportedSdk } from './providers/types.js';
 import { getTheme, setTheme, getThemeKeys, getActiveThemeKey, THEMES } from './theme.js';
 import type { SourceItem } from './provenance.js';
+import { renderRubricLine } from './rubric.js';
 import {
   buildAgentStatusPanel,
   pickActiveStep,
@@ -2885,6 +2886,14 @@ Remember: the systemPrompt should read like a persona definition — who this sp
       initSpinner();
       await agent.processInput(agentInput, inlineImages, resolvedEntries);
       historyStore.save(agent.getHistory());
+      // Per-turn rubric footer (#145). One muted line showing the composed
+      // verdict + check counts. Suppressed when there is nothing to attest
+      // (no checks of any kind contributed this turn — e.g. a pure-question
+      // turn with no plan and no evaluate call).
+      const rubric = agent.getLastRubric();
+      if (rubric && rubric.checks.length > 0) {
+        printInfo(renderRubricLine(rubric));
+      }
     } catch (err: unknown) {
       if (!interrupted) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/rubric.test.ts
+++ b/src/rubric.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { verdictOf, countByStatus, renderRubricLine, type Check, type Rubric } from './rubric.js';
+
+const c = (status: Check['status'], extra: Partial<Check> = {}): Check => ({
+  id: extra.id ?? 'x',
+  label: extra.label ?? 'check',
+  status,
+  evidence: extra.evidence,
+});
+
+describe('verdictOf', () => {
+  it('returns pass on empty list', () => {
+    expect(verdictOf([])).toBe('pass');
+  });
+
+  it('returns pass when all checks pass', () => {
+    expect(verdictOf([c('pass'), c('pass')])).toBe('pass');
+  });
+
+  it('returns pass when only skips are present', () => {
+    expect(verdictOf([c('skip'), c('skip')])).toBe('pass');
+  });
+
+  it('returns warn on mixed pass + warn', () => {
+    expect(verdictOf([c('pass'), c('warn'), c('pass')])).toBe('warn');
+  });
+
+  it('returns fail on any fail (even mixed with warn)', () => {
+    expect(verdictOf([c('warn'), c('pass'), c('fail')])).toBe('fail');
+  });
+
+  it('treats skip as neutral', () => {
+    expect(verdictOf([c('skip'), c('warn')])).toBe('warn');
+    expect(verdictOf([c('skip'), c('pass')])).toBe('pass');
+  });
+});
+
+describe('countByStatus', () => {
+  it('tallies all four statuses', () => {
+    const checks = [c('pass'), c('pass'), c('warn'), c('fail'), c('skip'), c('skip')];
+    expect(countByStatus(checks)).toEqual({ pass: 2, warn: 1, fail: 1, skip: 2 });
+  });
+
+  it('zero-fills statuses with no checks', () => {
+    expect(countByStatus([])).toEqual({ pass: 0, warn: 0, fail: 0, skip: 0 });
+  });
+});
+
+describe('renderRubricLine', () => {
+  it('emits PASS with no reason when verdict is pass', () => {
+    const r: Rubric = { verdict: 'pass', checks: [c('pass'), c('pass')] };
+    expect(renderRubricLine(r)).toBe('eval: PASS (2✓)');
+  });
+
+  it('emits FAIL with first failing check label as reason', () => {
+    const r: Rubric = {
+      verdict: 'fail',
+      checks: [c('pass'), c('fail', { label: 'plan_terminal', evidence: '2 unresolved' })],
+    };
+    expect(renderRubricLine(r)).toBe('eval: FAIL (1✓ 1✗) — plan_terminal (2 unresolved)');
+  });
+
+  it('honors an explicit reason on the rubric', () => {
+    const r: Rubric = { verdict: 'warn', checks: [c('warn')], reason: 'custom' };
+    expect(renderRubricLine(r)).toBe('eval: WARN (1⚠) — custom');
+  });
+
+  it('renders an empty rubric with no tally', () => {
+    expect(renderRubricLine({ verdict: 'pass', checks: [] })).toBe('eval: PASS');
+  });
+});

--- a/src/rubric.ts
+++ b/src/rubric.ts
@@ -1,0 +1,76 @@
+/**
+ * Machine-checkable evaluation rubric (issue #145).
+ *
+ * Replaces narrative "looks good" self-evaluation with a small structured
+ * judgment derived from observable signals: plan terminal state, post-write
+ * tool checks, verification-attestation against the turn's tool-call log,
+ * and the PAC critic verdict. Composed at end-of-turn (REPL) and end-of-run
+ * (cron) and rendered as one line.
+ */
+
+export type Verdict = 'pass' | 'warn' | 'fail';
+
+export type CheckStatus = Verdict | 'skip';
+
+export interface Check {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  evidence?: string;
+}
+
+export interface Rubric {
+  verdict: Verdict;
+  checks: Check[];
+  reason?: string;
+}
+
+/**
+ * Worst-of aggregation: any `fail` wins, else any `warn` wins, else `pass`.
+ * `skip` counts as "not run, neither good nor bad."
+ *
+ * An empty (or skip-only) check list yields `pass` — there's no evidence of
+ * trouble. Callers that need a "no checks ran" signal should inspect
+ * `checks.every(c => c.status === 'skip')` separately.
+ */
+export function verdictOf(checks: readonly Check[]): Verdict {
+  let warn = false;
+  for (const c of checks) {
+    if (c.status === 'fail') return 'fail';
+    if (c.status === 'warn') warn = true;
+  }
+  return warn ? 'warn' : 'pass';
+}
+
+/** Count of checks at each status, used by `renderRubricLine`. */
+export function countByStatus(checks: readonly Check[]): Record<CheckStatus, number> {
+  const out: Record<CheckStatus, number> = { pass: 0, warn: 0, fail: 0, skip: 0 };
+  for (const c of checks) out[c.status]++;
+  return out;
+}
+
+/**
+ * One-line summary suitable for REPL footers and cron log alerts. Examples:
+ *   `eval: PASS (4✓)`
+ *   `eval: WARN (3✓ 1⚠) — post-write check failed for file_edit_lines`
+ *   `eval: FAIL (2✓ 1✗) — 2 plan steps unresolved`
+ */
+export function renderRubricLine(r: Rubric): string {
+  const counts = countByStatus(r.checks);
+  const parts: string[] = [];
+  if (counts.pass > 0) parts.push(`${counts.pass}✓`);
+  if (counts.warn > 0) parts.push(`${counts.warn}⚠`);
+  if (counts.fail > 0) parts.push(`${counts.fail}✗`);
+  const tally = parts.length > 0 ? ` (${parts.join(' ')})` : '';
+  const verdict = r.verdict.toUpperCase();
+  const reason = r.reason ? ` — ${r.reason}` : firstNonPassReason(r);
+  return `eval: ${verdict}${tally}${reason}`;
+}
+
+function firstNonPassReason(r: Rubric): string {
+  if (r.verdict === 'pass') return '';
+  const c = r.checks.find((x) => x.status === 'fail') ?? r.checks.find((x) => x.status === 'warn');
+  if (!c) return '';
+  const ev = c.evidence ? ` (${c.evidence})` : '';
+  return ` — ${c.label}${ev}`;
+}

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -164,6 +164,20 @@ export interface AugmentOptions {
    * `evidence` sub-policy for this turn).
    */
   evidenceEnabled?: boolean;
+  /**
+   * Per-turn sink for `ToolMeta.verifyOutput` results (issue #145). When
+   * provided, every tool call that defines `verifyOutput` and returns
+   * `status: 'ok'` contributes a structured `Check` to this array — which is
+   * later folded into the turn rubric by `Agent.processInput` (and the cron
+   * runner). Omitting the sink disables the hook (legacy / tests).
+   */
+  postWriteChecks?: import('../rubric.js').Check[];
+  /**
+   * Per-turn tracker for verification attestation (issue #145). When provided,
+   * every successful tool call is recorded so `attestAll(steps)` can later
+   * answer "was the stated verification actually exercised?"
+   */
+  verificationTracker?: import('../verification-tracker.js').VerificationTracker;
 }
 
 function isProfileStore(v: AugmentOptions | ToolProfileStore): v is ToolProfileStore {
@@ -276,6 +290,8 @@ export function augmentTools(
   // contexts that never consult the policy (cron, bare depsToCtx callers),
   // populating the shared store with entries the model was never told about.
   const evidenceEnabled = provenance ? opts.evidenceEnabled === true : false;
+  const postWriteChecks = opts.postWriteChecks;
+  const verificationTracker = opts.verificationTracker;
 
   /**
    * Stable 53-bit djb2 hash for an args string. Used to derive an evidence
@@ -514,6 +530,8 @@ export function augmentTools(
               const previewSrc =
                 typeof serialized === 'string' ? serialized : safeSerialize(serialized);
               registerEvidence(toolName, args, source.meta, previewSrc);
+              recordVerification(verificationTracker, toolName, args, envelope.result);
+              runVerifyOutput(postWriteChecks, source.meta, args, envelope.result);
             }
             return serialized;
           },
@@ -570,6 +588,8 @@ export function augmentTools(
             const previewSrc =
               typeof capturedResult === 'string' ? capturedResult : safeSerialize(capturedResult);
             registerEvidence(toolName, args, readToolMeta(toolDef), previewSrc);
+            recordVerification(verificationTracker, toolName, args, capturedResult);
+            runVerifyOutput(postWriteChecks, readToolMeta(toolDef), args, capturedResult);
           }
           setImmediate(() => {
             try {
@@ -589,4 +609,53 @@ export function augmentTools(
   }
 
   return augmented;
+}
+
+/**
+ * Push a `verifyOutput` outcome into the turn's `postWriteChecks` sink
+ * (issue #145). No-op when no sink is wired, when the tool has no meta, or
+ * when `verifyOutput` is undefined. Hook throws never propagate — a buggy
+ * verification check must not abort the real tool call.
+ */
+function runVerifyOutput(
+  sink: import('../rubric.js').Check[] | undefined,
+  meta: import('../framework/tools/types.js').ToolMeta | undefined,
+  args: unknown,
+  result: unknown,
+): void {
+  if (!sink || !meta?.verifyOutput) return;
+  try {
+    const outcome = meta.verifyOutput(args, result);
+    if (!outcome) return;
+    sink.push({
+      id: `post_write_${meta.name}`,
+      label: `${meta.name} post-write check`,
+      status: outcome.status,
+      evidence: outcome.evidence,
+    });
+  } catch (err) {
+    debugLog(
+      `augment:verifyOutput:${meta.name}:threw`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * Record a successful tool call into the turn's `VerificationTracker`
+ * (issue #145). No-op when no tracker is wired. Hook is best-effort —
+ * tracker errors never propagate.
+ */
+function recordVerification(
+  tracker: import('../verification-tracker.js').VerificationTracker | undefined,
+  toolName: string,
+  args: unknown,
+  result: unknown,
+): void {
+  if (!tracker) return;
+  try {
+    tracker.recordCall(toolName, args, result);
+  } catch (err) {
+    debugLog(`augment:verificationTracker:threw`, err instanceof Error ? err.message : String(err));
+  }
 }

--- a/src/tools/evaluate.test.ts
+++ b/src/tools/evaluate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createEvaluateTool } from './evaluate.js';
+import { VerificationStore } from '../agent-status.js';
 
 const printEvaluation = vi.fn();
 vi.mock('../output.js', () => ({
@@ -14,7 +15,7 @@ describe('evaluate tool', () => {
     tool = createEvaluateTool();
   });
 
-  it('prints the evaluation and returns an ack', async () => {
+  it('prints the evaluation and returns the legacy ack when no checks provided', async () => {
     const result = await tool.execute!(
       { evaluation: 'Actually, that response looked empty — let me retry.' } as any,
       {} as any,
@@ -27,5 +28,57 @@ describe('evaluate tool', () => {
 
   it('requires evaluation text (zod schema)', () => {
     expect(tool.parameters).toBeDefined();
+  });
+
+  it('with structured checks: returns verdict-tagged ack and writes to VerificationStore', async () => {
+    const store = new VerificationStore();
+    const t = createEvaluateTool(store);
+    const result = await t.execute!(
+      {
+        evaluation: 'Wrote the file; confirmed via re-read.',
+        checks: [
+          { id: 'post_write_confirmed', label: 'post-write read', status: 'pass' },
+          { id: 'schema_matched', label: 'schema', status: 'pass' },
+        ],
+      } as any,
+      {} as any,
+    );
+    expect(result).toBe('Evaluation recorded: PASS (2 checks).');
+    const v = store.getLast();
+    expect(v?.verdict).toBe('pass');
+    expect(v?.source).toBe('evaluate');
+    expect(v?.checks).toHaveLength(2);
+  });
+
+  it('with a failing check: returns FAIL verdict and writes fail to store', async () => {
+    const store = new VerificationStore();
+    const t = createEvaluateTool(store);
+    const result = await t.execute!(
+      {
+        evaluation: 'Tried to write but the file is missing post-write.',
+        checks: [
+          {
+            id: 'post_write_confirmed',
+            label: 'post-write read',
+            status: 'fail',
+            evidence: 'file not found',
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+    expect(result).toBe('Evaluation recorded: FAIL (1 check).');
+    expect(store.getLast()?.verdict).toBe('fail');
+  });
+
+  it('without a VerificationStore: still tags the ack but does not throw', async () => {
+    const result = await tool.execute!(
+      {
+        evaluation: 'ok',
+        checks: [{ id: 'x', label: 'x', status: 'warn' }],
+      } as any,
+      {} as any,
+    );
+    expect(result).toBe('Evaluation recorded: WARN (1 check).');
   });
 });

--- a/src/tools/evaluate.ts
+++ b/src/tools/evaluate.ts
@@ -1,6 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printEvaluation } from '../output.js';
+import { verdictOf, type Check } from '../rubric.js';
+import type { VerificationStore } from '../agent-status.js';
 
 /**
  * Creates the `evaluate` tool for coordinator (ReAct) mode.
@@ -9,21 +11,50 @@ import { printEvaluation } from '../output.js';
  * reasoning), `evaluate` runs AFTER a tool call or batch of tool calls to
  * check whether the result matches expectations, surface surprises, and
  * decide whether to continue or course-correct.
+ *
+ * Issue #145 extension: callers may also pass a list of structured `checks`
+ * which compute a machine-checkable verdict (pass/warn/fail) and write it
+ * into the caller's `VerificationStore` if one was supplied.
  */
-export function createEvaluateTool() {
+const CheckSchema = z.object({
+  id: z.string().describe('Stable identifier for this check (e.g. "post_write_confirmed").'),
+  label: z.string().describe('Short human-readable label.'),
+  status: z.enum(['pass', 'warn', 'fail', 'skip']),
+  evidence: z.string().optional().describe('Optional one-line evidence.'),
+});
+
+export function createEvaluateTool(verification?: VerificationStore) {
   return tool({
     description:
-      "Self-evaluate after a tool call or batch of parallel calls. Required in coordinator mode between each act and the next think/act. State in 1-3 sentences: (1) did the result match what you expected, (2) did it reveal any surprises, errors, or risks, (3) should you continue on the current path or course-correct? Be willing to catch yourself — phrases like 'Actually, that's not right because...' or 'Wait — this might make things worse, let me take a different approach' are exactly what this is for.",
+      "Self-evaluate after a tool call or batch of parallel calls. Required in coordinator mode between each act and the next think/act. State in 1-3 sentences: (1) did the result match what you expected, (2) did it reveal any surprises, errors, or risks, (3) should you continue on the current path or course-correct? Be willing to catch yourself — phrases like 'Actually, that's not right because...' or 'Wait — this might make things worse, let me take a different approach' are exactly what this is for. You may optionally attach a `checks` array of structured judgments (pass/warn/fail/skip) — these contribute to the turn's machine-checkable rubric (issue #145).",
     parameters: z.object({
       evaluation: z
         .string()
         .describe(
           'A concise self-check after the most recent action (1-3 sentences). Cover: expectation vs. actual, any red flags, and whether to continue or correct course.',
         ),
+      checks: z
+        .array(CheckSchema)
+        .optional()
+        .describe(
+          'Optional structured checks behind the evaluation. Each Check states pass/warn/fail/skip plus optional evidence. Useful checks include: verification_ran, output_matched_schema, post_write_confirmed, plan_steps_terminal.',
+        ),
     }),
-    execute: async ({ evaluation }): Promise<string> => {
+    execute: async ({ evaluation, checks }): Promise<string> => {
       printEvaluation(evaluation);
-      return 'Evaluation recorded.';
+      if (!checks || checks.length === 0) {
+        return 'Evaluation recorded.';
+      }
+      const verdict = verdictOf(checks as Check[]);
+      if (verification) {
+        verification.setLast({
+          verdict,
+          reason: evaluation,
+          source: 'evaluate',
+          checks: checks as Check[],
+        });
+      }
+      return `Evaluation recorded: ${verdict.toUpperCase()} (${checks.length} check${checks.length === 1 ? '' : 's'}).`;
     },
   });
 }

--- a/src/tools/file.ts
+++ b/src/tools/file.ts
@@ -497,6 +497,32 @@ export function createFileTools(provenance?: ProvenanceStore) {
         deterministic: false,
         sideEffect: 'local',
         cacheable: false,
+        // Post-write check (issue #145): re-stat the file and confirm its
+        // hash matches the new_hash the tool just declared. Pass on match,
+        // warn on mismatch (someone else wrote it under us), fail if the
+        // file disappeared. Skips when the result shape isn't recognized.
+        verifyOutput: (_args, result) => {
+          if (!result || typeof result !== 'object') return null;
+          const r = result as Record<string, unknown>;
+          const p = typeof r.path === 'string' ? r.path : null;
+          const expected = typeof r.new_hash === 'string' ? r.new_hash : null;
+          if (!p || !expected) return null;
+          try {
+            const onDisk = fs.readFileSync(p, 'utf-8');
+            const actual = hashContent(onDisk);
+            if (actual === expected) {
+              return { status: 'pass', evidence: `hash matches (${actual.slice(0, 8)})` };
+            }
+            return {
+              status: 'warn',
+              evidence: `hash drift: declared ${expected.slice(0, 8)}, actual ${actual.slice(0, 8)}`,
+            };
+          } catch (err) {
+            const code = (err as NodeJS.ErrnoException)?.code;
+            if (code === 'ENOENT') return { status: 'fail', evidence: 'file missing post-write' };
+            return null;
+          }
+        },
       },
     ),
   };

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -21,6 +21,8 @@ import type { AgentContext } from '../framework/context.js';
 import type { PolicyDecision } from '../policy/types.js';
 import { ProvenanceStore } from '../provenance.js';
 import { VerificationStore } from '../agent-status.js';
+import { VerificationTracker } from '../verification-tracker.js';
+import type { Check } from '../rubric.js';
 import { type WrapperResult } from '../structured-output.js';
 import { appendReasoningLog } from '../reasoning-log.js';
 import { capSubagentResult, SUBAGENT_RESULT_MAX_CHARS } from './result-cap.js';
@@ -121,6 +123,13 @@ export interface ToolWrapperDeps {
    */
   verification?: VerificationStore;
   /**
+   * Parent turn's verification tracker + post-write check sink. Forwarded so
+   * tool calls made from inside a wrapper contribute to the same per-turn
+   * rubric the main agent composes. Issue #145.
+   */
+  verificationTracker?: VerificationTracker;
+  postWriteChecks?: Check[];
+  /**
    * Parent turn's policy decision. Forwarded so the inner wrapper
    * inherits the user's `toolMode` (#179) — otherwise the augment layer
    * defaults to `'write'` and any write tool the wrapper calls bypasses
@@ -146,6 +155,8 @@ export function ctxToToolWrapperDeps(ctx: AgentContext): ToolWrapperDeps {
     toolProfileStore: ctx.stores.toolProfiles,
     provenance: ctx.provenance,
     verification: ctx.verification,
+    verificationTracker: ctx.verificationTracker,
+    postWriteChecks: ctx.postWriteChecks,
     policyDecision: ctx.policyDecision,
   };
 }
@@ -167,6 +178,8 @@ export function depsToCtx(deps: ToolWrapperDeps): AgentContext {
     toolOptions: deps.options,
     provenance: deps.provenance ?? new ProvenanceStore(),
     verification: deps.verification ?? new VerificationStore(),
+    verificationTracker: deps.verificationTracker ?? new VerificationTracker(),
+    postWriteChecks: deps.postWriteChecks ?? [],
     ...(deps.policyDecision ? { policyDecision: deps.policyDecision } : {}),
   };
 }

--- a/src/verification-tracker.test.ts
+++ b/src/verification-tracker.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { VerificationTracker, tokenize } from './verification-tracker.js';
+import type { Step } from './plan-store.js';
+
+const step = (id: number, verification: string): Step => ({
+  id,
+  description: 'test step',
+  verification,
+  status: 'done',
+  signoff: 'done',
+});
+
+describe('tokenize', () => {
+  it('lowercases and splits on non-alphanumeric', () => {
+    expect(tokenize('Read README.md')).toEqual(new Set(['read', 'readme']));
+  });
+
+  it('drops short tokens', () => {
+    expect(tokenize('a b cd efg')).toEqual(new Set(['efg']));
+  });
+
+  it('drops stopwords', () => {
+    expect(tokenize('the file is in the directory')).toEqual(new Set(['file', 'directory']));
+  });
+
+  it('returns empty set on empty / stopword-only input', () => {
+    expect(tokenize('')).toEqual(new Set());
+    expect(tokenize('the and for')).toEqual(new Set());
+  });
+});
+
+describe('VerificationTracker.attest', () => {
+  it('returns pass when ≥2 tokens are matched across tool calls', () => {
+    const t = new VerificationTracker();
+    t.recordCall('file_read_lines', { path: 'src/foo.ts' }, 'export const foo = 1;');
+    t.recordCall('shell', { command: 'grep readme README.md' }, '');
+    const check = t.attest(step(1, 'Read README.md and confirm foo export'));
+    expect(check.status).toBe('pass');
+    expect(check.evidence).toContain('tokens matched');
+  });
+
+  it('returns warn on exactly 1 matched token', () => {
+    const t = new VerificationTracker();
+    // 'foo' is the only token in verification that appears in any call
+    t.recordCall('shell', { command: 'echo foo' }, 'foo');
+    const check = t.attest(step(2, 'Confirm widget xenon zephyr foo'));
+    expect(check.status).toBe('warn');
+  });
+
+  it('returns fail when no recorded calls reference any token', () => {
+    const t = new VerificationTracker();
+    t.recordCall('shell', { command: 'pwd' }, '/tmp');
+    const check = t.attest(step(3, 'Read README.md and confirm foo export'));
+    expect(check.status).toBe('fail');
+  });
+
+  it('returns fail when no calls were recorded at all', () => {
+    const t = new VerificationTracker();
+    const check = t.attest(step(4, 'Run tests and confirm passing'));
+    expect(check.status).toBe('fail');
+    expect(check.evidence).toContain('no tool calls');
+  });
+
+  it('returns skip when verification has no informative tokens', () => {
+    const t = new VerificationTracker();
+    t.recordCall('shell', { command: 'ls' }, 'output');
+    const check = t.attest(step(5, 'the and for'));
+    expect(check.status).toBe('skip');
+  });
+
+  it('matches tokens in tool name, args, or result', () => {
+    const t = new VerificationTracker();
+    t.recordCall('memory_write', { domain: 'general', text: 'noted' }, 'ok');
+    // 'memory' is in tool name, 'general' in args
+    const check = t.attest(step(6, 'Persist note to memory in general domain'));
+    expect(check.status).toBe('pass');
+  });
+
+  it('truncates result text to first ~500 chars', () => {
+    const t = new VerificationTracker();
+    const huge = 'x'.repeat(1000) + ' uniqueSentinel123';
+    t.recordCall('shell', { command: 'cat big' }, huge);
+    const check = t.attest(step(7, 'find uniqueSentinel123 in output'));
+    // 'uniquesentinel123' is past the 500-char cap, so 'find' is the only
+    // remaining (stopword-filtered) candidate → 0/1 matched → fail
+    expect(check.status).not.toBe('pass');
+  });
+});
+
+describe('VerificationTracker bookkeeping', () => {
+  it('callCount reflects record + clear', () => {
+    const t = new VerificationTracker();
+    expect(t.callCount()).toBe(0);
+    t.recordCall('shell', { command: 'a' }, '');
+    t.recordCall('shell', { command: 'b' }, '');
+    expect(t.callCount()).toBe(2);
+    t.clear();
+    expect(t.callCount()).toBe(0);
+  });
+
+  it('attestAll returns one Check per step', () => {
+    const t = new VerificationTracker();
+    t.recordCall('shell', { command: 'ls README.md' }, 'README.md');
+    const checks = t.attestAll([step(1, 'README exists'), step(2, 'foo bar baz')]);
+    expect(checks).toHaveLength(2);
+    expect(checks[0].id).toBe('attest_step_1');
+    expect(checks[1].id).toBe('attest_step_2');
+  });
+});

--- a/src/verification-tracker.test.ts
+++ b/src/verification-tracker.test.ts
@@ -87,6 +87,37 @@ describe('VerificationTracker.attest', () => {
   });
 });
 
+describe('VerificationTracker attestation gating', () => {
+  it('skips non-done steps (cancelled / errored / pending / in_progress)', () => {
+    const t = new VerificationTracker();
+    // Even with rich tool calls that would otherwise pass, a non-done step
+    // has nothing to attest — its plan-state classification owns it.
+    t.recordCall('file_read_lines', { path: 'src/foo.ts' }, 'foo bar baz');
+    t.recordCall('shell', { command: 'grep readme README.md' }, '');
+    for (const status of ['pending', 'in_progress', 'cancelled', 'error'] as const) {
+      const s: Step = {
+        id: 1,
+        description: 'd',
+        verification: 'Read README.md and confirm foo export',
+        status,
+      };
+      const check = t.attest(s);
+      expect(check.status, `status=${status}`).toBe('skip');
+      expect(check.evidence, `status=${status}`).toContain(status);
+    }
+  });
+
+  it('rejects false-positive substring matches (cat ≠ certificate)', () => {
+    const t = new VerificationTracker();
+    // Verification token `cat` would have matched the substring `certificate`
+    // under the old `corpus.includes(t)` rule. With token-set membership it
+    // must not — and `confirm` doesn't appear at all.
+    t.recordCall('shell', { command: 'openssl x509 -in cert.pem' }, 'certificate valid');
+    const check = t.attest(step(99, 'cat the file and confirm output'));
+    expect(check.status).not.toBe('pass');
+  });
+});
+
 describe('VerificationTracker bookkeeping', () => {
   it('callCount reflects record + clear', () => {
     const t = new VerificationTracker();

--- a/src/verification-tracker.ts
+++ b/src/verification-tracker.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-turn attestation tracker (issue #145).
+ *
+ * Records every tool call the agent makes during a turn so we can answer
+ * "did the agent actually execute the verification it claimed?" After the
+ * turn, `attest(verification)` tokenizes the plan step's verification text
+ * and looks for ≥2 distinct tokens across the recorded tool calls
+ * (name + args + first ~500 chars of result). Heuristic by design — meant
+ * to surface "you said you'd check X but never touched anything related,"
+ * not to be a proof.
+ */
+
+import type { Check } from './rubric.js';
+import type { Step } from './plan-store.js';
+
+interface RecordedCall {
+  toolName: string;
+  argsText: string;
+  resultText: string;
+}
+
+const STOPWORDS = new Set<string>([
+  'the',
+  'and',
+  'for',
+  'that',
+  'with',
+  'this',
+  'from',
+  'into',
+  'have',
+  'has',
+  'was',
+  'were',
+  'will',
+  'are',
+  'all',
+  'any',
+  'not',
+  'but',
+  'you',
+  'your',
+  'our',
+  'its',
+  "it's",
+  'a',
+  'an',
+  'in',
+  'on',
+  'at',
+  'of',
+  'to',
+  'is',
+  'be',
+  'by',
+  'do',
+  'or',
+  'as',
+  'so',
+  'check',
+  'verify',
+  'check_',
+  'should',
+  'than',
+  'then',
+  'when',
+  'must',
+  'can',
+  'see',
+  'run',
+]);
+
+const MIN_TOKEN_LEN = 3;
+const RESULT_PREVIEW_CHARS = 500;
+const MIN_MATCHES_FOR_PASS = 2;
+
+export class VerificationTracker {
+  private calls: RecordedCall[] = [];
+
+  recordCall(toolName: string, args: unknown, result: unknown): void {
+    this.calls.push({
+      toolName,
+      argsText: safeStringify(args),
+      resultText: safeStringify(result).slice(0, RESULT_PREVIEW_CHARS),
+    });
+  }
+
+  clear(): void {
+    this.calls = [];
+  }
+
+  callCount(): number {
+    return this.calls.length;
+  }
+
+  /**
+   * Attest one plan step's `verification` string against the recorded calls.
+   * Returns a Check with `pass`/`warn`/`fail` based on how many distinct
+   * verification-tokens were observed across the tool-call corpus.
+   */
+  attest(step: Step): Check {
+    const tokens = tokenize(step.verification);
+    const id = `attest_step_${step.id}`;
+    const label = `step ${step.id} verification exercised`;
+    if (tokens.size === 0) {
+      return { id, label, status: 'skip', evidence: 'no informative tokens' };
+    }
+    const corpus = this.calls
+      .map((c) => `${c.toolName} ${c.argsText} ${c.resultText}`.toLowerCase())
+      .join(' ');
+    if (corpus.length === 0) {
+      return { id, label, status: 'fail', evidence: 'no tool calls this turn' };
+    }
+    const matched = new Set<string>();
+    for (const t of tokens) {
+      if (corpus.includes(t)) matched.add(t);
+    }
+    if (matched.size >= MIN_MATCHES_FOR_PASS) {
+      return {
+        id,
+        label,
+        status: 'pass',
+        evidence: `${matched.size}/${tokens.size} tokens matched`,
+      };
+    }
+    if (matched.size === 1) {
+      return { id, label, status: 'warn', evidence: `only 1/${tokens.size} tokens matched` };
+    }
+    return { id, label, status: 'fail', evidence: `0/${tokens.size} tokens matched` };
+  }
+
+  /** Attest every non-skipped step on a plan. Returns one Check per step. */
+  attestAll(steps: readonly Step[]): Check[] {
+    return steps.map((s) => this.attest(s));
+  }
+}
+
+function safeStringify(v: unknown): string {
+  if (v === undefined || v === null) return '';
+  if (typeof v === 'string') return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+export function tokenize(text: string): Set<string> {
+  const out = new Set<string>();
+  if (!text) return out;
+  const lowered = text.toLowerCase();
+  for (const raw of lowered.split(/[^a-z0-9_]+/)) {
+    if (raw.length < MIN_TOKEN_LEN) continue;
+    if (STOPWORDS.has(raw)) continue;
+    out.add(raw);
+  }
+  return out;
+}

--- a/src/verification-tracker.ts
+++ b/src/verification-tracker.ts
@@ -97,23 +97,38 @@ export class VerificationTracker {
    * Attest one plan step's `verification` string against the recorded calls.
    * Returns a Check with `pass`/`warn`/`fail` based on how many distinct
    * verification-tokens were observed across the tool-call corpus.
+   *
+   * Only `done` steps are attested: `verification` describes the proof of
+   * successful completion, so cancelled / errored / pending steps have no
+   * verification to exercise. Plan-state checks (`steps_terminal`,
+   * `no_error_steps`, `signoffs_present`) cover those cases independently.
+   *
+   * Matching uses tokenized set-membership on both the verification text and
+   * the recorded tool-call corpus — substring matching would otherwise let
+   * `cat` satisfy `certificate`, `file` satisfy `profile`, etc.
    */
   attest(step: Step): Check {
-    const tokens = tokenize(step.verification);
     const id = `attest_step_${step.id}`;
     const label = `step ${step.id} verification exercised`;
+    if (step.status !== 'done') {
+      return { id, label, status: 'skip', evidence: `step is ${step.status}, not done` };
+    }
+    const tokens = tokenize(step.verification);
     if (tokens.size === 0) {
       return { id, label, status: 'skip', evidence: 'no informative tokens' };
     }
-    const corpus = this.calls
-      .map((c) => `${c.toolName} ${c.argsText} ${c.resultText}`.toLowerCase())
-      .join(' ');
-    if (corpus.length === 0) {
+    if (this.calls.length === 0) {
       return { id, label, status: 'fail', evidence: 'no tool calls this turn' };
+    }
+    const corpusTokens = new Set<string>();
+    for (const c of this.calls) {
+      for (const tok of tokenize(`${c.toolName} ${c.argsText} ${c.resultText}`)) {
+        corpusTokens.add(tok);
+      }
     }
     const matched = new Set<string>();
     for (const t of tokens) {
-      if (corpus.includes(t)) matched.add(t);
+      if (corpusTokens.has(t)) matched.add(t);
     }
     if (matched.size >= MIN_MATCHES_FOR_PASS) {
       return {
@@ -129,7 +144,12 @@ export class VerificationTracker {
     return { id, label, status: 'fail', evidence: `0/${tokens.size} tokens matched` };
   }
 
-  /** Attest every non-skipped step on a plan. Returns one Check per step. */
+  /**
+   * Attest every step on a plan. Returns one Check per step. Non-`done` steps
+   * yield a `skip` Check via {@link attest} so the consumer always gets a
+   * 1:1 mapping but worst-of aggregation isn't dragged down by steps the
+   * plan-state checks already classify.
+   */
   attestAll(steps: readonly Step[]): Check[] {
     return steps.map((s) => this.attest(s));
   }
@@ -149,7 +169,12 @@ export function tokenize(text: string): Set<string> {
   const out = new Set<string>();
   if (!text) return out;
   const lowered = text.toLowerCase();
-  for (const raw of lowered.split(/[^a-z0-9_]+/)) {
+  // Split on every non-alphanumeric character, INCLUDING underscore. Tool
+  // names like `memory_write` / `file_read_lines` carry their semantics in the
+  // sub-tokens, and the verification text rarely contains underscores — so
+  // splitting on `_` lets corpus tokens align with plain-English verification
+  // tokens (`memory`, `read`, `file`) without needing substring fallback.
+  for (const raw of lowered.split(/[^a-z0-9]+/)) {
     if (raw.length < MIN_TOKEN_LEN) continue;
     if (STOPWORDS.has(raw)) continue;
     out.add(raw);


### PR DESCRIPTION
## Summary

Replaces narrative self-evaluation with a machine-checkable rubric. Closes all four measurable checks called for in #145 in this PR — no follow-up issues.

- **Plan steps terminal?** `PlanStore.evaluateRubric()` derives `steps_terminal`, `signoffs_present` (≥10 char attestation), and `no_error_steps` from existing state.
- **Stated verification executed?** New `VerificationTracker` records every tool call (name, args, result preview) and answers attestation via token overlap against each step's `verification` string. Pass ≥2 token matches; warn 1; fail 0.
- **Did we mutate external state, and did we confirm it post-write?** New optional `ToolMeta.verifyOutput` hook runs after `status:'ok'`; `file_edit_lines` is the canonical opt-in (re-stats post-write, compares `new_hash`). Sink lives on `AgentContext.postWriteChecks`.
- **Evaluate emits structured judgment?** `evaluate` accepts optional `checks[]`, returns verdict-tagged ack, writes to `VerificationStore`. PAC critic verdict widened to include `'warn'`.

Surfacing:
- REPL turn footer renders one line via `renderRubricLine` (`eval: PASS (4✓)` / `eval: WARN (3✓ 1⚠) — …`).
- Cron log entries gain optional `verdict` + `rubricChecks`; both success and exception branches populate; warn-on-success is logged.
- Eval harness gains a new `evaluation-rubric` fixture with 13 invariants pinning `verdictOf`, `PlanStore.evaluateRubric`, and `verifyOutput`.

## Test plan

- [x] `npm test` — 2662 pass (116 files, +14 from rubric + tracker + fixture additions)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — no new warnings (150 → 150)
- [ ] Manual: REPL turn with multi-step plan shows `eval: PASS (4✓)` footer
- [ ] Manual: REPL turn that abandons a plan shows `eval: FAIL` with unresolved-steps reason
- [ ] Manual: cron job log entry has `verdict` + `rubricChecks` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)