### PR TITLE
feat(ui): phase A — ESM + Ink foundation + #211 round-1 fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "dotenv": "^16.4.0",
+        "ink": "^5.0.1",
         "node-cron": "^4.2.1",
         "node-html-parser": "^6.1.0",
         "node-notifier": "^10.0.1",
+        "react": "^18.3.1",
         "turndown": "^7.2.2",
         "zod": "^3.23.0"
       },
@@ -31,6 +33,7 @@
         "@types/node": "^22.10.0",
         "@types/node-cron": "^3.0.11",
         "@types/node-notifier": "^8.0.5",
+        "@types/react": "^18.3.12",
         "@types/turndown": "^5.0.6",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -223,6 +226,31 @@
       },
       "peerDependencies": {
         "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1386,6 +1414,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/turndown": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
@@ -1871,6 +1917,33 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1901,6 +1974,18 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/b4a": {
@@ -2162,6 +2247,89 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2226,6 +2394,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2268,6 +2445,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2432,6 +2616,12 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -2452,6 +2642,28 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2862,6 +3074,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -3027,6 +3251,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3037,6 +3273,84 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -3070,6 +3384,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3081,6 +3407,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -3259,6 +3600,24 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -3622,6 +3981,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3922,11 +4290,13 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3937,6 +4307,22 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -3971,6 +4357,52 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -4036,6 +4468,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -4181,6 +4622,49 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4189,6 +4673,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stackback": {
@@ -4223,6 +4728,38 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-final-newline": {
@@ -4464,6 +5001,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -5162,6 +5711,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5172,11 +5736,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -5190,6 +5804,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "bernard-agent",
   "version": "0.9.0",
   "description": "Local CLI AI agent with multi-provider support",
+  "type": "module",
   "main": "dist/index.js",
   "bin": {
     "bernard": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc && node -e \"require('fs').cpSync('src/builtin-specialists','dist/builtin-specialists',{recursive:true})\"",
+    "build": "tsc && node scripts/copy-builtins.mjs",
     "dev": "BERNARD_DEBUG=1 tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run",
@@ -60,9 +61,11 @@
     "chalk": "^4.1.2",
     "commander": "^12.1.0",
     "dotenv": "^16.4.0",
+    "ink": "^5.0.1",
     "node-cron": "^4.2.1",
     "node-html-parser": "^6.1.0",
     "node-notifier": "^10.0.1",
+    "react": "^18.3.1",
     "turndown": "^7.2.2",
     "zod": "^3.23.0"
   },
@@ -70,6 +73,7 @@
     "@types/node": "^22.10.0",
     "@types/node-cron": "^3.0.11",
     "@types/node-notifier": "^8.0.5",
+    "@types/react": "^18.3.12",
     "@types/turndown": "^5.0.6",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",

--- a/scripts/copy-builtins.mjs
+++ b/scripts/copy-builtins.mjs
@@ -1,0 +1,3 @@
+import { cpSync } from 'node:fs';
+
+cpSync('src/builtin-specialists', 'dist/builtin-specialists', { recursive: true });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -612,7 +612,7 @@ export class Agent {
       // missed. Scan every step plus the final text. Issues #173, #211.
       this.lastSources = this.ctx.provenance.list();
       const stepTexts = (result.steps ?? [])
-        .map((s: any) => (typeof s.text === 'string' ? s.text : ''))
+        .map((s) => (typeof s.text === 'string' ? s.text : ''))
         .join('\n');
       const citedScanText = stepTexts + '\n' + (result.text ?? '');
       const citedIds = extractCitationMarkers(citedScanText, this.ctx.provenance);
@@ -628,10 +628,16 @@ export class Agent {
 
       // Append a per-turn snapshot for the Shift+Tab full-screen viewer
       // (#211). Only record turns that actually had something to cite —
-      // empty turns would clutter the history view.
+      // empty turns would clutter the history view. `turnIndex` is the
+      // *conversation* turn position (0-based count of user messages in
+      // history), not the index within `turnProvenance` — otherwise turns
+      // that registered no sources would compress the indices and the
+      // viewer would show "Turn 2" for what the user typed as their 5th
+      // message. Derived from history so it's also correct on resume.
       if (this.lastSources.length > 0) {
+        const userTurnCount = this.history.filter((m) => m.role === 'user').length;
         this.turnProvenance.push({
-          turnIndex: this.turnProvenance.length,
+          turnIndex: Math.max(0, userTurnCount - 1),
           userInput: userInput,
           sources: this.lastSources.map((s) => ({ ...s })),
           citedIds: [...citedIds],

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -46,7 +46,7 @@ import { type ResolvedEntry } from './reference-resolver.js';
 import type { AgentContext } from './framework/context.js';
 import { DefaultPolicyEngine, isReactEffective } from './policy/index.js';
 import type { PolicyEngine, PolicyResult } from './policy/index.js';
-import { extractCitationMarkers, type SourceItem } from './provenance.js';
+import { extractCitationMarkers, type SourceItem, type TurnProvenance } from './provenance.js';
 import type { Step } from './plan-store.js';
 import type { VerificationEntry } from './agent-status.js';
 import { verdictOf, renderRubricLine, type Check, type Rubric } from './rubric.js';
@@ -101,6 +101,12 @@ export class Agent {
   private lastRAGResults: RAGSearchResult[] = [];
   private lastSources: SourceItem[] = [];
   private lastCitedSources: SourceItem[] = [];
+  /**
+   * Per-turn citation snapshots for the whole current conversation —
+   * powers the Shift+Tab full-screen citation viewer. Issue #211. Cleared
+   * by {@link clearHistory}; loaded on resume via {@link setTurnProvenance}.
+   */
+  private turnProvenance: TurnProvenance[] = [];
   /** Most recent per-turn rubric (#145). Composed at end of `processInput`. */
   private lastRubric: Rubric | null = null;
   private abortController: AbortController | null = null;
@@ -174,6 +180,23 @@ export class Agent {
    */
   getLastCitedSources(): SourceItem[] {
     return this.lastCitedSources;
+  }
+
+  /**
+   * Returns a snapshot of every completed turn's provenance for this
+   * conversation. Powers the Shift+Tab full-screen citation viewer.
+   * Issue #211.
+   */
+  getTurnProvenance(): TurnProvenance[] {
+    return [...this.turnProvenance];
+  }
+
+  /**
+   * Restores per-turn citation snapshots when a session is resumed. Replaces
+   * any in-memory records. Issue #211.
+   */
+  setTurnProvenance(records: TurnProvenance[]): void {
+    this.turnProvenance = [...records];
   }
 
   /**
@@ -583,10 +606,16 @@ export class Agent {
 
       // Snapshot provenance for the REPL viewer. `lastSources` is everything
       // registered this turn; `lastCitedSources` is the subset whose ids
-      // appeared as `[^Sn]` markers in the final text. Invalid markers are
-      // silently dropped by `extractCitationMarkers`. Issue #173.
+      // appeared as `[^Sn]` markers anywhere in the turn's emitted text.
+      // `result.text` is only the *final* step's prose; if the model emits
+      // markers in an earlier step and ends with a tool call, they would be
+      // missed. Scan every step plus the final text. Issues #173, #211.
       this.lastSources = this.ctx.provenance.list();
-      const citedIds = extractCitationMarkers(result.text ?? '', this.ctx.provenance);
+      const stepTexts = (result.steps ?? [])
+        .map((s: any) => (typeof s.text === 'string' ? s.text : ''))
+        .join('\n');
+      const citedScanText = stepTexts + '\n' + (result.text ?? '');
+      const citedIds = extractCitationMarkers(citedScanText, this.ctx.provenance);
       this.lastCitedSources = citedIds
         .map((id) => this.ctx.provenance.get(id))
         .filter((s): s is SourceItem => s !== undefined);
@@ -594,6 +623,19 @@ export class Agent {
         debugLog('agent:citations', {
           available: this.lastSources.length,
           cited: 0,
+        });
+      }
+
+      // Append a per-turn snapshot for the Shift+Tab full-screen viewer
+      // (#211). Only record turns that actually had something to cite —
+      // empty turns would clutter the history view.
+      if (this.lastSources.length > 0) {
+        this.turnProvenance.push({
+          turnIndex: this.turnProvenance.length,
+          userInput: userInput,
+          sources: this.lastSources.map((s) => ({ ...s })),
+          citedIds: [...citedIds],
+          timestamp: Date.now(),
         });
       }
 
@@ -678,6 +720,7 @@ export class Agent {
     this.lastResolvedReferences = [];
     this.lastSources = [];
     this.lastCitedSources = [];
+    this.turnProvenance = [];
     this.ctx.verification.clear();
     this.ctx.provenance.clear();
     this.ctx.postWriteChecks.length = 0;

--- a/src/cron/client.ts
+++ b/src/cron/client.ts
@@ -1,7 +1,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { fork } from 'node:child_process';
 import { CronStore } from './store.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** Checks whether the daemon process is alive by sending signal 0 to the recorded PID. Cleans up stale PID files. */
 export function isDaemonRunning(): boolean {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -54,6 +54,7 @@ export const UPDATE_CACHE_PATH = path.join(CACHE_DIR, 'update-check.json');
 
 // State
 export const HISTORY_FILE = path.join(STATE_DIR, 'conversation-history.json');
+export const PROVENANCE_HISTORY_FILE = path.join(STATE_DIR, 'provenance-history.json');
 export const LOGS_DIR = path.join(STATE_DIR, 'logs');
 export const TOOL_WRAPPER_LOG = path.join(LOGS_DIR, 'tool-wrappers.jsonl');
 export const CRON_PID_FILE = path.join(STATE_DIR, 'cron-daemon.pid');

--- a/src/provenance-history.test.ts
+++ b/src/provenance-history.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProvenanceHistoryStore } from './provenance-history.js';
+import type { TurnProvenance } from './provenance.js';
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+const fs = await import('node:fs');
+
+function makeRecord(turnIndex: number): TurnProvenance {
+  return {
+    turnIndex,
+    userInput: `q${turnIndex}`,
+    sources: [
+      {
+        id: 'S1',
+        kind: 'web',
+        label: 'example',
+        contentPreview: 'preview',
+        rawRef: 'https://example.com',
+        timestamp: 0,
+      },
+    ],
+    citedIds: ['S1'],
+    timestamp: 0,
+  };
+}
+
+describe('ProvenanceHistoryStore', () => {
+  let store: ProvenanceHistoryStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new ProvenanceHistoryStore();
+  });
+
+  describe('load', () => {
+    it('returns empty array when file does not exist', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      expect(store.load()).toEqual([]);
+    });
+
+    it('returns empty array for corrupt JSON', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('not valid json{{{');
+      expect(store.load()).toEqual([]);
+    });
+
+    it('returns empty array for non-array JSON', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('{"turnIndex": 0}');
+      expect(store.load()).toEqual([]);
+    });
+
+    it('filters entries missing required fields', () => {
+      const records = [
+        makeRecord(0),
+        { turnIndex: 'oops', sources: [], citedIds: [] },
+        { sources: [], citedIds: [] },
+        makeRecord(1),
+        null,
+        42,
+      ];
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(records));
+      const result = store.load();
+      expect(result).toHaveLength(2);
+      expect(result[0].turnIndex).toBe(0);
+      expect(result[1].turnIndex).toBe(1);
+    });
+
+    it('round-trips well-formed records', () => {
+      const records = [makeRecord(0), makeRecord(1)];
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(records));
+      expect(store.load()).toEqual(records);
+    });
+  });
+
+  describe('save', () => {
+    it('performs atomic write with tmp + rename', () => {
+      const records = [makeRecord(0)];
+      store.save(records);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('bernard'), {
+        recursive: true,
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('.tmp'),
+        JSON.stringify(records, null, 2),
+        'utf-8',
+      );
+      expect(fs.renameSync).toHaveBeenCalledWith(
+        expect.stringContaining('.tmp'),
+        expect.stringContaining('provenance-history.json'),
+      );
+    });
+  });
+
+  describe('clear', () => {
+    it('deletes the history file when it exists', () => {
+      store.clear();
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining('provenance-history.json'),
+      );
+    });
+
+    it('does not throw when file does not exist', () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      expect(() => store.clear()).not.toThrow();
+    });
+  });
+});

--- a/src/provenance-history.test.ts
+++ b/src/provenance-history.test.ts
@@ -73,6 +73,24 @@ describe('ProvenanceHistoryStore', () => {
       expect(result[1].turnIndex).toBe(1);
     });
 
+    it('filters entries missing userInput or timestamp', () => {
+      // The full-screen viewer dereferences `userInput.replace(...)` and
+      // `formatRelativeTime(timestamp)` unconditionally. A persisted record
+      // missing either field would crash the REPL on Shift+Tab.
+      const records = [
+        makeRecord(0),
+        { turnIndex: 1, sources: [], citedIds: [], timestamp: 0 }, // no userInput
+        { turnIndex: 2, sources: [], citedIds: [], userInput: 'q' }, // no timestamp
+        { turnIndex: 3, sources: [], citedIds: [], userInput: 0, timestamp: 0 }, // wrong type
+        makeRecord(4),
+      ];
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(records));
+      const result = store.load();
+      expect(result).toHaveLength(2);
+      expect(result[0].turnIndex).toBe(0);
+      expect(result[1].turnIndex).toBe(4);
+    });
+
     it('round-trips well-formed records', () => {
       const records = [makeRecord(0), makeRecord(1)];
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(records));

--- a/src/provenance-history.ts
+++ b/src/provenance-history.ts
@@ -14,14 +14,17 @@ export class ProvenanceHistoryStore {
       const data = fs.readFileSync(PROVENANCE_HISTORY_FILE, 'utf-8');
       const parsed = JSON.parse(data);
       if (!Array.isArray(parsed)) return [];
-      return parsed.filter(
-        (entry: unknown): entry is TurnProvenance =>
-          typeof entry === 'object' &&
-          entry !== null &&
-          typeof (entry as TurnProvenance).turnIndex === 'number' &&
-          Array.isArray((entry as TurnProvenance).sources) &&
-          Array.isArray((entry as TurnProvenance).citedIds),
-      );
+      return parsed.filter((entry: unknown): entry is TurnProvenance => {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const e = entry as Partial<TurnProvenance>;
+        return (
+          typeof e.turnIndex === 'number' &&
+          typeof e.userInput === 'string' &&
+          typeof e.timestamp === 'number' &&
+          Array.isArray(e.sources) &&
+          Array.isArray(e.citedIds)
+        );
+      });
     } catch {
       return [];
     }

--- a/src/provenance-history.ts
+++ b/src/provenance-history.ts
@@ -1,0 +1,44 @@
+import * as fs from 'node:fs';
+import type { TurnProvenance } from './provenance.js';
+import { STATE_DIR, PROVENANCE_HISTORY_FILE } from './paths.js';
+
+/**
+ * Persists the per-turn citation snapshots that power the Shift+Tab
+ * full-screen citation viewer (#211). Sibling of {@link HistoryStore}:
+ * conversation history stores messages; this stores the sources cited in
+ * each turn. Uses atomic writes (write-to-temp then rename).
+ */
+export class ProvenanceHistoryStore {
+  load(): TurnProvenance[] {
+    try {
+      const data = fs.readFileSync(PROVENANCE_HISTORY_FILE, 'utf-8');
+      const parsed = JSON.parse(data);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(
+        (entry: unknown): entry is TurnProvenance =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          typeof (entry as TurnProvenance).turnIndex === 'number' &&
+          Array.isArray((entry as TurnProvenance).sources) &&
+          Array.isArray((entry as TurnProvenance).citedIds),
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  save(records: TurnProvenance[]): void {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    const tmp = PROVENANCE_HISTORY_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(records, null, 2), 'utf-8');
+    fs.renameSync(tmp, PROVENANCE_HISTORY_FILE);
+  }
+
+  clear(): void {
+    try {
+      fs.unlinkSync(PROVENANCE_HISTORY_FILE);
+    } catch {
+      // file may not exist — ignore
+    }
+  }
+}

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -31,6 +31,23 @@ export interface SourceItem {
 
 export type SourceItemInput = Omit<SourceItem, 'id' | 'timestamp'>;
 
+/**
+ * Snapshot of one completed turn's provenance, for the Shift+Tab citation
+ * history view. Persisted alongside conversation history. Issue #211.
+ */
+export interface TurnProvenance {
+  /** Monotonic index within the conversation (0-based). */
+  turnIndex: number;
+  /** Raw user input that started this turn. Trimmed for display. */
+  userInput: string;
+  /** Every source registered during the turn. */
+  sources: SourceItem[];
+  /** Subset of `sources[].id` that the model actually cited with `[^Sn]`. */
+  citedIds: string[];
+  /** Wall-clock epoch ms at end of turn. */
+  timestamp: number;
+}
+
 const MAX_PREVIEW = 200;
 
 function truncatePreview(s: string): string {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -5,8 +5,6 @@ import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
 import * as os from 'node:os';
 import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {
   RAG_DIR,
   MCP_CONFIG_PATH,
@@ -148,11 +146,14 @@ import {
 import {
   selectFromMenu,
   promptValue,
+  MENU_REGION_ID,
   type MenuEntry,
   type MenuItem,
   type SelectResult,
   type ValueResult,
 } from './menu.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Launch the interactive REPL, wiring up readline, MCP servers, memory stores, and the agent loop.
@@ -834,10 +835,13 @@ export async function startRepl(
    * thread until Esc is pressed. Issue #211.
    */
   function enterFullScreenSources(): void {
-    // Drop any pinned regions (status overlay, plan strip) so they don't
-    // bleed into the full-screen paint.
+    // Drop any pinned regions (status overlay, plan strip, any menu /
+    // prompt-header left by an aborted selectFromMenu) so they don't
+    // bleed back in when the next paint re-renders pinned regions.
     clearPinnedRegion('viewer');
     clearPinnedRegion('plan');
+    clearPinnedRegion(MENU_REGION_ID);
+    clearPinnedRegion('prompt-header');
 
     const t = getTheme();
     const turns = agent.getTurnProvenance();
@@ -3087,6 +3091,9 @@ Remember: the systemPrompt should read like a persona definition — who this sp
 
         processing = true;
         interrupted = false;
+        // A new turn invalidates any pinned/full-screen viewer from the
+        // previous one. Same as the main text-input path below.
+        closeViewer();
         try {
           initSpinner();
           await agent.processInput(userText, [attachment]);
@@ -3136,6 +3143,9 @@ Remember: the systemPrompt should read like a persona definition — who this sp
 
           processing = true;
           interrupted = false;
+          // A new turn invalidates any pinned/full-screen viewer from the
+          // previous one. Same as the main text-input path below.
+          closeViewer();
           try {
             initSpinner();
             await agent.processInput(message);

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -4,6 +4,9 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
 import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {
   RAG_DIR,
   MCP_CONFIG_PATH,
@@ -85,7 +88,6 @@ import {
 } from './custom-providers.js';
 import type { SupportedSdk } from './providers/types.js';
 import { getTheme, setTheme, getThemeKeys, getActiveThemeKey, THEMES } from './theme.js';
-import type { SourceItem } from './provenance.js';
 import { renderRubricLine } from './rubric.js';
 import {
   buildAgentStatusPanel,
@@ -97,6 +99,7 @@ import { interactiveUpdate, getLocalVersion } from './update.js';
 import { CronStore } from './cron/store.js';
 import { isDaemonRunning } from './cron/client.js';
 import { HistoryStore } from './history.js';
+import { ProvenanceHistoryStore } from './provenance-history.js';
 import { generateText } from 'ai';
 import { getModelProfile } from './providers/index.js';
 import { resolveSiteModel } from './model-policy.js';
@@ -777,6 +780,11 @@ export async function startRepl(
     sources: 'Sources',
   };
   let viewerTab: ViewerTab | null = null;
+  // Sources is rendered full-screen (replace-thread) rather than as a pinned
+  // overlay so users can audit citations across the whole conversation. The
+  // flag suppresses hint redraws while active; Esc returns to the thread.
+  // Issue #211.
+  let fullScreenSourcesActive = false;
 
   function buildViewerHeader(active: ViewerTab, title: string): string[] {
     const t = getTheme();
@@ -784,27 +792,6 @@ export async function startRepl(
       tab === active ? t.accentBold(`[${VIEWER_LABELS[tab]}]`) : t.dim(VIEWER_LABELS[tab]),
     ).join('  ');
     return [`${t.accentBold(`▼ ${title}`)}  ${t.dim('·')}  ${strip}`];
-  }
-
-  function buildSourcesPanel(sources: SourceItem[], title: string): string[] {
-    const t = getTheme();
-    const lines: string[] = buildViewerHeader('sources', title);
-    if (sources.length === 0) {
-      lines.push(t.dim('(no sources from the last turn)'));
-    }
-    for (const s of sources) {
-      const head = `${t.accent(`[^${s.id}]`)} ${t.dim(`(${s.kind})`)} ${s.label}`;
-      lines.push(head);
-      if (s.rawRef && s.rawRef !== s.label) {
-        lines.push(`    ${t.dim(s.rawRef)}`);
-      }
-      if (s.contentPreview) {
-        const preview = s.contentPreview.replace(/\s+/g, ' ').slice(0, 160);
-        lines.push(`    ${t.dim(preview)}`);
-      }
-    }
-    lines.push(t.dim('Shift+Tab to cycle · Esc to close'));
-    return lines;
   }
 
   function buildStatusPanel(): string[] {
@@ -829,32 +816,114 @@ export async function startRepl(
     return lines;
   }
 
+  function formatRelativeTime(ts: number): string {
+    const delta = Math.max(0, Date.now() - ts);
+    const sec = Math.floor(delta / 1000);
+    if (sec < 60) return `${sec}s ago`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    const day = Math.floor(hr / 24);
+    return `${day}d ago`;
+  }
+
+  /**
+   * Paint the full-screen citation history view — every turn's sources for
+   * the current conversation, with cited entries highlighted. Replaces the
+   * thread until Esc is pressed. Issue #211.
+   */
+  function enterFullScreenSources(): void {
+    // Drop any pinned regions (status overlay, plan strip) so they don't
+    // bleed into the full-screen paint.
+    clearPinnedRegion('viewer');
+    clearPinnedRegion('plan');
+
+    const t = getTheme();
+    const turns = agent.getTurnProvenance();
+
+    // Clear screen and home cursor.
+    process.stdout.write('\x1b[2J\x1b[H');
+
+    const header = buildViewerHeader('sources', 'Citations — current conversation');
+    for (const line of header) process.stdout.write(line + '\n');
+    process.stdout.write('\n');
+
+    if (turns.length === 0) {
+      process.stdout.write(t.dim('No citations recorded in this conversation yet.') + '\n');
+    } else {
+      for (const turn of turns) {
+        const citedSet = new Set(turn.citedIds);
+        const inputSnip = turn.userInput.replace(/\s+/g, ' ').slice(0, 80);
+        const relTime = formatRelativeTime(turn.timestamp);
+        process.stdout.write(
+          t.accentBold(`Turn ${turn.turnIndex + 1}`) +
+            t.dim(` · ${relTime} · `) +
+            t.dim(`"${inputSnip}"`) +
+            '\n',
+        );
+        if (turn.sources.length === 0) {
+          process.stdout.write('  ' + t.dim('(no sources)') + '\n');
+        } else {
+          for (const s of turn.sources) {
+            const cited = citedSet.has(s.id);
+            const idLabel = cited ? t.accent(`[^${s.id}]`) : t.dim(`[^${s.id}]`);
+            const kindBadge = t.dim(`(${s.kind})`);
+            const head = `  ${idLabel} ${kindBadge} ${cited ? s.label : t.dim(s.label)}`;
+            process.stdout.write(head + '\n');
+            if (s.rawRef && s.rawRef !== s.label) {
+              process.stdout.write('      ' + t.dim(s.rawRef) + '\n');
+            }
+            if (s.contentPreview) {
+              const preview = s.contentPreview.replace(/\s+/g, ' ').slice(0, 160);
+              process.stdout.write('      ' + t.dim(preview) + '\n');
+            }
+          }
+        }
+        process.stdout.write('\n');
+      }
+    }
+
+    process.stdout.write(t.dim('Esc to return to thread · Shift+Tab to close') + '\n');
+
+    fullScreenSourcesActive = true;
+    viewerTab = 'sources';
+  }
+
+  function exitFullScreenSources(): void {
+    if (!fullScreenSourcesActive) return;
+    fullScreenSourcesActive = false;
+    viewerTab = null;
+    hintLineCount = 0;
+    // Clear screen and redraw the thread + prompt so the user lands back
+    // where they were.
+    process.stdout.write('\x1b[2J\x1b[H');
+    printConversationReplay(agent.getHistory());
+    process.stdout.write(getPromptStr());
+  }
+
   function renderViewer(tab: ViewerTab): void {
     if (tab === 'status') {
       setPinnedRegion('viewer', buildStatusPanel());
-    } else {
-      const cited = agent.getLastCitedSources();
-      const all = agent.getLastSources();
-      const sources = cited.length > 0 ? cited : all;
-      const title =
-        cited.length > 0
-          ? 'Cited sources (last response)'
-          : all.length > 0
-            ? 'Available sources (last turn — none cited)'
-            : 'Sources';
-      setPinnedRegion('viewer', buildSourcesPanel(sources, title));
+      viewerTab = tab;
+      return;
     }
-    viewerTab = tab;
+    // tab === 'sources' is now the full-screen replace-thread view.
+    enterFullScreenSources();
   }
 
   function closeViewer(): void {
+    if (fullScreenSourcesActive) {
+      exitFullScreenSources();
+      return;
+    }
     if (viewerTab === null) return;
     clearPinnedRegion('viewer');
     viewerTab = null;
   }
 
   function cycleViewer(): void {
-    // null → status → sources → null
+    // null → status (overlay) → sources (full-screen) → null
     if (viewerTab === null) {
       renderViewer(VIEWER_TABS[0]);
       return;
@@ -864,6 +933,11 @@ export async function startRepl(
     if (!next) {
       closeViewer();
       return;
+    }
+    // Moving from `status` to `sources` first tears down the pinned status
+    // overlay before painting full-screen so they don't overlap.
+    if (viewerTab === 'status') {
+      clearPinnedRegion('viewer');
     }
     renderViewer(next);
   }
@@ -923,7 +997,8 @@ export async function startRepl(
       !isPasting &&
       key.name !== 'paste-start' &&
       key.name !== 'paste-end' &&
-      key.name !== 'return'
+      key.name !== 'return' &&
+      !fullScreenSourcesActive
     ) {
       process.nextTick(() => {
         const line = (rl as any).line as string;
@@ -1160,6 +1235,7 @@ export async function startRepl(
   };
 
   const historyStore = new HistoryStore();
+  const provenanceHistoryStore = new ProvenanceHistoryStore();
   let initialHistory: import('ai').CoreMessage[] | undefined;
   if (resume) {
     const loaded = historyStore.load();
@@ -1217,6 +1293,20 @@ export async function startRepl(
     },
   });
   const agent = new Agent(agentCtx, { alertContext, initialHistory });
+
+  // Restore per-turn citation snapshots so the Shift+Tab full-screen
+  // viewer shows history from prior sessions on `bernard --resume` (#211).
+  if (resume) {
+    agent.setTurnProvenance(provenanceHistoryStore.load());
+  }
+
+  // Save both conversation history and per-turn citation snapshots together
+  // — they must stay in sync, and every save site already calls
+  // `historyStore.save(agent.getHistory())`. Issue #211.
+  function persistAgentState(): void {
+    historyStore.save(agent.getHistory());
+    provenanceHistoryStore.save(agent.getTurnProvenance());
+  }
 
   // Drain the correction-candidate backlog of non-correctable failures
   // (HTTP 404, rate limits, pool exhaustion, etc.) before the agent runs.
@@ -1346,7 +1436,7 @@ export async function startRepl(
     try {
       initSpinner();
       await agent.processInput(message);
-      historyStore.save(agent.getHistory());
+      persistAgentState();
     } catch (err: unknown) {
       if (!interrupted) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -1595,6 +1685,7 @@ export async function startRepl(
 
         agent.clearHistory();
         historyStore.clear();
+        provenanceHistoryStore.clear();
         console.clear();
         printWelcome(
           config.provider,
@@ -1629,7 +1720,7 @@ export async function startRepl(
               `Compacted: ~${formatTokenCount(result.tokensBefore)} → ~${formatTokenCount(result.tokensAfter)} tokens (${pct}% reduction)`,
             );
           }
-          historyStore.save(agent.getHistory());
+          persistAgentState();
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           printError(`Compaction failed: ${message}`);
@@ -2999,7 +3090,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
         try {
           initSpinner();
           await agent.processInput(userText, [attachment]);
-          historyStore.save(agent.getHistory());
+          persistAgentState();
         } catch (err: unknown) {
           if (!interrupted) {
             printError(err instanceof Error ? err.message : String(err));
@@ -3048,7 +3139,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
           try {
             initSpinner();
             await agent.processInput(message);
-            historyStore.save(agent.getHistory());
+            persistAgentState();
           } catch (err: unknown) {
             if (!interrupted) {
               const message = err instanceof Error ? err.message : String(err);
@@ -3112,7 +3203,7 @@ Remember: the systemPrompt should read like a persona definition — who this sp
     try {
       initSpinner();
       await agent.processInput(agentInput, inlineImages, resolvedEntries);
-      historyStore.save(agent.getHistory());
+      persistAgentState();
       // Per-turn rubric footer (#145). One muted line showing the composed
       // verdict + check counts. Suppressed when there is nothing to attest
       // (no checks of any kind contributed this turn — e.g. a pure-question

--- a/src/specialists.ts
+++ b/src/specialists.ts
@@ -1,8 +1,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { SPECIALISTS_DIR } from './paths.js';
 import { RESERVED_NAMES } from './reserved-names.js';
 import { atomicWriteFileSync, seedOnce } from './fs-utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** Specialist category. `persona` is the historical default; `tool-wrapper` specialists front a concrete tool or CLI; `meta` specialists operate on other specialists (e.g. specialist-creator, correction-agent). */
 export type SpecialistKind = 'persona' | 'tool-wrapper' | 'meta';

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,9 +1,12 @@
 import * as https from 'node:https';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { printInfo, printError } from './output.js';
 import { UPDATE_CACHE_PATH as CACHE_PATH } from './paths.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
First of six phases in the **nuclear REPL UI migration to Ink** (the response to repeated render-layer bugs in #211).

## Why bundled

Two distinct change sets land together because they're prerequisites for the same downstream phase:

1. **Phase A: ESM + Ink foundation** — flips the package to ESM, installs Ink + React, sets up the JSX runtime. Pure plumbing; no UI changes.
2. **#211 round-1 fixes** — agent-side marker-scan bug fix + new per-turn provenance data model + disk persistence. These are the data layer `<SourcesViewer>` will read in Phase B (#213), so they need to land first.

The Ink components themselves (Phase B) are explicitly **not** in this PR.

## Phase A: ESM + Ink foundation

- `package.json`: `"type": "module"`, adds `ink@^5.0.1`, `react@^18.3.1`, `@types/react@^18.3.12`. Build script moved to `scripts/copy-builtins.mjs` (the inline `node -e \"require(...)\"` doesn't work under ESM).
- `tsconfig.json`: `"jsx": "react-jsx"` — new JSX runtime, no `import React` boilerplate in components.
- Four `__dirname` sites rewritten via `fileURLToPath(import.meta.url)`: `src/update.ts`, `src/specialists.ts`, `src/cron/client.ts`, `src/repl.ts`.
- `chalk` intentionally **kept** for now — `src/theme.ts` still consumes it, chalk v4 (CJS) loads fine from ESM via Node's interop. It comes out in Phase D (#215) when `theme.ts` is rewritten to Ink color tokens.

No `require()` calls and no `module.exports` exist in `src/`, so no further ESM blockers.

## #211 round-1 fixes (carry-forward)

- **Marker-scan bug fix** (`src/agent.ts`): `extractCitationMarkers` previously ran on `result.text` (final step only). If the model emitted `[^Sn]` markers in an intermediate step and ended with a tool call, the final response showed citations but the viewer said \"no citations recorded.\" Now scans every `result.steps[].text` + `result.text`.
- **Per-turn provenance** (`src/provenance.ts`, `src/agent.ts`): new `TurnProvenance` interface — \`{turnIndex, userInput, sources, citedIds, timestamp}\`. `Agent` maintains a \`turnProvenance[]\` across the conversation, appended after each turn that registered sources, cleared in `clearHistory`, restored via `setTurnProvenance` on resume.
- **Disk persistence** (`src/provenance-history.ts` + test, `src/paths.ts`): new `ProvenanceHistoryStore` mirrors `HistoryStore`. Atomic write (tmp + rename), validates entries on load, stored at `STATE_DIR/provenance-history.json`. Wired into 5 save sites + 1 clear in `src/repl.ts`.
- **Full-screen Sources viewer** (`src/repl.ts`): `enterFullScreenSources` / `exitFullScreenSources` — paint-once full-screen citation list, every turn, cited entries accent-marked. Shift-Tab cycles to it.

## Known caveats in this PR (resolved by later phases)

The full-screen Sources viewer added here has **two open bugs** that are exactly what motivated the nuclear pivot:

1. The Status tab still uses `setPinnedRegion` and appears pinned under the prompt instead of full-screen.
2. Pressing Esc re-runs `printConversationReplay` (designed for resume-time dim replay), producing a fragmented \"Previous conversation:\" artifact instead of restoring the live thread.

Both disappear when the bespoke render layer is replaced in **Phase B (#213)** + **Phase D (#215)**. Patching them here would be churn against code that's getting deleted.

## Verification

- `npm run build` — clean.
- `npm test` — **2672/2672 pass**, including the 8 new `provenance-history.test.ts` tests + updated marker-scan coverage in `agent.test.ts`.

## Follow-up phases

| Phase | Issue | Scope |
|---|---|---|
| B | #213 | Ink app shell + overlays — closes remaining #211 UI bugs |
| C | #214 | Streaming output via Ink `useSyncExternalStore` message store |
| D | #215 | Delete bespoke layer (`setPinnedRegion`, `selectFromMenu`, chalk) |
| E | #216 | Rewrite REPL tests with `ink-testing-library` |
| F | #217 | Update CLAUDE.md for the new architecture |

Refs #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)