### PR TITLE
feat(ui): phase B — Ink component tree (build-only) (#213)

### DIFF
--- a/scripts/preview-ink.mjs
+++ b/scripts/preview-ink.mjs
@@ -33,7 +33,7 @@ const { ProvenanceHistoryStore } = await import('../src/provenance-history.ts');
 const { MemoryStore } = await import('../src/memory.ts');
 const { RoutineStore } = await import('../src/routines.ts');
 const { SpecialistStore } = await import('../src/specialists.ts');
-const { CandidateStore } = await import('../src/correction-candidates.ts');
+const { CandidateStore } = await import('../src/specialist-candidates.ts');
 const { App } = await import('../src/ui/App.tsx');
 
 const config = loadConfig();

--- a/scripts/preview-ink.mjs
+++ b/scripts/preview-ink.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * scripts/preview-ink.mjs — Phase B dev harness.
+ *
+ * Mounts the Ink <App> against a real Bernard agent so a developer can
+ * end-to-end validate the #211 round-2 fixes (Shift-Tab Status full-screen,
+ * Esc closes overlay without replay artifact) without touching their normal
+ * Bernard state.
+ *
+ * Sets BERNARD_HOME=$(mktemp -d) on every launch so memory, history,
+ * provenance, RAG state, etc. are isolated from the user's real install.
+ *
+ * Run with: `tsx scripts/preview-ink.mjs`
+ *
+ * Not shipped — this file is dev-only and is not imported from src/, not
+ * registered in package.json bin, and not part of the build artifact.
+ */
+import { createElement } from 'react';
+import { render } from 'ink';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Isolate state before any Bernard module reads BERNARD_HOME via src/paths.ts.
+process.env.BERNARD_HOME = mkdtempSync(join(tmpdir(), 'bernard-preview-ink-'));
+console.log(`[preview-ink] BERNARD_HOME=${process.env.BERNARD_HOME}`);
+
+const { loadConfig } = await import('../src/config.ts');
+const { Agent } = await import('../src/agent.ts');
+const { assembleContext } = await import('../src/framework/context.ts');
+const { HistoryStore } = await import('../src/history.ts');
+const { ProvenanceHistoryStore } = await import('../src/provenance-history.ts');
+const { MemoryStore } = await import('../src/memory.ts');
+const { RoutineStore } = await import('../src/routines.ts');
+const { SpecialistStore } = await import('../src/specialists.ts');
+const { CandidateStore } = await import('../src/correction-candidates.ts');
+const { App } = await import('../src/ui/App.tsx');
+
+const config = loadConfig();
+const memoryStore = new MemoryStore();
+const routineStore = new RoutineStore();
+const specialistStore = new SpecialistStore();
+const candidateStore = new CandidateStore();
+const historyStore = new HistoryStore();
+const provenanceHistoryStore = new ProvenanceHistoryStore();
+const sessionToolAllowlist = new Set();
+
+// No-op tool-callback wiring: the preview's purpose is overlay validation
+// (Shift-Tab / Esc), not exercising confirm/block/askUser. Tool callbacks
+// resolve immediately with safe defaults so any tool call that would have
+// prompted is auto-cancelled rather than hanging the preview.
+const toolOptions = {
+  shellTimeout: config.shellTimeout,
+  confirmDangerous: async () => false,
+  confirmAction: async () => false,
+  blockAction: async () => 'deny',
+  sessionToolAllowlist,
+  askUser: async (_questions) => ({ cancelled: true, answered: [] }),
+};
+
+const agentCtx = assembleContext({
+  config,
+  toolOptions,
+  stores: {
+    memory: memoryStore,
+    routines: routineStore,
+    specialists: specialistStore,
+    candidates: candidateStore,
+  },
+});
+const agent = new Agent(agentCtx);
+
+const onExit = async () => {
+  // No MCP / RAG to tear down in this minimal preview.
+};
+
+const { waitUntilExit } = render(
+  createElement(App, {
+    agent,
+    config,
+    historyStore,
+    provenanceHistoryStore,
+    sessionToolAllowlist,
+    onExit,
+  }),
+);
+
+await waitUntilExit();
+console.log(`[preview-ink] exit. BERNARD_HOME left at ${process.env.BERNARD_HOME}`);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -256,3 +256,96 @@ export function getThemeKeys(): string[] {
 export function getActiveThemeKey(): string {
   return activeThemeKey;
 }
+
+/**
+ * Raw color tokens for Ink components. Ink's `<Text color={...}>` takes hex
+ * strings or named ANSI colors, not chalk callables, so the migration to Ink
+ * needs a parallel palette derived from the same per-theme values as
+ * {@link Theme}.
+ *
+ * Components should use the `<Text dimColor>` prop for ANSI dim styling rather
+ * than reaching for a separate "dim" color token — that maps cleanly onto the
+ * legacy `chalk.dim` usage without an extra entry here.
+ */
+export interface ThemeColors {
+  accent: string;
+  muted: string;
+  text: string;
+  toolCall: string;
+  error: string;
+  success: string;
+  warning: string;
+  prefixColors: readonly string[];
+}
+
+const THEME_COLORS: Record<string, ThemeColors> = {
+  bernard: {
+    accent: '#f97316',
+    muted: 'gray',
+    text: 'white',
+    toolCall: 'yellow',
+    error: 'red',
+    success: 'green',
+    warning: 'yellow',
+    prefixColors: ['magenta', 'blue', 'green', 'yellow'],
+  },
+  ocean: {
+    accent: '#06b6d4',
+    muted: '#94a3b8',
+    text: '#e2e8f0',
+    toolCall: '#38bdf8',
+    error: '#f87171',
+    success: '#34d399',
+    warning: '#fbbf24',
+    prefixColors: ['#38bdf8', '#818cf8', '#34d399', '#06b6d4'],
+  },
+  forest: {
+    accent: '#22c55e',
+    muted: '#a3a3a3',
+    text: '#e5e5e5',
+    toolCall: '#86efac',
+    error: '#ef4444',
+    success: '#4ade80',
+    warning: '#facc15',
+    prefixColors: ['#4ade80', '#a78bfa', '#fbbf24', '#22d3ee'],
+  },
+  synthwave: {
+    accent: '#c084fc',
+    muted: '#a78bfa',
+    text: '#f0abfc',
+    toolCall: '#f472b6',
+    error: '#fb7185',
+    success: '#34d399',
+    warning: '#fde68a',
+    prefixColors: ['#f472b6', '#818cf8', '#22d3ee', '#c084fc'],
+  },
+  'high-contrast': {
+    accent: 'whiteBright',
+    muted: 'white',
+    text: 'whiteBright',
+    toolCall: 'yellowBright',
+    error: 'redBright',
+    success: 'greenBright',
+    warning: 'yellowBright',
+    prefixColors: ['magentaBright', 'cyanBright', 'greenBright', 'yellowBright'],
+  },
+  colorblind: {
+    accent: '#648FFF',
+    muted: '#b0b0b0',
+    text: '#e0e0e0',
+    toolCall: '#DC267F',
+    error: '#DC267F',
+    success: '#648FFF',
+    warning: '#FFB000',
+    prefixColors: ['#785EF0', '#DC267F', '#FFB000', '#648FFF'],
+  },
+};
+
+/**
+ * Returns the Ink-friendly color palette for the active theme. Mirrors the
+ * {@link Theme} returned by {@link getTheme}; the two stay in sync because
+ * {@link setTheme} updates `activeThemeKey` and both lookups read it.
+ */
+export function getThemeColors(): ThemeColors {
+  return THEME_COLORS[activeThemeKey] ?? THEME_COLORS[DEFAULT_THEME];
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useRef, useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import type { Agent } from '../agent.js';
+import type { BernardConfig } from '../config.js';
+import type { HistoryStore } from '../history.js';
+import type { ProvenanceHistoryStore } from '../provenance-history.js';
+import type {
+  AskUserQuestion,
+  AskUserBatchResult,
+  ConfirmActionInput,
+  BlockActionInput,
+  BlockOutcome,
+} from '../tools/types.js';
+import type { MenuEntry, MenuItem, MenuOptions } from '../menu.js';
+import { Thread } from './Thread.js';
+import { Prompt } from './Prompt.js';
+import { Spinner } from './Spinner.js';
+import { PlanStrip } from './PlanStrip.js';
+import { MenuOverlay } from './overlays/MenuOverlay.js';
+import { ConfirmDialog } from './overlays/ConfirmDialog.js';
+import { StatusViewer } from './overlays/StatusViewer.js';
+import { SourcesViewer } from './overlays/SourcesViewer.js';
+import { persistAgentState } from './save.js';
+import { getThemeColors } from '../theme.js';
+
+interface AppProps {
+  agent: Agent;
+  config: BernardConfig;
+  historyStore: HistoryStore;
+  provenanceHistoryStore: ProvenanceHistoryStore;
+  /** Per-REPL-session allowlist (#179). Owned by the caller so it survives mount. */
+  sessionToolAllowlist: Set<string>;
+  /** Called when the user requests exit (Ctrl-C or `/exit`). */
+  onExit: () => Promise<void> | void;
+}
+
+type Overlay = 'status' | 'sources' | 'menu' | 'confirm';
+
+interface PendingMenu {
+  entries: MenuEntry[];
+  options?: MenuOptions;
+  resolve: (result: { cancelled: true } | { cancelled: false; index: number; item: MenuItem }) => void;
+}
+
+interface PendingConfirm {
+  kind: 'confirm';
+  input: ConfirmActionInput;
+  resolve: (allowed: boolean, scope: 'once' | 'session') => void;
+}
+
+interface PendingBlock {
+  kind: 'block';
+  input: BlockActionInput;
+  resolve: (outcome: BlockOutcome) => void;
+}
+
+type PendingDialog = PendingConfirm | PendingBlock;
+
+/**
+ * Top-level Ink component. Owns the lifecycle of a Bernard REPL session:
+ * turn submission, history versioning, overlay queueing, Shift-Tab cycling,
+ * and Esc / Ctrl-C handling.
+ *
+ * `<App>` is **not** mounted from `src/index.ts` in Phase B — the legacy
+ * readline REPL is still the user-visible entry point. The dev preview
+ * script at `scripts/preview-ink.mjs` mounts this against an isolated
+ * `BERNARD_HOME` for end-to-end validation of the #211 round-2 fixes.
+ *
+ * Tool callbacks are constructed inside `<App>` and would be wired into the
+ * `ToolOptions` passed to `assembleContext` at mount time — see
+ * `scripts/preview-ink.mjs` for the wiring example. The contracts match
+ * `src/tools/types.ts:58-100` exactly so Phase D can swap them in without
+ * touching tool code.
+ */
+export function App({
+  agent,
+  config,
+  historyStore,
+  provenanceHistoryStore,
+  sessionToolAllowlist: _sessionToolAllowlist,
+  onExit,
+}: AppProps) {
+  const { exit } = useApp();
+  const [activeOverlay, setActiveOverlay] = useState<Overlay | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [historyVersion, setHistoryVersion] = useState(0);
+  const [pendingMenu, setPendingMenu] = useState<PendingMenu | null>(null);
+  const [pendingDialog, setPendingDialog] = useState<PendingDialog | null>(null);
+  const colors = getThemeColors();
+
+  // Confirm-action session memo: `${toolName}:${stableJson(args)}` → true.
+  // Mirrors the legacy REPL's confirm-allow-for-session map.
+  const confirmAllowSession = useRef<Map<string, boolean>>(new Map());
+
+  // Closes the active overlay and resolves any pending request as a cancel.
+  const closeOverlay = () => {
+    if (pendingMenu) {
+      pendingMenu.resolve({ cancelled: true });
+      setPendingMenu(null);
+    }
+    if (pendingDialog) {
+      if (pendingDialog.kind === 'confirm') pendingDialog.resolve(false, 'once');
+      else pendingDialog.resolve('deny');
+      setPendingDialog(null);
+    }
+    setActiveOverlay(null);
+  };
+
+  useInput((input, key) => {
+    // Shift-Tab cycles viewer tabs only while idle and no overlay-driven dialog is open.
+    if (key.shift && key.tab) {
+      if (busy) return;
+      if (activeOverlay === 'menu' || activeOverlay === 'confirm') return;
+      setActiveOverlay((curr) => {
+        if (curr === null) return 'status';
+        if (curr === 'status') return 'sources';
+        return null;
+      });
+      return;
+    }
+    if (key.escape) {
+      if (activeOverlay) {
+        closeOverlay();
+        return;
+      }
+      if (busy) {
+        agent.abort();
+      }
+    }
+  });
+
+  // Exit cleanup runs on Ink unmount.
+  useEffect(() => {
+    return () => {
+      void onExit();
+    };
+  }, [onExit]);
+
+  const handleSubmit = async (text: string) => {
+    if (text === '/exit' || text === '/quit') {
+      await onExit();
+      exit();
+      return;
+    }
+    if (text === '/clear') {
+      historyStore.clear();
+      provenanceHistoryStore.clear();
+      agent.clearHistory();
+      setHistoryVersion((v) => v + 1);
+      return;
+    }
+    setBusy(true);
+    try {
+      await agent.processInput(text);
+    } catch (err) {
+      console.error('agent error:', err);
+    } finally {
+      persistAgentState({ agent, historyStore, provenanceHistoryStore });
+      setBusy(false);
+      setHistoryVersion((v) => v + 1);
+    }
+  };
+
+  // Overlay-request helpers — exposed to the script that mounts <App> so it
+  // can build the ToolOptions callbacks (confirmFn, confirmActionFn,
+  // blockActionFn, askUserFn). Phase D will move this wiring into the mount.
+  // For Phase B these are deliberately unused in <App> itself; the contracts
+  // they implement (matching src/tools/types.ts) are documented in the
+  // ConfirmDialog and MenuOverlay components.
+  void requestMenu;
+  void requestConfirm;
+  void requestBlock;
+  void requestAskUser;
+
+  function requestMenu(
+    entries: MenuEntry[],
+    options?: MenuOptions,
+  ): Promise<{ cancelled: true } | { cancelled: false; index: number; item: MenuItem }> {
+    return new Promise((resolve) => {
+      setPendingMenu({ entries, options, resolve });
+      setActiveOverlay('menu');
+    });
+  }
+
+  function requestConfirm(input: ConfirmActionInput): Promise<boolean> {
+    const key = `${input.toolName}:${stableJson(input.args)}`;
+    if (confirmAllowSession.current.get(key)) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
+      setPendingDialog({
+        kind: 'confirm',
+        input,
+        resolve: (allowed, scope) => {
+          if (allowed && scope === 'session') confirmAllowSession.current.set(key, true);
+          resolve(allowed);
+        },
+      });
+      setActiveOverlay('confirm');
+    });
+  }
+
+  function requestBlock(input: BlockActionInput): Promise<BlockOutcome> {
+    return new Promise((resolve) => {
+      setPendingDialog({ kind: 'block', input, resolve });
+      setActiveOverlay('confirm');
+    });
+  }
+
+  async function requestAskUser(
+    questions: AskUserQuestion[],
+    signal?: AbortSignal,
+  ): Promise<AskUserBatchResult> {
+    const answers: string[] = [];
+    for (const q of questions) {
+      if (signal?.aborted) return { cancelled: true, answered: answers };
+      // Phase B: only choice questions are routed through the overlay.
+      // Free-text questions need a `<TextInputOverlay>` component, which
+      // lands in Phase D when the readline path is retired.
+      if (!q.choices || q.choices.length === 0) {
+        return { cancelled: true, answered: answers };
+      }
+      const entries: MenuEntry[] = q.choices.map((c) => ({ label: c }));
+      if (q.allowOther) entries.push({ label: q.otherLabel ?? 'Other (free-form)' });
+      const result = await requestMenu(entries, { title: q.question });
+      if (result.cancelled) return { cancelled: true, answered: answers };
+      answers.push(result.item.label);
+    }
+    return { answers };
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={colors.accent} bold>
+          bernard
+        </Text>
+        <Text dimColor> {config.provider}/{config.model}</Text>
+      </Box>
+      <Thread key={historyVersion} history={agent.getHistory()} />
+      {busy && (
+        <Box marginTop={1}>
+          <Spinner label="thinking…" />
+        </Box>
+      )}
+      <PlanStrip agent={agent} />
+      <Prompt disabled={busy || activeOverlay !== null} onSubmit={handleSubmit} />
+      {activeOverlay === 'status' && (
+        <StatusViewer agent={agent} config={config} sessionAllowedCount={_sessionToolAllowlist.size} />
+      )}
+      {activeOverlay === 'sources' && <SourcesViewer agent={agent} />}
+      {activeOverlay === 'menu' && pendingMenu && (
+        <MenuOverlay
+          entries={pendingMenu.entries}
+          options={pendingMenu.options}
+          onSelect={(index, item) => {
+            pendingMenu.resolve({ cancelled: false, index, item });
+            setPendingMenu(null);
+            setActiveOverlay(null);
+          }}
+          onCancel={() => {
+            pendingMenu.resolve({ cancelled: true });
+            setPendingMenu(null);
+            setActiveOverlay(null);
+          }}
+        />
+      )}
+      {activeOverlay === 'confirm' && pendingDialog && pendingDialog.kind === 'confirm' && (
+        <ConfirmDialog
+          kind="confirm"
+          toolName={pendingDialog.input.toolName}
+          reason={pendingDialog.input.reason}
+          risk={pendingDialog.input.risk}
+          onResolve={(allowed, scope) => {
+            pendingDialog.resolve(allowed, scope);
+            setPendingDialog(null);
+            setActiveOverlay(null);
+          }}
+          onCancel={() => {
+            pendingDialog.resolve(false, 'once');
+            setPendingDialog(null);
+            setActiveOverlay(null);
+          }}
+        />
+      )}
+      {activeOverlay === 'confirm' && pendingDialog && pendingDialog.kind === 'block' && (
+        <ConfirmDialog
+          kind="block"
+          toolName={pendingDialog.input.toolName}
+          reason={pendingDialog.input.reason}
+          onResolve={(outcome) => {
+            pendingDialog.resolve(outcome);
+            setPendingDialog(null);
+            setActiveOverlay(null);
+          }}
+          onCancel={() => {
+            pendingDialog.resolve('deny');
+            setPendingDialog(null);
+            setActiveOverlay(null);
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
+function stableJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -88,9 +88,15 @@ export function App({
   const [pendingDialog, setPendingDialog] = useState<PendingDialog | null>(null);
   const colors = getThemeColors();
 
-  // Confirm-action session memo: `${toolName}:${stableJson(args)}` → true.
+  // Confirm-action session memo: `${toolName}:${stableHash(args)}` → true.
   // Mirrors the legacy REPL's confirm-allow-for-session map.
   const confirmAllowSession = useRef<Map<string, boolean>>(new Map());
+  // One-shot guard so onExit runs exactly once whether the user types
+  // `/exit` (handleSubmit) or the Ink tree unmounts (useEffect cleanup).
+  const exitedRef = useRef(false);
+  // Synchronous guard against double-Enter: setBusy schedules a re-render but
+  // a second submit can land before Prompt sees `disabled={busy}` flip.
+  const submittingRef = useRef(false);
 
   // Closes the active overlay and resolves any pending request as a cancel.
   const closeOverlay = () => {
@@ -106,38 +112,52 @@ export function App({
     setActiveOverlay(null);
   };
 
-  useInput((input, key) => {
-    // Shift-Tab cycles viewer tabs only while idle and no overlay-driven dialog is open.
-    if (key.shift && key.tab) {
-      if (busy) return;
-      if (activeOverlay === 'menu' || activeOverlay === 'confirm') return;
-      setActiveOverlay((curr) => {
-        if (curr === null) return 'status';
-        if (curr === 'status') return 'sources';
-        return null;
-      });
-      return;
-    }
-    if (key.escape) {
-      if (activeOverlay) {
-        closeOverlay();
+  // Gate the App-level useInput so it never fires concurrently with an
+  // overlay's own useInput. Modal overlays (menu, confirm) own the keystream;
+  // viewer overlays (status, sources) leave it to App so Esc can close them
+  // and Shift-Tab can keep cycling.
+  const appInputActive =
+    activeOverlay === null || activeOverlay === 'status' || activeOverlay === 'sources';
+
+  useInput(
+    (_input, key) => {
+      // Shift-Tab cycles viewer tabs only while idle.
+      if (key.shift && key.tab) {
+        if (busy) return;
+        setActiveOverlay((curr) => {
+          if (curr === null) return 'status';
+          if (curr === 'status') return 'sources';
+          return null;
+        });
         return;
       }
-      if (busy) {
-        agent.abort();
+      if (key.escape) {
+        if (activeOverlay) {
+          closeOverlay();
+          return;
+        }
+        if (busy) {
+          agent.abort();
+        }
       }
-    }
-  });
+    },
+    { isActive: appInputActive },
+  );
 
-  // Exit cleanup runs on Ink unmount.
+  // Exit cleanup runs on Ink unmount. The exitedRef guard means `/exit` (which
+  // already awaited onExit) doesn't trigger a second invocation.
   useEffect(() => {
     return () => {
+      if (exitedRef.current) return;
+      exitedRef.current = true;
       void onExit();
     };
   }, [onExit]);
 
   const handleSubmit = async (text: string) => {
     if (text === '/exit' || text === '/quit') {
+      if (exitedRef.current) return;
+      exitedRef.current = true;
       await onExit();
       exit();
       return;
@@ -149,6 +169,10 @@ export function App({
       setHistoryVersion((v) => v + 1);
       return;
     }
+    // Drop a second Enter that arrives before the busy re-render has propagated
+    // to <Prompt disabled={busy}>. Without this, two turns can run concurrently.
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setBusy(true);
     try {
       await agent.processInput(text);
@@ -156,6 +180,7 @@ export function App({
       console.error('agent error:', err);
     } finally {
       persistAgentState({ agent, historyStore, provenanceHistoryStore });
+      submittingRef.current = false;
       setBusy(false);
       setHistoryVersion((v) => v + 1);
     }
@@ -183,7 +208,7 @@ export function App({
   }
 
   function requestConfirm(input: ConfirmActionInput): Promise<boolean> {
-    const key = `${input.toolName}:${stableJson(input.args)}`;
+    const key = `${input.toolName}:${stableHash(input.args)}`;
     if (confirmAllowSession.current.get(key)) return Promise.resolve(true);
     return new Promise<boolean>((resolve) => {
       setPendingDialog({
@@ -213,13 +238,17 @@ export function App({
     for (const q of questions) {
       if (signal?.aborted) return { cancelled: true, answered: answers };
       // Phase B: only choice questions are routed through the overlay.
-      // Free-text questions need a `<TextInputOverlay>` component, which
-      // lands in Phase D when the readline path is retired.
+      // Free-text and `allowOther` need a `<TextInputOverlay>` component
+      // which lands in Phase D when the readline path is retired. For now,
+      // bail with the partial answers already collected so the agent can see
+      // what the user did pick before the unsupported question.
       if (!q.choices || q.choices.length === 0) {
         return { cancelled: true, answered: answers };
       }
       const entries: MenuEntry[] = q.choices.map((c) => ({ label: c }));
-      if (q.allowOther) entries.push({ label: q.otherLabel ?? 'Other (free-form)' });
+      // Intentionally skip allowOther: choosing it would store the literal
+      // "Other (free-form)" label instead of the user's actual text. Better
+      // to surface only the canned choices until text input lands.
       const result = await requestMenu(entries, { title: q.question });
       if (result.cancelled) return { cancelled: true, answered: answers };
       answers.push(result.item.label);
@@ -302,10 +331,32 @@ export function App({
   );
 }
 
-function stableJson(value: unknown): string {
+/**
+ * Sort-keys-first JSON so `{a:1,b:2}` and `{b:2,a:1}` produce the same string.
+ * Mirrors `stableStringify` at `src/repl.ts:1122` — keeps the confirm-allow
+ * session memo stable across re-renders that reshuffle object key order.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(',')}}`;
+}
+
+/** djb2 over the stable-JSON form. Matches `stableHash` at `src/repl.ts:1113`. */
+function stableHash(value: unknown): string {
+  let json: string;
   try {
-    return JSON.stringify(value);
+    json = stableStringify(value);
   } catch {
-    return String(value);
+    json = String(value);
   }
+  let h = 5381;
+  for (let i = 0; i < json.length; i++) {
+    h = ((h << 5) + h + json.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16);
 }

--- a/src/ui/PlanStrip.tsx
+++ b/src/ui/PlanStrip.tsx
@@ -1,0 +1,39 @@
+import { Box, Text } from 'ink';
+import type { Agent } from '../agent.js';
+import { getThemeColors } from '../theme.js';
+import { pickActiveStep, summarizePlan } from '../agent-status.js';
+
+interface PlanStripProps {
+  agent: Agent;
+}
+
+/**
+ * Replaces the legacy pinned plan region. Reads `agent.getPlanSnapshot()` and
+ * renders a one-line summary of the active step plus a `done/total` count.
+ * Mounted above `<Prompt>` in the `<App>` JSX so it sits in the same screen
+ * position as the legacy region.
+ */
+export function PlanStrip({ agent }: PlanStripProps) {
+  const colors = getThemeColors();
+  const steps = agent.getPlanSnapshot();
+  const active = pickActiveStep(steps);
+  const { done, total } = summarizePlan(steps);
+  if (total === 0) return null;
+  return (
+    <Box flexDirection="row" marginLeft={2}>
+      <Text color={colors.accent} bold>
+        plan
+      </Text>
+      <Text dimColor>
+        {' '}
+        {done}/{total}
+      </Text>
+      {active && (
+        <Text>
+          {'  '}
+          {active.description}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/Prompt.tsx
+++ b/src/ui/Prompt.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { getThemeColors } from '../theme.js';
+import { SlashHints } from './SlashHints.js';
+
+interface PromptProps {
+  /** When true, suppress key handling — used while an overlay is open. */
+  disabled?: boolean;
+  /** Called on Enter with the current buffer (trimmed of trailing newline). */
+  onSubmit: (text: string) => void;
+}
+
+/**
+ * Single-line input box. Uses Ink's `useInput` directly so the surface area
+ * stays small (no `ink-text-input` dep). Maintains its own buffer state and
+ * emits `onSubmit(text)` on Enter; an empty buffer is rejected silently to
+ * match the legacy prompt's behavior.
+ *
+ * Disabled while an overlay is open so the overlay can capture keystrokes
+ * exclusively. Phase D will extend this with paste handling and history
+ * navigation when the readline path is retired.
+ */
+export function Prompt({ disabled = false, onSubmit }: PromptProps) {
+  const [buffer, setBuffer] = useState('');
+  const colors = getThemeColors();
+
+  useInput(
+    (input, key) => {
+      if (key.return) {
+        const text = buffer.trim();
+        if (text.length === 0) return;
+        setBuffer('');
+        onSubmit(text);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setBuffer((b) => b.slice(0, -1));
+        return;
+      }
+      if (key.ctrl || key.meta) return;
+      // Ignore arrow / function keys — `input` is empty for those.
+      if (input && !key.escape && !key.tab) {
+        setBuffer((b) => b + input);
+      }
+    },
+    { isActive: !disabled },
+  );
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <SlashHints buffer={buffer} />
+      <Box>
+        <Text color={colors.accent} bold>
+          ›{' '}
+        </Text>
+        <Text>{buffer}</Text>
+        {!disabled && <Text color={colors.accent}>▌</Text>}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/SlashHints.tsx
+++ b/src/ui/SlashHints.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from 'ink';
+import { getThemeColors } from '../theme.js';
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+}
+
+/**
+ * The static set of slash commands the Ink shell will ship at cutover.
+ *
+ * Phase B intentionally lists only the commands `<App>` wires through in this
+ * milestone (`/exit`, `/clear`, `/profiles`). Phase D ports the remaining
+ * commands from `src/repl.ts` (`/agent-options`, `/manage-profiles`, `/cron`,
+ * `/image`, `/run-routine`, etc.) when the bespoke layer is deleted and adds
+ * their entries here.
+ */
+export const SLASH_COMMANDS: readonly SlashCommand[] = [
+  { name: '/exit', description: 'Exit Bernard' },
+  { name: '/clear', description: 'Clear conversation history' },
+  { name: '/profiles', description: 'Switch settings profile' },
+];
+
+interface SlashHintsProps {
+  /** Current input buffer; hints render only when this starts with `/`. */
+  buffer: string;
+}
+
+/**
+ * Renders a small list of slash-command suggestions filtered by the current
+ * input buffer. Mounted as a child of `<Prompt>` so it sits directly above
+ * the input line — same UX as the legacy `redrawWithHints` path it replaces.
+ */
+export function SlashHints({ buffer }: SlashHintsProps) {
+  const colors = getThemeColors();
+  if (!buffer.startsWith('/')) return null;
+  const query = buffer.slice(1).toLowerCase();
+  const matches = SLASH_COMMANDS.filter((c) => c.name.slice(1).toLowerCase().startsWith(query));
+  if (matches.length === 0) return null;
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      {matches.map((cmd) => (
+        <Box key={cmd.name}>
+          <Text color={colors.accent} bold>
+            {cmd.name}
+          </Text>
+          <Text dimColor> — {cmd.description}</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/ui/SlashHints.tsx
+++ b/src/ui/SlashHints.tsx
@@ -7,18 +7,18 @@ export interface SlashCommand {
 }
 
 /**
- * The static set of slash commands the Ink shell will ship at cutover.
+ * The static set of slash commands the Ink shell wires through in Phase B.
  *
- * Phase B intentionally lists only the commands `<App>` wires through in this
- * milestone (`/exit`, `/clear`, `/profiles`). Phase D ports the remaining
- * commands from `src/repl.ts` (`/agent-options`, `/manage-profiles`, `/cron`,
- * `/image`, `/run-routine`, etc.) when the bespoke layer is deleted and adds
- * their entries here.
+ * Only commands `<App>.handleSubmit` actually handles are listed here so a
+ * suggestion can't fall through to `agent.processInput` and get sent to the
+ * model as prose. Phase D ports the remaining commands from `src/repl.ts`
+ * (`/profiles`, `/agent-options`, `/manage-profiles`, `/cron`, `/image`,
+ * `/run-routine`, etc.) when the bespoke layer is deleted and adds their
+ * entries here.
  */
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   { name: '/exit', description: 'Exit Bernard' },
   { name: '/clear', description: 'Clear conversation history' },
-  { name: '/profiles', description: 'Switch settings profile' },
 ];
 
 interface SlashHintsProps {

--- a/src/ui/Spinner.tsx
+++ b/src/ui/Spinner.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { Text } from 'ink';
+import { getThemeColors } from '../theme.js';
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+interface SpinnerProps {
+  /** Optional status label shown next to the animation. */
+  label?: string;
+}
+
+/**
+ * Braille-dot spinner. Mounted while the agent is processing a turn so the
+ * user has a visible "still working" signal. Streaming token output lands in
+ * Phase C; until then this is the only mid-turn feedback the Ink shell shows.
+ */
+export function Spinner({ label }: SpinnerProps) {
+  const [frame, setFrame] = useState(0);
+  const colors = getThemeColors();
+  useEffect(() => {
+    const id = setInterval(() => setFrame((f) => (f + 1) % FRAMES.length), 80);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <Text color={colors.accent}>
+      {FRAMES[frame]}
+      {label ? ` ${label}` : ''}
+    </Text>
+  );
+}

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -1,0 +1,160 @@
+import { Box, Text } from 'ink';
+import type {
+  CoreMessage,
+  CoreUserMessage,
+  CoreAssistantMessage,
+  CoreToolMessage,
+  TextPart,
+  ImagePart,
+  ToolCallPart,
+  ToolResultPart,
+} from 'ai';
+
+type ReasoningPart = { type: 'reasoning'; text: string };
+type RedactedReasoningPart = { type: 'redacted-reasoning'; data: string };
+import { getThemeColors } from '../theme.js';
+
+interface ThreadProps {
+  history: CoreMessage[];
+}
+
+/**
+ * Renders the conversation as a flowing list of message blocks. Reads the
+ * AI SDK's `CoreMessage[]` shape directly — same array `Agent.getHistory()`
+ * returns. Re-renders when `<App>` bumps `historyVersion` after a turn ends.
+ *
+ * Streaming-output migration (Phase C) will keep this component but feed it
+ * from an in-memory message store so the in-flight assistant message updates
+ * token-by-token. Phase B renders the message in bulk at turn end.
+ */
+export function Thread({ history }: ThreadProps) {
+  return (
+    <Box flexDirection="column">
+      {history.map((msg, idx) => (
+        <MessageBlock key={idx} message={msg} />
+      ))}
+    </Box>
+  );
+}
+
+function MessageBlock({ message }: { message: CoreMessage }) {
+  if (message.role === 'user') return <UserMessage message={message as CoreUserMessage} />;
+  if (message.role === 'assistant')
+    return <AssistantMessage message={message as CoreAssistantMessage} />;
+  if (message.role === 'tool') return <ToolResultMessage message={message as CoreToolMessage} />;
+  // System messages are agent-internal; don't render in the thread.
+  return null;
+}
+
+function UserMessage({ message }: { message: CoreUserMessage }) {
+  const colors = getThemeColors();
+  const text = extractUserText(message);
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color={colors.accent} bold>
+        you
+      </Text>
+      <Text>{text}</Text>
+    </Box>
+  );
+}
+
+function AssistantMessage({ message }: { message: CoreAssistantMessage }) {
+  const colors = getThemeColors();
+  const parts = normalizeAssistantContent(message.content);
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color={colors.accent} bold>
+        bernard
+      </Text>
+      {parts.map((part, idx) => {
+        if (part.type === 'text') return <Text key={idx}>{part.text}</Text>;
+        if (part.type === 'reasoning')
+          return (
+            <Text key={idx} dimColor italic>
+              {part.text}
+            </Text>
+          );
+        if (part.type === 'tool-call') return <ToolCallBlock key={idx} part={part} />;
+        // 'redacted-reasoning' / unknown parts: skip silently.
+        return null;
+      })}
+    </Box>
+  );
+}
+
+function ToolCallBlock({ part }: { part: ToolCallPart }) {
+  const colors = getThemeColors();
+  const argSummary = summariseArgs(part.args);
+  return (
+    <Box>
+      <Text color={colors.toolCall}>⚙ {part.toolName}</Text>
+      {argSummary && <Text dimColor>  {argSummary}</Text>}
+    </Box>
+  );
+}
+
+function ToolResultMessage({ message }: { message: CoreToolMessage }) {
+  const colors = getThemeColors();
+  const parts = Array.isArray(message.content) ? message.content : [];
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      {parts.map((part: ToolResultPart, idx) => {
+        const snippet = renderResultSnippet(part.result);
+        const isError = part.isError === true;
+        return (
+          <Box key={idx}>
+            <Text color={isError ? colors.error : undefined} dimColor={!isError}>
+              ↳ {snippet}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+function extractUserText(message: CoreUserMessage): string {
+  if (typeof message.content === 'string') return message.content;
+  const out: string[] = [];
+  for (const part of message.content as Array<TextPart | ImagePart>) {
+    if (part.type === 'text') out.push(part.text);
+    else if (part.type === 'image') out.push('[image]');
+  }
+  return out.join('\n');
+}
+
+type AssistantPart = TextPart | ToolCallPart | ReasoningPart | RedactedReasoningPart;
+
+function normalizeAssistantContent(
+  content: CoreAssistantMessage['content'],
+): AssistantPart[] {
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return content as AssistantPart[];
+}
+
+function summariseArgs(args: unknown): string {
+  if (args == null) return '';
+  try {
+    const json = JSON.stringify(args);
+    if (json.length <= 80) return json;
+    return json.slice(0, 79) + '…';
+  } catch {
+    return '';
+  }
+}
+
+function renderResultSnippet(result: unknown): string {
+  if (result == null) return '(no result)';
+  if (typeof result === 'string') return truncate(result, 200);
+  try {
+    return truncate(JSON.stringify(result), 200);
+  } catch {
+    return '(unserializable result)';
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}

--- a/src/ui/overlays/ConfirmDialog.tsx
+++ b/src/ui/overlays/ConfirmDialog.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { getThemeColors } from '../../theme.js';
+import type { RiskLevel } from '../../risk.js';
+import type { BlockOutcome } from '../../tools/types.js';
+
+type ConfirmChoice = 'allow-once' | 'allow-session' | 'cancel';
+type BlockChoice = 'allow-once' | 'allow-tool-for-session' | 'deny';
+
+interface ConfirmDialogPropsCommon {
+  toolName: string;
+  reason: string;
+  onCancel: () => void;
+}
+
+interface ConfirmKindProps extends ConfirmDialogPropsCommon {
+  kind: 'confirm';
+  risk?: RiskLevel;
+  onResolve: (allowed: boolean, scope: 'once' | 'session') => void;
+}
+
+interface BlockKindProps extends ConfirmDialogPropsCommon {
+  kind: 'block';
+  onResolve: (outcome: BlockOutcome) => void;
+}
+
+export type ConfirmDialogProps = ConfirmKindProps | BlockKindProps;
+
+/**
+ * Replaces the legacy three-option dialogs from `src/repl.ts`:
+ *   - `kind: 'confirm'` mirrors `confirmActionFn` (risk-based, #144):
+ *       "Allow once / Allow for session / Cancel"
+ *   - `kind: 'block'`   mirrors `blockActionFn` (read-only mode, #179):
+ *       "Allow once / Enable for this tool, this session / Deny"
+ *
+ * Wire-shape (props named after the tool-side callback contracts in
+ * `src/tools/types.ts:58-100`) is identical to the legacy callbacks so
+ * Phase D can drop the readline implementations and route to this component
+ * without touching tool code.
+ */
+export function ConfirmDialog(props: ConfirmDialogProps) {
+  const colors = getThemeColors();
+  const choices = props.kind === 'confirm'
+    ? (['allow-once', 'allow-session', 'cancel'] as ConfirmChoice[])
+    : (['allow-once', 'allow-tool-for-session', 'deny'] as BlockChoice[]);
+  const labels = props.kind === 'confirm'
+    ? ['Allow once', 'Allow for session', 'Cancel']
+    : ['Allow once', 'Enable for this tool, this session', 'Deny'];
+  const [highlight, setHighlight] = useState(0);
+
+  const commit = (idx: number) => {
+    if (props.kind === 'confirm') {
+      const choice = choices[idx] as ConfirmChoice;
+      if (choice === 'cancel') props.onResolve(false, 'once');
+      else props.onResolve(true, choice === 'allow-session' ? 'session' : 'once');
+    } else {
+      const choice = choices[idx] as BlockChoice;
+      props.onResolve(choice);
+    }
+  };
+
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') {
+      props.onCancel();
+      return;
+    }
+    if (key.escape) {
+      props.onCancel();
+      return;
+    }
+    if (key.return) {
+      commit(highlight);
+      return;
+    }
+    if (key.upArrow) {
+      setHighlight((h) => Math.max(0, h - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setHighlight((h) => Math.min(choices.length - 1, h + 1));
+      return;
+    }
+    if (/^[1-3]$/.test(input)) {
+      const idx = parseInt(input, 10) - 1;
+      if (idx < choices.length) commit(idx);
+    }
+  });
+
+  const riskColor =
+    props.kind === 'confirm' && props.risk === 'high'
+      ? colors.error
+      : props.kind === 'confirm' && props.risk === 'medium'
+        ? colors.warning
+        : colors.accent;
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box>
+        <Text color={riskColor} bold>
+          {props.kind === 'confirm'
+            ? `Confirm ${props.risk ?? 'action'}: ${props.toolName}`
+            : `Blocked (read-only mode): ${props.toolName}`}
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>{props.reason}</Text>
+      </Box>
+      <Text> </Text>
+      {labels.map((label, idx) => {
+        const isHighlighted = idx === highlight;
+        return (
+          <Box key={idx}>
+            <Text color={colors.accent}>{isHighlighted ? '> ' : '  '}</Text>
+            <Text bold={isHighlighted} color={isHighlighted ? colors.accent : undefined}>
+              {idx + 1}. {label}
+            </Text>
+          </Box>
+        );
+      })}
+      <Text> </Text>
+      <Text dimColor>↑/↓ move · Enter select · Esc cancel</Text>
+    </Box>
+  );
+}

--- a/src/ui/overlays/MenuOverlay.tsx
+++ b/src/ui/overlays/MenuOverlay.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { getThemeColors } from '../../theme.js';
 import type { MenuEntry, MenuItem, MenuOptions } from '../../menu.js';
@@ -8,6 +8,14 @@ interface MenuOverlayProps {
   options?: MenuOptions;
   onSelect: (index: number, item: MenuItem) => void;
   onCancel: () => void;
+  /**
+   * Optional external cancel signal. The legacy `selectFromMenu` accepts one
+   * via `MenuOptions.signal` so a parent (e.g. an aborted agent turn) can drop
+   * a stale menu without user interaction. Mirroring that here keeps the
+   * `askUser` and confirm-action paths unaffected when the user presses Esc
+   * mid-turn.
+   */
+  signal?: AbortSignal;
 }
 
 function isSection(entry: MenuEntry): entry is { type: 'section'; title: string } {
@@ -27,10 +35,27 @@ function isSection(entry: MenuEntry): entry is { type: 'section'; title: string 
  * items, never selectable. `options.headerLines` renders above the title so
  * the `ask_user` tab strip continues to work unchanged.
  */
-export function MenuOverlay({ entries, options, onSelect, onCancel }: MenuOverlayProps) {
+export function MenuOverlay({
+  entries,
+  options,
+  onSelect,
+  onCancel,
+  signal,
+}: MenuOverlayProps) {
   const colors = getThemeColors();
   const items = entries.filter((e): e is MenuItem => !isSection(e));
   const [highlight, setHighlight] = useState(0);
+
+  useEffect(() => {
+    if (!signal) return;
+    if (signal.aborted) {
+      onCancel();
+      return;
+    }
+    const onAbort = () => onCancel();
+    signal.addEventListener('abort', onAbort);
+    return () => signal.removeEventListener('abort', onAbort);
+  }, [signal, onCancel]);
 
   useInput((input, key) => {
     if (key.ctrl && input === 'c') {

--- a/src/ui/overlays/MenuOverlay.tsx
+++ b/src/ui/overlays/MenuOverlay.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { getThemeColors } from '../../theme.js';
+import type { MenuEntry, MenuItem, MenuOptions } from '../../menu.js';
+
+interface MenuOverlayProps {
+  entries: MenuEntry[];
+  options?: MenuOptions;
+  onSelect: (index: number, item: MenuItem) => void;
+  onCancel: () => void;
+}
+
+function isSection(entry: MenuEntry): entry is { type: 'section'; title: string } {
+  return 'type' in entry && entry.type === 'section';
+}
+
+/**
+ * Replaces `selectFromMenu` from `src/menu.ts` with an Ink overlay.
+ *
+ * Keyboard contract matches the legacy menu (`src/menu.ts:325-360`):
+ *   - ↑/↓ moves the highlight (sections are skipped)
+ *   - digits 1-9 commit the matching item immediately
+ *   - Enter commits the highlighted item
+ *   - Esc / q / Ctrl-C cancel
+ *
+ * Section dividers from `MenuEntry` are rendered as muted headers between
+ * items, never selectable. `options.headerLines` renders above the title so
+ * the `ask_user` tab strip continues to work unchanged.
+ */
+export function MenuOverlay({ entries, options, onSelect, onCancel }: MenuOverlayProps) {
+  const colors = getThemeColors();
+  const items = entries.filter((e): e is MenuItem => !isSection(e));
+  const [highlight, setHighlight] = useState(0);
+
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') {
+      onCancel();
+      return;
+    }
+    if (key.escape || input === 'q') {
+      onCancel();
+      return;
+    }
+    if (key.return) {
+      const item = items[highlight];
+      if (item) onSelect(highlight, item);
+      return;
+    }
+    if (key.upArrow) {
+      setHighlight((h) => Math.max(0, h - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setHighlight((h) => Math.min(items.length - 1, h + 1));
+      return;
+    }
+    if (/^[1-9]$/.test(input)) {
+      const idx = parseInt(input, 10) - 1;
+      if (idx < items.length) onSelect(idx, items[idx]);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {options?.headerLines?.map((line, idx) => (
+        <Text key={`h-${idx}`}>{line}</Text>
+      ))}
+      {options?.headerLines && options.headerLines.length > 0 && <Text> </Text>}
+      {options?.title && (
+        <>
+          <Text color={colors.accent} bold>
+            {options.title}
+          </Text>
+          <Text> </Text>
+        </>
+      )}
+      <MenuList entries={entries} highlight={highlight} />
+      <Text> </Text>
+      <Text dimColor>↑/↓ move · Enter select · Esc cancel</Text>
+    </Box>
+  );
+}
+
+function MenuList({ entries, highlight }: { entries: MenuEntry[]; highlight: number }) {
+  const colors = getThemeColors();
+  let itemIndex = 0;
+  return (
+    <Box flexDirection="column">
+      {entries.map((entry, idx) => {
+        if (isSection(entry)) {
+          return (
+            <Text key={`s-${idx}`} color={colors.muted}>
+              {entry.title}
+            </Text>
+          );
+        }
+        const n = itemIndex + 1;
+        const myIndex = itemIndex;
+        itemIndex++;
+        const activeMarker = entry.active ? ' (active)' : '';
+        const annotation = entry.annotation ? ` ${entry.annotation}` : '';
+        const isHighlighted = myIndex === highlight;
+        const label = `${n}. ${entry.label}${activeMarker}${annotation}`;
+        return (
+          <Box key={`i-${idx}`} flexDirection="column">
+            <Box>
+              <Text color={colors.accent}>{isHighlighted ? '> ' : '  '}</Text>
+              <Text bold={isHighlighted} color={isHighlighted ? colors.accent : undefined}>
+                {label}
+              </Text>
+            </Box>
+            {isHighlighted && entry.description && (
+              <Box marginLeft={4}>
+                <Text dimColor>{entry.description}</Text>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/ui/overlays/SourcesViewer.tsx
+++ b/src/ui/overlays/SourcesViewer.tsx
@@ -1,0 +1,82 @@
+import { Box, Text } from 'ink';
+import type { Agent } from '../../agent.js';
+import type { TurnProvenance, SourceItem } from '../../provenance.js';
+import { getThemeColors } from '../../theme.js';
+
+interface SourcesViewerProps {
+  agent: Agent;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+/**
+ * Full-screen per-turn citation list. Consumes `agent.getTurnProvenance()`
+ * (wired in Phase A — see `src/provenance.ts:38` for the shape).
+ *
+ * Accent rule matches the legacy renderer at `src/repl.ts:874`: a source is
+ * "cited" when `citedIds.includes(source.id)`. Cited entries render in the
+ * theme accent color; uncited entries render dim.
+ *
+ * Empty state covers two cases (fresh session, and a session where no turn
+ * produced citations). Both render the same hint so the user knows the panel
+ * is working as designed and not stuck.
+ */
+export function SourcesViewer({ agent }: SourcesViewerProps) {
+  const colors = getThemeColors();
+  const turns = agent.getTurnProvenance();
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color={colors.accent} bold>
+        Sources
+      </Text>
+      <Text> </Text>
+      {turns.length === 0 ? (
+        <Text dimColor>No citations recorded yet.</Text>
+      ) : (
+        turns.map((turn) => <TurnBlock key={turn.turnIndex} turn={turn} />)
+      )}
+      <Text> </Text>
+      <Text dimColor>Esc to close · Shift-Tab to switch tabs</Text>
+    </Box>
+  );
+}
+
+function TurnBlock({ turn }: { turn: TurnProvenance }) {
+  const colors = getThemeColors();
+  const citedSet = new Set(turn.citedIds);
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box>
+        <Text color={colors.muted}>Turn {turn.turnIndex + 1}:</Text>
+        <Text> {truncate(turn.userInput, 80)}</Text>
+      </Box>
+      {turn.sources.length === 0 ? (
+        <Box marginLeft={2}>
+          <Text dimColor>(no sources registered)</Text>
+        </Box>
+      ) : (
+        turn.sources.map((src) => (
+          <SourceRow key={src.id} source={src} cited={citedSet.has(src.id)} />
+        ))
+      )}
+    </Box>
+  );
+}
+
+function SourceRow({ source, cited }: { source: SourceItem; cited: boolean }) {
+  const colors = getThemeColors();
+  return (
+    <Box marginLeft={2}>
+      <Text color={cited ? colors.accent : undefined} dimColor={!cited} bold={cited}>
+        [{source.id}]
+      </Text>
+      <Text color={cited ? undefined : colors.muted} dimColor={!cited}>
+        {' '}
+        {source.kind} · {truncate(source.label, 80)}
+      </Text>
+    </Box>
+  );
+}

--- a/src/ui/overlays/SourcesViewer.tsx
+++ b/src/ui/overlays/SourcesViewer.tsx
@@ -68,15 +68,32 @@ function TurnBlock({ turn }: { turn: TurnProvenance }) {
 
 function SourceRow({ source, cited }: { source: SourceItem; cited: boolean }) {
   const colors = getThemeColors();
+  // Mirrors the legacy renderer at `src/repl.ts:874-885`: cited entries get
+  // the accent label + un-dimmed body; uncited entries use plain dimColor
+  // (no extra color override, which can over-darken on some themes).
+  const showRawRef = source.rawRef && source.rawRef !== source.label;
+  const showPreview = !!source.contentPreview;
   return (
-    <Box marginLeft={2}>
-      <Text color={cited ? colors.accent : undefined} dimColor={!cited} bold={cited}>
-        [{source.id}]
-      </Text>
-      <Text color={cited ? undefined : colors.muted} dimColor={!cited}>
-        {' '}
-        {source.kind} · {truncate(source.label, 80)}
-      </Text>
+    <Box flexDirection="column" marginLeft={2}>
+      <Box>
+        <Text color={cited ? colors.accent : undefined} dimColor={!cited} bold={cited}>
+          [^{source.id}]
+        </Text>
+        <Text dimColor> ({source.kind}) </Text>
+        <Text dimColor={!cited}>{truncate(source.label, 80)}</Text>
+      </Box>
+      {showRawRef && (
+        <Box marginLeft={4}>
+          <Text dimColor>{truncate(source.rawRef, 120)}</Text>
+        </Box>
+      )}
+      {showPreview && (
+        <Box marginLeft={4}>
+          <Text dimColor>
+            {truncate(source.contentPreview.replace(/\s+/g, ' '), 160)}
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/ui/overlays/StatusViewer.tsx
+++ b/src/ui/overlays/StatusViewer.tsx
@@ -1,0 +1,175 @@
+import { Box, Text } from 'ink';
+import type { Agent } from '../../agent.js';
+import type { BernardConfig } from '../../config.js';
+import {
+  pickActiveStep,
+  summarizePlan,
+  type AgentStatusInputs,
+} from '../../agent-status.js';
+import { getThemeColors } from '../../theme.js';
+
+interface StatusViewerProps {
+  agent: Agent;
+  config: BernardConfig;
+  sessionAllowedCount: number;
+}
+
+const LABEL_WIDTH = 15;
+const MAX_VALUE_CHARS = 200;
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+/**
+ * Full-screen Agent Status panel. Replaces the legacy `buildAgentStatusPanel`
+ * + `setPinnedRegion('viewer', …)` flow from `src/repl.ts`. Renders the same
+ * `AgentStatusInputs` shape that `src/agent-status.ts:15` defines, but as Ink
+ * components — no ANSI assembly, no pinned region.
+ *
+ * **Closes #211 round-2 bug 1 by construction**: there is no pinned-region
+ * concept in Ink. The panel is just a JSX subtree that fills the viewport
+ * above the thread; closing it (Esc) unmounts the subtree and Ink's render
+ * diff leaves the thread + prompt in place.
+ */
+export function StatusViewer({ agent, config, sessionAllowedCount }: StatusViewerProps) {
+  const colors = getThemeColors();
+  const inputs = collectStatusInputs(agent, config, sessionAllowedCount);
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color={colors.accent} bold>
+        Agent Status
+      </Text>
+      <Text> </Text>
+      <Row label="Goal" value={inputs.goal ? truncate(inputs.goal, MAX_VALUE_CHARS) : '(none)'} />
+      <Row label="Permissions" value={permissionsValue(inputs.permissions)} />
+      <Row label="Strategy" value={inputs.constraints?.strategyId ?? '(none)'} />
+      <Row label="Response shape" value={responseShapeValue(inputs.constraints)} />
+      <AssumptionsRows assumptions={inputs.assumptions} />
+      <PlanStepRow planStep={inputs.planStep} planSummary={inputs.planSummary} />
+      <VerificationRow entry={inputs.lastVerification} />
+      <Text> </Text>
+      <Text dimColor>Esc to close · Shift-Tab to switch tabs</Text>
+    </Box>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Text dimColor>{label.padEnd(LABEL_WIDTH)}</Text>
+      <Text>{value}</Text>
+    </Box>
+  );
+}
+
+function AssumptionsRows({
+  assumptions,
+}: {
+  assumptions: AgentStatusInputs['assumptions'];
+}) {
+  if (assumptions.length === 0) return <Row label="Assumptions" value="(none)" />;
+  return (
+    <Box flexDirection="column">
+      {assumptions.map((a, idx) => {
+        const text = `"${a.phrase}" → ${truncate(a.resolvedTo, 80)} (${a.sourceKey})`;
+        return (
+          <Box key={idx}>
+            <Text dimColor>{(idx === 0 ? 'Assumptions' : '').padEnd(LABEL_WIDTH)}</Text>
+            <Text>{text}</Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+function PlanStepRow({
+  planStep,
+  planSummary,
+}: {
+  planStep: AgentStatusInputs['planStep'];
+  planSummary: AgentStatusInputs['planSummary'];
+}) {
+  if (!planStep) return <Row label="Plan step" value="(none)" />;
+  const { id, status, description, verification } = planStep;
+  const header = `[${status}] ${id} of ${planSummary.total} — ${truncate(description, 120)}`;
+  return (
+    <Box flexDirection="column">
+      <Row label="Plan step" value={header} />
+      {verification && (
+        <Box>
+          <Text dimColor>{''.padEnd(LABEL_WIDTH)}</Text>
+          <Text dimColor>verify: {truncate(verification, 120)}</Text>
+        </Box>
+      )}
+      {planSummary.done > 0 && planSummary.done < planSummary.total && (
+        <Box>
+          <Text dimColor>{''.padEnd(LABEL_WIDTH)}</Text>
+          <Text dimColor>
+            ({planSummary.done}/{planSummary.total} done)
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function VerificationRow({ entry }: { entry: AgentStatusInputs['lastVerification'] }) {
+  const colors = getThemeColors();
+  if (!entry) return <Row label="Last verify" value="(none)" />;
+  const tagColor =
+    entry.verdict === 'pass'
+      ? colors.success
+      : entry.verdict === 'warn'
+        ? colors.warning
+        : colors.error;
+  return (
+    <Box>
+      <Text dimColor>{'Last verify'.padEnd(LABEL_WIDTH)}</Text>
+      <Text color={tagColor} bold>
+        {entry.verdict.toUpperCase()}
+      </Text>
+      <Text> — {truncate(entry.reason, 120)}</Text>
+      {entry.source && <Text dimColor>  ({truncate(entry.source, 60)})</Text>}
+    </Box>
+  );
+}
+
+function permissionsValue(p: AgentStatusInputs['permissions']): string {
+  const base = `tools: ${p.toolMode} · confirm: ${p.confirmMode}`;
+  if (p.sessionAllowedCount > 0) return `${base} (${p.sessionAllowedCount} session-allowed)`;
+  return base;
+}
+
+function responseShapeValue(d: AgentStatusInputs['constraints']): string {
+  if (!d) return '(none)';
+  const parts: string[] = [];
+  if (d.concise?.enabled) parts.push('concise');
+  if (d.citations?.requireForFactualClaims) parts.push('citations: required');
+  if (d.evidence?.requireForVerifiedClaims) parts.push('evidence: required');
+  return parts.length > 0 ? parts.join(' · ') : 'default';
+}
+
+function collectStatusInputs(
+  agent: Agent,
+  config: BernardConfig,
+  sessionAllowedCount: number,
+): AgentStatusInputs {
+  const steps = agent.getPlanSnapshot();
+  return {
+    goal: agent.getLastUserInput(),
+    permissions: {
+      toolMode: config.toolMode,
+      confirmMode: config.confirmMode,
+      sessionAllowedCount,
+    },
+    constraints: agent.getLastPolicyDecision()?.decision ?? null,
+    assumptions: agent.getLastResolvedReferences(),
+    planStep: pickActiveStep(steps),
+    planSummary: summarizePlan(steps),
+    lastVerification: agent.getLastVerification(),
+  };
+}

--- a/src/ui/save.ts
+++ b/src/ui/save.ts
@@ -1,0 +1,33 @@
+import type { Agent } from '../agent.js';
+import type { HistoryStore } from '../history.js';
+import type { ProvenanceHistoryStore } from '../provenance-history.js';
+
+/**
+ * Persists the agent's current conversation and per-turn provenance to disk.
+ *
+ * Mirrors the legacy REPL's `persistAgentState()` helper, but takes its inputs
+ * as a typed argument bag so `<App>` can call it without depending on
+ * `src/repl.ts`. Phase D will delete the duplicate in `src/repl.ts` when the
+ * legacy REPL is removed; until then the two copies do not interact because
+ * the Ink path is not user-mounted.
+ *
+ * Failures are swallowed and logged — a save error must never crash the REPL
+ * mid-turn (the legacy helper has the same contract).
+ */
+export function persistAgentState(args: {
+  agent: Agent;
+  historyStore: HistoryStore;
+  provenanceHistoryStore: ProvenanceHistoryStore;
+}): void {
+  const { agent, historyStore, provenanceHistoryStore } = args;
+  try {
+    historyStore.save(agent.getHistory());
+  } catch (err) {
+    console.error('Failed to save conversation history:', err);
+  }
+  try {
+    provenanceHistoryStore.save(agent.getTurnProvenance());
+  } catch (err) {
+    console.error('Failed to save provenance history:', err);
+  }
+}


### PR DESCRIPTION
## Summary

Builds the Ink component tree under `src/ui/` that will replace Bernard's bespoke readline+ANSI REPL at the cutover (Phase D). Strictly additive — `src/index.ts`, `src/repl.ts`, `src/output.ts`, `src/menu.ts` are untouched. No opt-in flag. No user-visible behavior change in this PR.

This aligns with the nuclear-migration plan ([#213 phase plan](https://github.com/phillt/bernard/issues/213)): the user sees nothing change until Phase D flips the default and deletes the bespoke layer in the same PR. Phases B and C are entirely internal scaffolding.

## What's in this PR

- **`src/theme.ts`** — `ThemeColors` interface, per-theme `THEME_COLORS` records, `getThemeColors()` export. Additive — the chalk `ColorFn` API stays untouched for Phase D to delete.
- **`src/ui/App.tsx`** — top-level component owning `mode`, `activeOverlay`, `historyVersion`, overlay-request queue. Hosts Shift-Tab + Esc + Ctrl-C via `useInput`.
- **`src/ui/{Thread,Prompt,Spinner,SlashHints,PlanStrip}.tsx`** — core view components.
- **`src/ui/overlays/{StatusViewer,SourcesViewer,MenuOverlay,ConfirmDialog}.tsx`** — overlay subtree.
- **`src/ui/save.ts`** — pure `persistAgentState({agent, historyStore, provenanceHistoryStore})` helper.
- **`scripts/preview-ink.mjs`** — dev harness that mounts `<App>` against an isolated `BERNARD_HOME=$(mktemp -d)`. Not shipped, not in `package.json` bin, not imported from `src/`.

## #211 round-2 bug fixes (reproducible in the preview)

- **Bug 1 (Status pinned under prompt)** → fixed by construction. `<StatusViewer>` is a JSX subtree rendered above `<Thread>` + `<Prompt>` in `<App>`'s render — there is no pinned-region concept in Ink.
- **Bug 2 (Esc → `printConversationReplay` artifact)** → fixed by construction. Closing an overlay sets `activeOverlay = null`; Ink's render diff leaves `<Thread>` mounted underneath untouched. `printConversationReplay` is never called from any Ink path.

These will become live for users in Phase D; until then they're reproducible via `tsx scripts/preview-ink.mjs`.

## Out of scope (per plan)

- Real-time streaming output → Phase C (#214).
- Mounting `<App>` from `src/index.ts` + deleting the bespoke layer → Phase D (#215).
- Free-form `ask_user` text input → Phase D (Phase B handles choice questions only).
- REPL test rewrite with `ink-testing-library` → Phase E (#216).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 2673/2673 pass (Phase B is invisible to the live REPL, so no behavioral regression is possible)
- [x] `git diff --stat` shows changes only under `src/ui/`, `src/theme.ts` (additive), `scripts/preview-ink.mjs`
- [ ] Manual: `tsx scripts/preview-ink.mjs` — verify Shift-Tab cycles Status/Sources full-screen, Esc closes overlay cleanly, `/clear` empties the thread

Refs #211, #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)