### PR TITLE
feat(ui): phase C — streaming message store + main-agent token streaming

### DIFF
--- a/scripts/preview-ink.mjs
+++ b/scripts/preview-ink.mjs
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
 /**
- * scripts/preview-ink.mjs — Phase B dev harness.
+ * scripts/preview-ink.mjs — Ink dev harness.
  *
  * Mounts the Ink <App> against a real Bernard agent so a developer can
- * end-to-end validate the #211 round-2 fixes (Shift-Tab Status full-screen,
- * Esc closes overlay without replay artifact) without touching their normal
+ * end-to-end validate the in-flight Ink REPL without touching their normal
  * Bernard state.
+ *
+ * Phase C (#214) note: <App> registers a MessageStore as the active output
+ * sink on mount, so this preview now exercises true token streaming on the
+ * main agent (text appears incrementally) and bulk-at-step rendering on
+ * sub-agents / tool-wrappers. When run outside the Ink tree (legacy REPL),
+ * no sink is registered and outputHook falls through to the existing stdout
+ * printers unchanged.
  *
  * Sets BERNARD_HOME=$(mktemp -d) on every launch so memory, history,
  * provenance, RAG state, etc. are isolated from the user's real install.

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -186,6 +186,11 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
   site: 'main',
   historyMode: 'persistent',
   repairLabel: 'main',
+  // Phase C (#214): main-only token streaming. Sub-agents / specialists /
+  // tool-wrappers stay on `generateText` so concurrent dispatches don't
+  // interleave token streams in the terminal. The streaming branch only
+  // activates when `setOutputSink` has registered a consumer.
+  streaming: true,
 
   systemPrompt(_ctx, input) {
     // The Agent class pre-renders the prompt via `buildMainSystemPrompt` and

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -4,6 +4,7 @@ import { resolveSiteModel } from '../../model-policy.js';
 import { makeRepairHook } from '../../tool-call-repair.js';
 import { augmentTools } from '../../tools/augment.js';
 import type { AgentContext } from '../context.js';
+import { getOutputSink } from '../hooks/output-sink.js';
 import { runAgent, type AgentResult, type AgentSpec } from '../runner.js';
 import type { IterateFn, IterateOpts, StrategyContext } from '../strategies/types.js';
 import type { AgentDefinition, HistoryMode, ModelOverrides, ResolvedModel } from './types.js';
@@ -148,6 +149,16 @@ export async function runDefinition<TInput, TFormatted>(
     return msg ? [msg] : [];
   };
 
+  // Phase C (#214) streaming gate. Both conditions must hold: the definition
+  // opts in (`main` only today), AND a sink is currently registered (the Ink
+  // `<App>` is mounted). The legacy readline REPL never registers a sink, so
+  // it always falls through to `generateText` — identical behavior to today.
+  const sink = def.streaming ? getOutputSink() : null;
+  const useStreaming = sink !== null;
+  const onTextDelta = useStreaming
+    ? (delta: string) => sink.append({ kind: 'text-delta', text: delta })
+    : undefined;
+
   // `messages` here is a placeholder — `innerIterate` rebuilds the messages
   // array on every call, so the seed alone is sufficient for the baseSpec.
   const baseSpec: AgentSpec = {
@@ -162,6 +173,8 @@ export async function runDefinition<TInput, TFormatted>(
     prepareStep,
     repair,
     hooks,
+    useStreaming,
+    onTextDelta,
   };
 
   let stepLimitHit = false;

--- a/src/framework/agents/types.ts
+++ b/src/framework/agents/types.ts
@@ -160,4 +160,15 @@ export interface AgentDefinition<TInput = unknown, TFormatted = unknown> {
 
   /** Optional prefix for log lines emitted from strategies (e.g. `[sub:42]`). */
   prefix?(input: TInput): string | undefined;
+
+  /**
+   * Phase C (#214): when `true` AND an output sink is registered via
+   * `setOutputSink`, the runner uses `streamText` instead of `generateText`
+   * and pushes per-token deltas into the sink for this definition's runs.
+   * When false / omitted, the run stays on `generateText` regardless of
+   * whether a sink is active. Only the main-agent definition sets this so
+   * sub-agent / specialist / tool-wrapper dispatches don't interleave
+   * concurrent token streams in the terminal.
+   */
+  streaming?: boolean;
 }

--- a/src/framework/hooks/__tests__/output.test.ts
+++ b/src/framework/hooks/__tests__/output.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../../output.js', () => ({
   printToolCall: vi.fn(),
@@ -7,10 +7,15 @@ vi.mock('../../../output.js', () => ({
 }));
 
 import { outputHook } from '../output.js';
+import { setOutputSink, type OutputSink, type StreamEvent } from '../output-sink.js';
 import { printToolCall, printToolResult, printAssistantText } from '../../../output.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  setOutputSink(null);
 });
 
 function payload(
@@ -73,5 +78,73 @@ describe('outputHook', () => {
       payload({ text: '', toolCalls: [{ toolName: 'shell', toolCallId: 'x', args: {} }] }),
     );
     expect(printAssistantText).not.toHaveBeenCalled();
+  });
+
+  describe('with an OutputSink registered', () => {
+    function makeRecordingSink(): { sink: OutputSink; events: StreamEvent[] } {
+      const events: StreamEvent[] = [];
+      return { sink: { append: (e) => events.push(e) }, events };
+    }
+
+    it('routes step events to the sink instead of stdout', async () => {
+      const { sink, events } = makeRecordingSink();
+      setOutputSink(sink);
+      const hook = outputHook('sub:2');
+      await hook.onStepFinish!(
+        payload({
+          text: 'subtree summary',
+          toolCalls: [{ toolName: 'shell', toolCallId: 't1', args: { command: 'ls' } }],
+          toolResults: [
+            { toolName: 'shell', toolCallId: 't1', result: { output: 'x', is_error: false } },
+          ],
+        }),
+      );
+      expect(printToolCall).not.toHaveBeenCalled();
+      expect(printToolResult).not.toHaveBeenCalled();
+      expect(printAssistantText).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        {
+          kind: 'tool-call',
+          callId: 't1',
+          toolName: 'shell',
+          args: { command: 'ls' },
+          agentLabel: 'sub:2',
+        },
+        {
+          kind: 'tool-result',
+          callId: 't1',
+          result: { output: 'x', is_error: false },
+          isError: false,
+          agentLabel: 'sub:2',
+        },
+        { kind: 'text-delta', text: 'subtree summary', agentLabel: 'sub:2' },
+      ]);
+    });
+
+    it('omits the bulk text-delta for the main agent (prefix === undefined)', async () => {
+      const { sink, events } = makeRecordingSink();
+      setOutputSink(sink);
+      const hook = outputHook();
+      await hook.onStepFinish!(
+        payload({
+          text: 'main reply',
+          toolCalls: [{ toolName: 'memory', toolCallId: 'm1', args: { op: 'list' } }],
+          toolResults: [{ toolName: 'memory', toolCallId: 'm1', result: 'ok' }],
+        }),
+      );
+      // Tool events still flow (the runner needs them for inline rendering),
+      // but text is suppressed here because the runner's streamText loop is
+      // already pushing per-token deltas for the main agent.
+      expect(events.map((e) => e.kind)).toEqual(['tool-call', 'tool-result']);
+    });
+
+    it('falls through to stdout when sink is cleared mid-test', async () => {
+      const { sink } = makeRecordingSink();
+      setOutputSink(sink);
+      setOutputSink(null);
+      const hook = outputHook();
+      await hook.onStepFinish!(payload({ text: 'fallback', toolCalls: [], toolResults: [] }));
+      expect(printAssistantText).toHaveBeenCalledWith('fallback', undefined);
+    });
   });
 });

--- a/src/framework/hooks/output-sink.ts
+++ b/src/framework/hooks/output-sink.ts
@@ -1,0 +1,75 @@
+/**
+ * Module-level seam connecting the framework's output channel to a live
+ * consumer (the Ink message store in Phase C, but the interface is concrete
+ * enough that anything implementing {@link OutputSink} can be plugged in).
+ *
+ * The seven `outputHook(prefix)` call sites across the agent definitions
+ * (`main`, `sub`, `specialist`, `task`, `tool-wrapper`, the three PAC phases)
+ * are static — threading a sink reference through every `AgentDefinition`
+ * signature would touch every call site and every test that constructs an
+ * `AgentContext`. A module-level slot keeps the seam narrow: callers that
+ * want stream events register a sink at startup; callers that don't (the
+ * legacy readline REPL, cron) leave the slot null and the framework falls
+ * through to its existing stdout printers verbatim.
+ *
+ * Phase D consideration: when the readline REPL is deleted, the slot becomes
+ * always-set under normal operation. It still falls back to null for cron and
+ * for the few unit tests that import `outputHook` without mounting `<App>`.
+ */
+
+/** Per-step events the framework pushes to a registered sink. */
+export type StreamEvent =
+  | {
+      kind: 'text-delta';
+      /** Incremental text delta. May be a full step's text in the bulk path. */
+      text: string;
+      /** Sub-agent / wrapper prefix (e.g. `sub:2`). Undefined for the main agent. */
+      agentLabel?: string;
+    }
+  | {
+      kind: 'tool-call';
+      callId: string;
+      toolName: string;
+      args: unknown;
+      agentLabel?: string;
+    }
+  | {
+      kind: 'tool-result';
+      callId: string;
+      result: unknown;
+      isError: boolean;
+      agentLabel?: string;
+    };
+
+/**
+ * Minimal contract the framework needs from a consumer. The concrete
+ * `MessageStore` under `src/ui/message-store.ts` adds React-specific
+ * `subscribe` / `getSnapshot` on top, but the framework layer only sees this.
+ */
+export interface OutputSink {
+  append(event: StreamEvent): void;
+}
+
+let activeSink: OutputSink | null = null;
+
+/**
+ * Register (or clear with `null`) the live output sink. `<App>` calls this
+ * once in a mount-time `useEffect` and again with `null` on unmount.
+ *
+ * This is global by design — see the module-level comment. The expected
+ * single-mounted-app pattern means only one consumer can be registered at a
+ * time; calling `setOutputSink` while one is already active overwrites it
+ * silently. Callers that need to compose sinks should do so on their side.
+ */
+export function setOutputSink(sink: OutputSink | null): void {
+  activeSink = sink;
+}
+
+/**
+ * Read the current sink. Returns `null` when no consumer is registered, in
+ * which case `outputHook` falls through to its stdout printers. The legacy
+ * readline REPL never calls `setOutputSink`, so its behavior is unchanged.
+ */
+export function getOutputSink(): OutputSink | null {
+  return activeSink;
+}

--- a/src/framework/hooks/output.ts
+++ b/src/framework/hooks/output.ts
@@ -1,4 +1,5 @@
 import { printToolCall, printToolResult, printAssistantText } from '../../output.js';
+import { detectToolError } from '../../tool-profiles.js';
 import { getOutputSink } from './output-sink.js';
 import type { AgentHook } from './types.js';
 
@@ -42,11 +43,16 @@ export function outputHook(prefix?: string): AgentHook {
           });
         }
         for (const tr of toolResults ?? []) {
+          // Per-tool shapes vary (`shell` uses `is_error`, `web_read` returns
+          // an "Error:" string, MCP tools surface text content, …) — defer to
+          // the same classifier the stdout printer uses so the Ink thread
+          // colors failed calls red consistently with the legacy path.
+          const errInfo = detectToolError(tr.toolName, tr.result);
           sink.append({
             kind: 'tool-result',
             callId: tr.toolCallId,
             result: tr.result,
-            isError: false,
+            isError: errInfo.isError,
             agentLabel: prefix,
           });
         }

--- a/src/framework/hooks/output.ts
+++ b/src/framework/hooks/output.ts
@@ -1,4 +1,5 @@
 import { printToolCall, printToolResult, printAssistantText } from '../../output.js';
+import { getOutputSink } from './output-sink.js';
 import type { AgentHook } from './types.js';
 
 /**
@@ -9,10 +10,53 @@ import type { AgentHook } from './types.js';
  * Extracted from the verbatim `onStepFinish` lambda that was previously
  * duplicated across `subagent.ts`, `specialist-run.ts`, `task.ts`, and
  * `tool-wrapper-run.ts`. The main agent uses this hook with no prefix.
+ *
+ * Phase C (#214): when an `OutputSink` is registered via `setOutputSink`,
+ * step events flow into the sink instead of the stdout printers. The sink
+ * branch never falls through to stdout — the Ink renderer owns the screen
+ * when a sink is active, and double-writing would tear the terminal. When
+ * no sink is registered (legacy readline REPL, cron jobs, most tests), the
+ * existing stdout path runs unchanged.
+ *
+ * Streaming text is NOT emitted from this hook — `onStepFinish` only fires
+ * at step completion. Per-token deltas for the main agent come from the
+ * runner's `streamText` branch (`src/framework/runner.ts`) which pushes
+ * `text-delta` events directly into the sink as they arrive. To avoid
+ * double-rendering the main agent's text (once per delta and once in bulk
+ * at step end), the sink branch here skips `text-delta` for the main agent
+ * (`prefix === undefined`) — sub-agents and wrappers still emit a single
+ * bulk `text-delta` per step since they don't stream.
  */
 export function outputHook(prefix?: string): AgentHook {
   return {
     onStepFinish: ({ text, toolCalls, toolResults }) => {
+      const sink = getOutputSink();
+      if (sink) {
+        for (const tc of toolCalls ?? []) {
+          sink.append({
+            kind: 'tool-call',
+            callId: tc.toolCallId,
+            toolName: tc.toolName,
+            args: tc.args,
+            agentLabel: prefix,
+          });
+        }
+        for (const tr of toolResults ?? []) {
+          sink.append({
+            kind: 'tool-result',
+            callId: tr.toolCallId,
+            result: tr.result,
+            isError: false,
+            agentLabel: prefix,
+          });
+        }
+        if (text && prefix !== undefined) {
+          // Sub-agent / wrapper bulk-render. Main agent (prefix === undefined)
+          // is handled by the runner's streamText loop pushing per-token deltas.
+          sink.append({ kind: 'text-delta', text, agentLabel: prefix });
+        }
+        return;
+      }
       for (const tc of toolCalls ?? []) {
         printToolCall(tc.toolName, tc.args as Record<string, unknown>, prefix);
       }

--- a/src/framework/runner.ts
+++ b/src/framework/runner.ts
@@ -1,5 +1,6 @@
 import {
   generateText,
+  streamText,
   type CoreMessage,
   type GenerateTextResult,
   type LanguageModel,
@@ -29,6 +30,21 @@ export interface AgentSpec {
   repair?: ToolCallRepairFunction<any>;
   /** Observer hooks composed in-order on `onStepFinish`. */
   hooks?: AgentHook[];
+  /**
+   * Phase C (#214): opt-in switch from `generateText` to `streamText` for
+   * this run. Only the main-agent dispatch sets this — and only when an
+   * output sink is registered, so the deltas have a consumer. Leaving it
+   * `false`/undefined keeps every other call site (sub-agents, wrappers,
+   * pre-turn LLM passes, context summarization) on the unchanged
+   * `generateText` path.
+   */
+  useStreaming?: boolean;
+  /**
+   * Called once per text-delta chunk when `useStreaming` is true. The runner
+   * still resolves the final {@link AgentResult} after the stream drains, so
+   * callers downstream of `runAgent` see the same shape they always did.
+   */
+  onTextDelta?: (delta: string) => void;
 }
 
 /** Result type re-exported so callers needn't depend on `ai` directly. */
@@ -71,6 +87,9 @@ function composeOnStepFinish(
  */
 export async function runAgent(spec: AgentSpec): Promise<AgentResult> {
   const onStepFinish = composeOnStepFinish(spec.hooks);
+  if (spec.useStreaming) {
+    return runStreaming(spec, onStepFinish);
+  }
   return generateText({
     model: spec.model,
     providerOptions: spec.providerOptions,
@@ -84,4 +103,93 @@ export async function runAgent(spec: AgentSpec): Promise<AgentResult> {
     experimental_repairToolCall: spec.repair,
     onStepFinish,
   });
+}
+
+/**
+ * `streamText` branch (Phase C, #214). Pushes deltas to `spec.onTextDelta` as
+ * they arrive, then assembles a `GenerateTextResult`-shaped object from the
+ * `StreamTextResult` promises so callers downstream — strategies, plan
+ * enforcement, provenance, format hooks — see no shape difference. The
+ * `onStepFinish` hook still fires per step exactly as in the non-streaming
+ * path, so tool-call / tool-result events route through `outputHook` to the
+ * sink alongside the per-token deltas.
+ */
+async function runStreaming(
+  spec: AgentSpec,
+  onStepFinish: ((payload: StepFinishPayload) => Promise<void>) | undefined,
+): Promise<AgentResult> {
+  // `streamText` accepts a subset of `generateText` settings — no
+  // `experimental_prepareStep`. The main agent (the only `streaming: true`
+  // definition) doesn't use prepareStep, so this is sound. If a future
+  // streaming-capable definition needs prepareStep, the AI SDK has
+  // `experimental_continueSteps` for the equivalent steering on this path.
+  const stream = streamText({
+    model: spec.model,
+    providerOptions: spec.providerOptions,
+    tools: spec.tools,
+    maxSteps: spec.maxSteps,
+    maxTokens: spec.maxTokens,
+    system: spec.system,
+    messages: spec.messages,
+    abortSignal: spec.abortSignal,
+    experimental_repairToolCall: spec.repair,
+    onStepFinish,
+  });
+  // Drain the text stream so promises resolve. `onTextDelta` lets the caller
+  // forward each chunk to the message store; `streamText` continues running
+  // even if the consumer is slow because the chunks land on internal queues.
+  for await (const delta of stream.textStream) {
+    spec.onTextDelta?.(delta);
+  }
+  // The other promises (toolCalls, toolResults, steps, etc.) are already
+  // resolved once textStream completes — awaiting them is cheap.
+  const [
+    text,
+    steps,
+    finishReason,
+    usage,
+    warnings,
+    toolCalls,
+    toolResults,
+    reasoning,
+    reasoningDetails,
+    providerMetadata,
+    request,
+    response,
+    files,
+    sources,
+  ] = await Promise.all([
+    stream.text,
+    stream.steps,
+    stream.finishReason,
+    stream.usage,
+    stream.warnings,
+    stream.toolCalls,
+    stream.toolResults,
+    stream.reasoning,
+    stream.reasoningDetails,
+    stream.providerMetadata,
+    stream.request,
+    stream.response,
+    stream.files,
+    stream.sources,
+  ]);
+  return {
+    text,
+    steps,
+    finishReason,
+    usage,
+    warnings,
+    toolCalls,
+    toolResults,
+    reasoning,
+    reasoningDetails,
+    providerMetadata,
+    experimental_providerMetadata: providerMetadata,
+    request,
+    response,
+    files,
+    sources,
+    experimental_output: undefined as never,
+  } as unknown as AgentResult;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,6 +21,8 @@ import { ConfirmDialog } from './overlays/ConfirmDialog.js';
 import { StatusViewer } from './overlays/StatusViewer.js';
 import { SourcesViewer } from './overlays/SourcesViewer.js';
 import { persistAgentState } from './save.js';
+import { MessageStore } from './message-store.js';
+import { setOutputSink } from '../framework/hooks/output-sink.js';
 import { getThemeColors } from '../theme.js';
 
 interface AppProps {
@@ -97,6 +99,15 @@ export function App({
   // Synchronous guard against double-Enter: setBusy schedules a re-render but
   // a second submit can land before Prompt sees `disabled={busy}` flip.
   const submittingRef = useRef(false);
+  // Phase C (#214): one MessageStore per <App> lifecycle. Held in a ref so
+  // re-renders don't reinstantiate it (which would unsubscribe consumers and
+  // drop in-flight events). Registered with the framework's output-sink seam
+  // in a mount-time effect; cleared on unmount.
+  const messageStoreRef = useRef<MessageStore | null>(null);
+  if (messageStoreRef.current === null) {
+    messageStoreRef.current = new MessageStore();
+  }
+  const messageStore = messageStoreRef.current;
 
   // Closes the active overlay and resolves any pending request as a cancel.
   const closeOverlay = () => {
@@ -154,6 +165,15 @@ export function App({
     };
   }, [onExit]);
 
+  // Phase C (#214) sink registration. The framework's `getOutputSink()` reads
+  // this slot on every step; the legacy readline REPL leaves it null. Cleared
+  // on unmount so a test or preview that re-mounts <App> doesn't leak the
+  // previous store into the new run.
+  useEffect(() => {
+    setOutputSink(messageStore);
+    return () => setOutputSink(null);
+  }, [messageStore]);
+
   const handleSubmit = async (text: string) => {
     if (text === '/exit' || text === '/quit') {
       if (exitedRef.current) return;
@@ -173,6 +193,9 @@ export function App({
     // to <Prompt disabled={busy}>. Without this, two turns can run concurrently.
     if (submittingRef.current) return;
     submittingRef.current = true;
+    // Clear the previous turn's stream events so the in-flight
+    // <StreamingAssistantMessage> renders only this turn's deltas.
+    messageStore.reset();
     setBusy(true);
     try {
       await agent.processInput(text);
@@ -264,7 +287,12 @@ export function App({
         </Text>
         <Text dimColor> {config.provider}/{config.model}</Text>
       </Box>
-      <Thread key={historyVersion} history={agent.getHistory()} />
+      <Thread
+        key={historyVersion}
+        history={agent.getHistory()}
+        messageStore={messageStore}
+        busy={busy}
+      />
       {busy && (
         <Box marginTop={1}>
           <Spinner label="thinking…" />

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -114,10 +114,15 @@ function StreamGroupBody({ events }: { events: StreamEvent[] }) {
     textBuffer = '';
   };
   // Pair tool-calls with their results by callId so the result renders
-  // directly under its call instead of as a separate orphan block.
+  // directly under its call instead of as a separate orphan block. The
+  // callsById set lets the orphan check below run in O(1) rather than
+  // re-scanning the event list per result — important once the list grows
+  // (tool-heavy turns can produce dozens of call/result pairs).
   const resultsByCall = new Map<string, Extract<StreamEvent, { kind: 'tool-result' }>>();
+  const callsById = new Set<string>();
   for (const ev of events) {
     if (ev.kind === 'tool-result') resultsByCall.set(ev.callId, ev);
+    else if (ev.kind === 'tool-call') callsById.add(ev.callId);
   }
   for (const ev of events) {
     if (ev.kind === 'text-delta') {
@@ -143,7 +148,7 @@ function StreamGroupBody({ events }: { events: StreamEvent[] }) {
     // tool-result handled inline above; skip if it has a matching call.
     // If a result arrived without its call (shouldn't happen, but defensive),
     // render it as a standalone row so the user still sees it.
-    if (!events.some((e) => e.kind === 'tool-call' && e.callId === ev.callId)) {
+    if (!callsById.has(ev.callId)) {
       flushText();
       elements.push(
         <Box key={`r-${ev.callId}`} marginLeft={2}>

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -1,3 +1,4 @@
+import { useSyncExternalStore, type ReactNode } from 'react';
 import { Box, Text } from 'ink';
 import type {
   CoreMessage,
@@ -13,9 +14,19 @@ import type {
 type ReasoningPart = { type: 'reasoning'; text: string };
 type RedactedReasoningPart = { type: 'redacted-reasoning'; data: string };
 import { getThemeColors } from '../theme.js';
+import type { MessageStore, StreamEvent } from './message-store.js';
 
 interface ThreadProps {
   history: CoreMessage[];
+  /**
+   * Phase C (#214): when `busy === true`, `<Thread>` mounts a
+   * `<StreamingAssistantMessage>` below the static history that subscribes
+   * to `messageStore` and renders per-token deltas + inline tool-call /
+   * tool-result blocks as they arrive. Omitted (or `busy === false`) means
+   * the static-history `<Thread>` path runs identically to Phase B.
+   */
+  messageStore?: MessageStore;
+  busy?: boolean;
 }
 
 /**
@@ -27,12 +38,137 @@ interface ThreadProps {
  * from an in-memory message store so the in-flight assistant message updates
  * token-by-token. Phase B renders the message in bulk at turn end.
  */
-export function Thread({ history }: ThreadProps) {
+export function Thread({ history, messageStore, busy }: ThreadProps) {
   return (
     <Box flexDirection="column">
       {history.map((msg, idx) => (
         <MessageBlock key={idx} message={msg} />
       ))}
+      {busy && messageStore && <StreamingAssistantMessage store={messageStore} />}
+    </Box>
+  );
+}
+
+/**
+ * In-flight turn view. Subscribes via `useSyncExternalStore` and renders
+ * the accumulated text-deltas plus any tool-call / tool-result blocks that
+ * have arrived so far. Unmounts when the turn ends (`busy` flips false) —
+ * by then the AI SDK history has the finished message and the static
+ * `<AssistantMessage>` takes over rendering it.
+ */
+export function StreamingAssistantMessage({ store }: { store: MessageStore }) {
+  const colors = getThemeColors();
+  const events = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  if (events.length === 0) return null;
+  const groups = groupByLabel(events);
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {groups.map((group, idx) => (
+        <Box key={idx} flexDirection="column">
+          <Text color={colors.accent} bold>
+            {group.label ?? 'bernard'}
+          </Text>
+          <StreamGroupBody events={group.events} />
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+interface EventGroup {
+  label: string | undefined;
+  events: StreamEvent[];
+}
+
+/**
+ * Bucket events by `agentLabel` while preserving order. Sub-agent output
+ * lands under e.g. a `sub:2` header; main-agent output (no label) lands
+ * under `bernard`. New groups open whenever the label changes, so two
+ * interleaved sub-agent dispatches render as two distinct labeled blocks
+ * even if they share a label key.
+ */
+function groupByLabel(events: readonly StreamEvent[]): EventGroup[] {
+  const out: EventGroup[] = [];
+  for (const ev of events) {
+    const label = ev.agentLabel;
+    const tail = out[out.length - 1];
+    if (tail && tail.label === label) {
+      tail.events.push(ev);
+    } else {
+      out.push({ label, events: [ev] });
+    }
+  }
+  return out;
+}
+
+function StreamGroupBody({ events }: { events: StreamEvent[] }) {
+  const colors = getThemeColors();
+  // Concatenate text-deltas into a single rolling string so we don't render
+  // one <Text> per token (which Ink would lay out as separate lines).
+  const elements: ReactNode[] = [];
+  let textBuffer = '';
+  let textKey = 0;
+  const flushText = () => {
+    if (textBuffer.length === 0) return;
+    elements.push(<Text key={`t-${textKey++}`}>{textBuffer}</Text>);
+    textBuffer = '';
+  };
+  // Pair tool-calls with their results by callId so the result renders
+  // directly under its call instead of as a separate orphan block.
+  const resultsByCall = new Map<string, Extract<StreamEvent, { kind: 'tool-result' }>>();
+  for (const ev of events) {
+    if (ev.kind === 'tool-result') resultsByCall.set(ev.callId, ev);
+  }
+  for (const ev of events) {
+    if (ev.kind === 'text-delta') {
+      textBuffer += ev.text;
+      continue;
+    }
+    if (ev.kind === 'tool-call') {
+      flushText();
+      const argsSummary = summariseArgs(ev.args);
+      elements.push(
+        <Box key={`c-${ev.callId}`} flexDirection="column">
+          <Box>
+            <Text color={colors.toolCall}>⚙ {ev.toolName}</Text>
+            {argsSummary && <Text dimColor>  {argsSummary}</Text>}
+          </Box>
+          {resultsByCall.has(ev.callId) && (
+            <StreamingToolResult result={resultsByCall.get(ev.callId)!} />
+          )}
+        </Box>,
+      );
+      continue;
+    }
+    // tool-result handled inline above; skip if it has a matching call.
+    // If a result arrived without its call (shouldn't happen, but defensive),
+    // render it as a standalone row so the user still sees it.
+    if (!events.some((e) => e.kind === 'tool-call' && e.callId === ev.callId)) {
+      flushText();
+      elements.push(
+        <Box key={`r-${ev.callId}`} marginLeft={2}>
+          <Text color={ev.isError ? colors.error : undefined} dimColor={!ev.isError}>
+            ↳ {renderResultSnippet(ev.result)}
+          </Text>
+        </Box>,
+      );
+    }
+  }
+  flushText();
+  return <>{elements}</>;
+}
+
+function StreamingToolResult({
+  result,
+}: {
+  result: Extract<StreamEvent, { kind: 'tool-result' }>;
+}) {
+  const colors = getThemeColors();
+  return (
+    <Box marginLeft={2}>
+      <Text color={result.isError ? colors.error : undefined} dimColor={!result.isError}>
+        ↳ {renderResultSnippet(result.result)}
+      </Text>
     </Box>
   );
 }

--- a/src/ui/__tests__/message-store.test.ts
+++ b/src/ui/__tests__/message-store.test.ts
@@ -10,16 +10,57 @@ describe('MessageStore', () => {
   it('appends events and flips snapshot identity per append', () => {
     const store = new MessageStore();
     const a = store.getSnapshot();
-    store.append({ kind: 'text-delta', text: 'hi' });
+    store.append({ kind: 'tool-call', callId: 'c1', toolName: 'shell', args: {} });
     const b = store.getSnapshot();
-    store.append({ kind: 'text-delta', text: ' there' });
+    store.append({ kind: 'tool-result', callId: 'c1', result: 'ok', isError: false });
     const c = store.getSnapshot();
     // useSyncExternalStore relies on reference inequality to detect changes.
     expect(a).not.toBe(b);
     expect(b).not.toBe(c);
     expect(c).toEqual([
-      { kind: 'text-delta', text: 'hi' },
-      { kind: 'text-delta', text: ' there' },
+      { kind: 'tool-call', callId: 'c1', toolName: 'shell', args: {} },
+      { kind: 'tool-result', callId: 'c1', result: 'ok', isError: false },
+    ]);
+  });
+
+  it('coalesces consecutive text-deltas for the same agentLabel', () => {
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'hi' });
+    store.append({ kind: 'text-delta', text: ' there' });
+    store.append({ kind: 'text-delta', text: '!' });
+    expect(store.getSnapshot()).toEqual([{ kind: 'text-delta', text: 'hi there!' }]);
+  });
+
+  it('still flips snapshot identity on every coalesced text-delta', () => {
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'hi' });
+    const a = store.getSnapshot();
+    store.append({ kind: 'text-delta', text: ' there' });
+    const b = store.getSnapshot();
+    expect(a).not.toBe(b);
+  });
+
+  it('does not coalesce across different agentLabels', () => {
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'main' });
+    store.append({ kind: 'text-delta', text: 'sub', agentLabel: 'sub:2' });
+    store.append({ kind: 'text-delta', text: 'main2' });
+    expect(store.getSnapshot()).toEqual([
+      { kind: 'text-delta', text: 'main' },
+      { kind: 'text-delta', text: 'sub', agentLabel: 'sub:2' },
+      { kind: 'text-delta', text: 'main2' },
+    ]);
+  });
+
+  it('does not coalesce across a tool-call boundary', () => {
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'before ' });
+    store.append({ kind: 'tool-call', callId: 'c1', toolName: 'shell', args: {} });
+    store.append({ kind: 'text-delta', text: 'after' });
+    expect(store.getSnapshot()).toEqual([
+      { kind: 'text-delta', text: 'before ' },
+      { kind: 'tool-call', callId: 'c1', toolName: 'shell', args: {} },
+      { kind: 'text-delta', text: 'after' },
     ]);
   });
 

--- a/src/ui/__tests__/message-store.test.ts
+++ b/src/ui/__tests__/message-store.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MessageStore, type StreamEvent } from '../message-store.js';
+
+describe('MessageStore', () => {
+  it('returns an empty snapshot before any events', () => {
+    const store = new MessageStore();
+    expect(store.getSnapshot()).toEqual([]);
+  });
+
+  it('appends events and flips snapshot identity per append', () => {
+    const store = new MessageStore();
+    const a = store.getSnapshot();
+    store.append({ kind: 'text-delta', text: 'hi' });
+    const b = store.getSnapshot();
+    store.append({ kind: 'text-delta', text: ' there' });
+    const c = store.getSnapshot();
+    // useSyncExternalStore relies on reference inequality to detect changes.
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    expect(c).toEqual([
+      { kind: 'text-delta', text: 'hi' },
+      { kind: 'text-delta', text: ' there' },
+    ]);
+  });
+
+  it('notifies subscribers on every append', () => {
+    const store = new MessageStore();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+    store.append({ kind: 'text-delta', text: 'a' });
+    store.append({ kind: 'text-delta', text: 'b' });
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    store.append({ kind: 'text-delta', text: 'c' });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset clears events and notifies subscribers', () => {
+    const store = new MessageStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.append({ kind: 'text-delta', text: 'x' });
+    listener.mockClear();
+    store.reset();
+    expect(store.getSnapshot()).toEqual([]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset is a no-op when the store is already empty', () => {
+    const store = new MessageStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.reset();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('supports multiple independent subscribers', () => {
+    const store = new MessageStore();
+    const a = vi.fn();
+    const b = vi.fn();
+    const unsubA = store.subscribe(a);
+    store.subscribe(b);
+    store.append({ kind: 'text-delta', text: '1' });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    unsubA();
+    store.append({ kind: 'text-delta', text: '2' });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+
+  it('subscribe / getSnapshot are bound so they work when destructured', () => {
+    const store = new MessageStore();
+    const { subscribe, getSnapshot } = store;
+    const listener = vi.fn();
+    subscribe(listener);
+    store.append({ kind: 'text-delta', text: 'bound' });
+    expect(listener).toHaveBeenCalled();
+    expect(getSnapshot()).toEqual([{ kind: 'text-delta', text: 'bound' }]);
+  });
+
+  it('accepts every StreamEvent variant', () => {
+    const store = new MessageStore();
+    const events: StreamEvent[] = [
+      { kind: 'text-delta', text: 'hello' },
+      { kind: 'tool-call', callId: 'c1', toolName: 'shell', args: { command: 'ls' } },
+      { kind: 'tool-result', callId: 'c1', result: 'ok', isError: false },
+      {
+        kind: 'tool-result',
+        callId: 'c2',
+        result: 'boom',
+        isError: true,
+        agentLabel: 'sub:2',
+      },
+    ];
+    for (const e of events) store.append(e);
+    expect(store.getSnapshot()).toEqual(events);
+  });
+});

--- a/src/ui/message-store.ts
+++ b/src/ui/message-store.ts
@@ -40,6 +40,24 @@ export class MessageStore implements OutputSink {
   readonly getSnapshot = (): readonly StreamEvent[] => this.events;
 
   append(event: StreamEvent): void {
+    // Coalesce consecutive text-delta events for the same agentLabel into a
+    // single entry. Without this the main agent's streamText loop appends one
+    // event per token — a 4 000-token response would build a 4 000-element
+    // array via O(n) spread per token (O(n²) total) and force the renderer to
+    // walk the full list on every snapshot. Coalescing keeps the event count
+    // bounded by the number of tool boundaries instead of token count.
+    if (event.kind === 'text-delta' && this.events.length > 0) {
+      const tail = this.events[this.events.length - 1];
+      if (tail.kind === 'text-delta' && tail.agentLabel === event.agentLabel) {
+        const merged: StreamEvent = {
+          ...tail,
+          text: tail.text + event.text,
+        };
+        this.events = [...this.events.slice(0, -1), merged];
+        for (const listener of this.listeners) listener();
+        return;
+      }
+    }
     this.events = [...this.events, event];
     for (const listener of this.listeners) listener();
   }

--- a/src/ui/message-store.ts
+++ b/src/ui/message-store.ts
@@ -1,0 +1,58 @@
+import type { OutputSink, StreamEvent } from '../framework/hooks/output-sink.js';
+
+export type { StreamEvent } from '../framework/hooks/output-sink.js';
+
+/**
+ * Per-turn event log consumed by `<StreamingAssistantMessage>` via
+ * `useSyncExternalStore`. Phase C (#214) seam between the framework's
+ * streaming output (`runner.ts` deltas + `outputHook` step events) and the
+ * Ink renderer.
+ *
+ * Lifecycle:
+ *   - `<App>` constructs one store at mount, holds it in a `useRef`, and
+ *     registers it via `setOutputSink(store)`.
+ *   - At the start of every turn (`handleSubmit` before `agent.processInput`)
+ *     the store calls `reset()` so the in-flight `<StreamingAssistantMessage>`
+ *     renders only the current turn's events.
+ *   - On turn end, the existing `historyVersion` bump moves the now-complete
+ *     assistant message into the static-history `<Thread>` view; the
+ *     streaming component unmounts. The store's events stay in place until
+ *     the next `reset()` so any late deltas land on the now-unmounted
+ *     consumer without crashing.
+ *
+ * Snapshot identity: every `append` constructs a new array, so React's
+ * `useSyncExternalStore` equality check correctly detects the change. The
+ * store is a plain class (no React imports) so the framework layer's
+ * `OutputSink` contract is the only seam — `src/ui/` depends on the
+ * framework, never the other way around.
+ */
+export class MessageStore implements OutputSink {
+  private events: readonly StreamEvent[] = [];
+  private readonly listeners = new Set<() => void>();
+  // Bound so consumers can destructure `{ subscribe, getSnapshot }` from the
+  // store without losing `this`. `useSyncExternalStore` calls them as free
+  // functions, so the arrow form is required.
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  readonly getSnapshot = (): readonly StreamEvent[] => this.events;
+
+  append(event: StreamEvent): void {
+    this.events = [...this.events, event];
+    for (const listener of this.listeners) listener();
+  }
+
+  /**
+   * Drop accumulated events. Called by `<App>` at the start of every turn so
+   * the in-flight `<StreamingAssistantMessage>` only renders the current
+   * turn's deltas. Notifies subscribers so any still-mounted consumer
+   * re-renders with the empty snapshot.
+   */
+  reset(): void {
+    if (this.events.length === 0) return;
+    this.events = [];
+    for (const listener of this.listeners) listener();
+  }
+}


### PR DESCRIPTION
## Summary

Phase C of the Ink REPL migration (#214). Builds the message-store seam, wires `outputHook` and the main runner through it (sink-aware), and has `<Thread>` render an in-flight `<StreamingAssistantMessage>` that subscribes via `useSyncExternalStore`. Sub-agents and tool-wrappers continue to bulk-render at step completion. When no sink is registered (i.e., the legacy REPL), every code path falls through to its current stdout behavior unchanged.

**Design constraint**: per the user's "expandability + modular design at the center" directive, this PR uses one module-level sink slot rather than threading the sink through every `AgentDefinition` signature. Adding a future Ink-side consumer (e.g. a recording sink for tests, or a debug overlay) only needs to call `setOutputSink(...)` — no agent-definition fan-out.

### Scope decisions

- **Streaming is main-agent only.** Sub-agents stay on `generateText` so concurrent dispatches don't interleave token streams in the terminal. The `AgentDefinition.streaming` flag is the modular toggle.
- **Status helpers** (`printInfo` / `printWarning` / `printError` / `printDebug`) stay on stdout until Phase D. The Ink preview just won't show those lines until D.
- **Single user-facing cutover** rule still holds: users still see the legacy readline REPL after this PR. The Ink tree is exercised via `scripts/preview-ink.mjs`. Phase D flips the default and deletes the bespoke layer in one PR.

## What changed

**New files**
- `src/framework/hooks/output-sink.ts` — module-level `OutputSink` slot + `StreamEvent` union (text-delta / tool-call / tool-result).
- `src/ui/message-store.ts` — `useSyncExternalStore`-compatible class implementing `OutputSink`; snapshot identity flips per append.
- `src/ui/__tests__/message-store.test.ts` — 8 pure data-flow tests.

**Modified**
- `src/framework/hooks/output.ts` — `onStepFinish` branches on `getOutputSink()`. Sink path pushes tool events for every agent and `text-delta` only for the main agent (`prefix === undefined`).
- `src/framework/runner.ts` — `AgentSpec.useStreaming` + `onTextDelta`; `runStreaming` uses `streamText`, drains `textStream`, then awaits the `StreamTextResult` promises to assemble a `GenerateTextResult`-shape so downstream callers (provenance, plan strip, response-style, format hooks) see no shape difference.
- `src/framework/agents/types.ts` + `run.ts` — `AgentDefinition.streaming` flag; `run.ts` opts into streaming only when the definition declares it AND an output sink is registered.
- `src/framework/agents/main.ts` — `streaming: true` on the main definition only.
- `src/ui/Thread.tsx` — `<StreamingAssistantMessage>` subscribes via `useSyncExternalStore`; groups events by `agentLabel`; pairs tool-calls with results by `callId`.
- `src/ui/App.tsx` — one `MessageStore` per `<App>` lifecycle (`useRef`), `setOutputSink` on mount / `null` on unmount, `reset()` at start of every turn.
- `src/framework/hooks/__tests__/output.test.ts` — +3 sink-branch tests.
- `scripts/preview-ink.mjs` — header doc updated to describe new streaming behavior.

## Test plan

- [x] `npm run build` clean.
- [x] `npm test` — 2684 pass (2673 existing + 8 message-store + 3 sink-branch).
- [x] `git diff --stat` confined to `src/ui/`, `src/framework/hooks/`, `src/framework/runner.ts`, `src/framework/agents/{types,run,main}.ts`, `scripts/preview-ink.mjs`. No changes to `src/repl.ts` / `src/index.ts` / `src/output.ts` / `src/agent.ts`.
- [ ] Manual via \`tsx scripts/preview-ink.mjs\`:
  - Long assistant message renders **token-by-token**, not bulk-at-step-end.
  - Sub-agent dispatch still appears at step completion (bulk) — confirms the modular boundary.
  - Tool calls render inline with their result paired below by `callId`.
  - Citations (`[^Sn]`) appear inline in the streamed text.
  - Esc mid-stream — agent aborts; partial in-flight message remains visible.
  - Legacy `bernard` REPL behaves identically — no sink registered, `sink === null` branch unchanged.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)