### PR TITLE
feat(ui): REPL polish — input wrap fix, persistent timing, tool-detail gating, hint/status bars

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -690,7 +690,6 @@ export class Agent {
       throw new Error(`Agent error: ${message}`);
     } finally {
       this.abortController = null;
-      this.spinnerStats = null;
     }
   }
 

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -1,6 +1,7 @@
 import type { CoreMessage } from 'ai';
 import { buildContextMessage, type ContextMessageInputs } from '../../context-message.js';
 import { resolveSiteModel } from '../../model-policy.js';
+import { detectToolError } from '../../tool-profiles.js';
 import { makeRepairHook } from '../../tool-call-repair.js';
 import { augmentTools } from '../../tools/augment.js';
 import type { AgentContext } from '../context.js';
@@ -158,6 +159,26 @@ export async function runDefinition<TInput, TFormatted>(
   const onTextDelta = useStreaming
     ? (delta: string) => sink.append({ kind: 'text-delta', text: delta })
     : undefined;
+  const onToolCallStart = useStreaming
+    ? (ev: { callId: string; toolName: string; args: unknown }) =>
+        sink.append({
+          kind: 'tool-call',
+          callId: ev.callId,
+          toolName: ev.toolName,
+          args: ev.args,
+        })
+    : undefined;
+  const onToolResult = useStreaming
+    ? (ev: { callId: string; toolName: string; result: unknown }) => {
+        const errInfo = detectToolError(ev.toolName, ev.result);
+        sink.append({
+          kind: 'tool-result',
+          callId: ev.callId,
+          result: ev.result,
+          isError: errInfo.isError,
+        });
+      }
+    : undefined;
 
   // `messages` here is a placeholder — `innerIterate` rebuilds the messages
   // array on every call, so the seed alone is sufficient for the baseSpec.
@@ -175,6 +196,8 @@ export async function runDefinition<TInput, TFormatted>(
     hooks,
     useStreaming,
     onTextDelta,
+    onToolCallStart,
+    onToolResult,
   };
 
   let stepLimitHit = false;

--- a/src/framework/hooks/__tests__/output.test.ts
+++ b/src/framework/hooks/__tests__/output.test.ts
@@ -61,7 +61,7 @@ describe('outputHook', () => {
     ]);
   });
 
-  it('omits the bulk text-delta for the main agent (prefix === undefined)', async () => {
+  it('omits all events for the main agent (prefix === undefined)', async () => {
     const hook = outputHook();
     await hook.onStepFinish!(
       payload({
@@ -70,9 +70,10 @@ describe('outputHook', () => {
         toolResults: [{ toolName: 'memory', toolCallId: 'm1', result: 'ok' }],
       }),
     );
-    // Tool events flow; text is suppressed here because the runner's
-    // streamText loop is already pushing per-token deltas for the main agent.
-    expect(recorder.events.map((e) => e.kind)).toEqual(['tool-call', 'tool-result']);
+    // The runner's fullStream loop pushes text-delta + tool-call + tool-result
+    // to the sink directly for the main agent, so this hook no-ops to avoid
+    // double-rendering. Sub-agents / wrappers still use the bulk path above.
+    expect(recorder.events).toEqual([]);
   });
 
   it('no-ops on empty step', async () => {

--- a/src/framework/hooks/output.ts
+++ b/src/framework/hooks/output.ts
@@ -32,32 +32,38 @@ export function outputHook(prefix?: string): AgentHook {
     onStepFinish: ({ text, toolCalls, toolResults }) => {
       const sink = getOutputSink();
       if (!sink) return;
-      for (const tc of toolCalls ?? []) {
-        sink.append({
-          kind: 'tool-call',
-          callId: tc.toolCallId,
-          toolName: tc.toolName,
-          args: tc.args,
-          agentLabel: prefix,
-        });
-      }
-      for (const tr of toolResults ?? []) {
-        // Per-tool shapes vary (`shell` uses `is_error`, `web_read` returns
-        // an "Error:" string, MCP tools surface text content, …) — defer to
-        // the same classifier so the Ink thread colors failed calls red.
-        const errInfo = detectToolError(tr.toolName, tr.result);
-        sink.append({
-          kind: 'tool-result',
-          callId: tr.toolCallId,
-          result: tr.result,
-          isError: errInfo.isError,
-          agentLabel: prefix,
-        });
-      }
-      if (text && prefix !== undefined) {
-        // Sub-agent / wrapper bulk-render. Main agent (prefix === undefined)
-        // is handled by the runner's streamText loop pushing per-token deltas.
-        sink.append({ kind: 'text-delta', text, agentLabel: prefix });
+      // Main agent (`prefix === undefined`) streams via `runStreaming`, which
+      // already pushes `tool-call` / `tool-result` to the sink the moment the
+      // model finishes the call and the SDK returns the execute result. Emit
+      // them here again and the Ink thread would render each tool twice.
+      // Sub-agents / wrappers don't stream, so they still need this path.
+      if (prefix !== undefined) {
+        for (const tc of toolCalls ?? []) {
+          sink.append({
+            kind: 'tool-call',
+            callId: tc.toolCallId,
+            toolName: tc.toolName,
+            args: tc.args,
+            agentLabel: prefix,
+          });
+        }
+        for (const tr of toolResults ?? []) {
+          // Per-tool shapes vary (`shell` uses `is_error`, `web_read` returns
+          // an "Error:" string, MCP tools surface text content, …) — defer to
+          // the same classifier so the Ink thread colors failed calls red.
+          const errInfo = detectToolError(tr.toolName, tr.result);
+          sink.append({
+            kind: 'tool-result',
+            callId: tr.toolCallId,
+            result: tr.result,
+            isError: errInfo.isError,
+            agentLabel: prefix,
+          });
+        }
+        if (text) {
+          // Sub-agent / wrapper bulk-render.
+          sink.append({ kind: 'text-delta', text, agentLabel: prefix });
+        }
       }
     },
   };

--- a/src/framework/runner.ts
+++ b/src/framework/runner.ts
@@ -45,6 +45,18 @@ export interface AgentSpec {
    * callers downstream of `runAgent` see the same shape they always did.
    */
   onTextDelta?: (delta: string) => void;
+  /**
+   * Fired the moment the model finishes emitting a complete tool call (i.e.
+   * the AI SDK's `tool-call` event in `fullStream`). Lets the caller surface
+   * a `⚙ toolName` row in the UI while the tool's `execute` is still running,
+   * which would otherwise stay invisible until the entire step finished.
+   */
+  onToolCallStart?: (event: { callId: string; toolName: string; args: unknown }) => void;
+  /**
+   * Fired when a tool's `execute` returns. Pairs with `onToolCallStart` by
+   * `callId`. Useful for live-updating the result block under the call row.
+   */
+  onToolResult?: (event: { callId: string; toolName: string; result: unknown }) => void;
 }
 
 /** Result type re-exported so callers needn't depend on `ai` directly. */
@@ -135,12 +147,84 @@ async function runStreaming(
     experimental_repairToolCall: spec.repair,
     onStepFinish,
   });
-  // Drain the text stream so promises resolve. `onTextDelta` lets the caller
-  // forward each chunk to the message store; `streamText` continues running
-  // even if the consumer is slow because the chunks land on internal queues.
-  for await (const delta of stream.textStream) {
-    spec.onTextDelta?.(delta);
+  // Defensive: race every await against the parent abort signal. The AI SDK
+  // is supposed to settle `textStream` and the result promises when its own
+  // `abortSignal` fires, but in practice some providers leave the stream
+  // pending after the underlying fetch is cancelled (observed on the OpenAI
+  // path mid-reasoning). Without this race the REPL hangs on Esc because the
+  // for-await never throws. We pin a single rejecting promise to the signal
+  // and race it against each await so an abort always unwinds the runner.
+  const abortSignal = spec.abortSignal;
+  const abortPromise = abortSignal
+    ? new Promise<never>((_, reject) => {
+        if (abortSignal.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        abortSignal.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        );
+      })
+    : null;
+  const raceAbort = async <T>(p: Promise<T>): Promise<T> =>
+    abortPromise ? (Promise.race([p, abortPromise]) as Promise<T>) : p;
+
+  // Drain the full stream. `fullStream` (vs `textStream`) emits tool-call /
+  // tool-result events as they arrive, so the renderer can show `⚙ toolName`
+  // the moment the model finishes the call — without that, MCP tools that
+  // sit in `execute` for several seconds look indistinguishable from the
+  // model still reasoning. Text deltas remain forwarded via `onTextDelta` so
+  // existing callers see no behavior change.
+  try {
+    const iter = stream.fullStream[Symbol.asyncIterator]();
+    while (true) {
+      const next = await raceAbort(iter.next());
+      if (next.done) break;
+      // The AI SDK narrows `tool-call` / `tool-result` parts on the `TOOLS`
+      // generic; since we type-erase tools to `Record<string, Tool>` for the
+      // shared runner, those branches collapse to `never`. Cast through
+      // `unknown` so we can pattern-match on `type` without coupling the
+      // runner to a specific tool set.
+      const part = next.value as {
+        type: string;
+        textDelta?: string;
+        toolCallId?: string;
+        toolName?: string;
+        args?: unknown;
+        result?: unknown;
+        error?: unknown;
+      };
+      if (part.type === 'text-delta') {
+        if (part.textDelta) spec.onTextDelta?.(part.textDelta);
+      } else if (part.type === 'tool-call') {
+        spec.onToolCallStart?.({
+          callId: part.toolCallId ?? '',
+          toolName: part.toolName ?? '',
+          args: part.args,
+        });
+      } else if (part.type === 'tool-result') {
+        spec.onToolResult?.({
+          callId: part.toolCallId ?? '',
+          toolName: part.toolName ?? '',
+          result: part.result,
+        });
+      } else if (part.type === 'error') {
+        // Surface stream errors immediately rather than waiting for the
+        // settled promises below to re-throw — keeps the original stack.
+        throw part.error;
+      }
+    }
+  } catch (err) {
+    // Swallow the abort here so the result-promise awaits below can throw the
+    // canonical AbortError from the race, keeping the error shape consistent.
+    if (!(err instanceof Error && err.name === 'AbortError')) throw err;
   }
+  // Suppress unhandled-rejection noise for the abortPromise once the run is
+  // unwinding — every downstream `raceAbort` will surface it as the thrown
+  // error from `Promise.all`.
+  abortPromise?.catch(() => {});
   // The other promises (toolCalls, toolResults, steps, etc.) are already
   // resolved once textStream completes — awaiting them is cheap.
   const [
@@ -158,22 +242,24 @@ async function runStreaming(
     response,
     files,
     sources,
-  ] = await Promise.all([
-    stream.text,
-    stream.steps,
-    stream.finishReason,
-    stream.usage,
-    stream.warnings,
-    stream.toolCalls,
-    stream.toolResults,
-    stream.reasoning,
-    stream.reasoningDetails,
-    stream.providerMetadata,
-    stream.request,
-    stream.response,
-    stream.files,
-    stream.sources,
-  ]);
+  ] = await raceAbort(
+    Promise.all([
+      stream.text,
+      stream.steps,
+      stream.finishReason,
+      stream.usage,
+      stream.warnings,
+      stream.toolCalls,
+      stream.toolResults,
+      stream.reasoning,
+      stream.reasoningDetails,
+      stream.providerMetadata,
+      stream.request,
+      stream.response,
+      stream.files,
+      stream.sources,
+    ]),
+  );
   return {
     text,
     steps,

--- a/src/framework/runner.ts
+++ b/src/framework/runner.ts
@@ -199,27 +199,44 @@ async function runStreaming(
       if (part.type === 'text-delta') {
         if (part.textDelta) spec.onTextDelta?.(part.textDelta);
       } else if (part.type === 'tool-call') {
-        spec.onToolCallStart?.({
-          callId: part.toolCallId ?? '',
-          toolName: part.toolName ?? '',
-          args: part.args,
-        });
+        // Skip malformed events: an empty callId would collide across tool
+        // pairings in the sink, and an empty name renders as a blank `⚙ `.
+        if (part.toolCallId && part.toolName) {
+          spec.onToolCallStart?.({
+            callId: part.toolCallId,
+            toolName: part.toolName,
+            args: part.args,
+          });
+        }
       } else if (part.type === 'tool-result') {
-        spec.onToolResult?.({
-          callId: part.toolCallId ?? '',
-          toolName: part.toolName ?? '',
-          result: part.result,
-        });
+        if (part.toolCallId && part.toolName) {
+          spec.onToolResult?.({
+            callId: part.toolCallId,
+            toolName: part.toolName,
+            result: part.result,
+          });
+        }
       } else if (part.type === 'error') {
         // Surface stream errors immediately rather than waiting for the
         // settled promises below to re-throw — keeps the original stack.
-        throw part.error;
+        // Providers occasionally emit a non-Error value (string, plain
+        // object); wrap so downstream `err.message` / `err.name` checks work.
+        if (part.error instanceof Error) throw part.error;
+        const wrapped = new Error(
+          typeof part.error === 'string' ? part.error : JSON.stringify(part.error),
+        );
+        throw wrapped;
       }
     }
   } catch (err) {
     // Swallow the abort here so the result-promise awaits below can throw the
     // canonical AbortError from the race, keeping the error shape consistent.
-    if (!(err instanceof Error && err.name === 'AbortError')) throw err;
+    // Gate on `signal.aborted` so a provider-side AbortError (server timeout,
+    // internal cancellation) still propagates — otherwise the turn ends with
+    // no text and no diagnostic.
+    const isUserAbort =
+      err instanceof Error && err.name === 'AbortError' && abortSignal?.aborted === true;
+    if (!isUserAbort) throw err;
   }
   // Suppress unhandled-rejection noise for the abortPromise once the run is
   // unwinding — every downstream `raceAbort` will surface it as the thrown

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,12 +143,6 @@ The user has been notified and this session is open for them to review and act o
         alertBanner = `Cron alert: ${alert.jobName} — ${alert.message} (${alert.timestamp})`;
       }
 
-      printWelcome(
-        config.provider,
-        config.model,
-        getLocalVersion(),
-        config.providerBaseUrl ?? config.customProviders?.[config.provider]?.baseURL,
-      );
       const prefs = loadPreferences();
       startupUpdateCheck(!!prefs.autoUpdate);
 
@@ -203,15 +197,23 @@ async function runInkRepl(args: {
   }
 
   const statuses = mcpManager.getServerStatuses();
-  if (statuses.length > 0) {
-    printInfo('  MCP servers:');
-    for (const s of statuses) {
-      if (s.connected) {
-        printInfo(`    ✓ ${s.name} (${s.toolCount} tools)`);
-      } else {
-        printError(`    ✗ ${s.name}: ${s.error}`);
-      }
-    }
+  const connected = statuses.filter((s) => s.connected);
+  const failed = statuses.filter((s) => !s.connected);
+  const totalTools = connected.reduce((acc, s) => acc + s.toolCount, 0);
+
+  printWelcome(
+    config.provider,
+    config.model,
+    getLocalVersion(),
+    config.providerBaseUrl ?? config.customProviders?.[config.provider]?.baseURL,
+    statuses.length > 0
+      ? { connected: connected.length, failed: failed.length, tools: totalTools }
+      : undefined,
+  );
+  // Surface any failed MCP servers explicitly below the splash so users can
+  // see *which* one is broken — the splash itself just reports the count.
+  for (const s of failed) {
+    printError(`  ✗ mcp ${s.name}: ${s.error}`);
   }
 
   const mcpTools = mcpManager.getTools();

--- a/src/output.ts
+++ b/src/output.ts
@@ -62,6 +62,23 @@ export function buildSpinnerMessage(stats: SpinnerStats): string {
   return `Thinking (${elapsed} | ${up}↑ ${down}↓ | ${remainingPct}% until compression)`;
 }
 
+/**
+ * Compact status string for the always-on bottom-right status bar.
+ * Omits elapsed time (only meaningful per-turn) and formats counts/headroom
+ * the same way as `buildSpinnerMessage`.
+ */
+export function buildStatusLine(stats: SpinnerStats): string {
+  const up = formatTokenCount(stats.totalPromptTokens);
+  const down = formatTokenCount(stats.totalCompletionTokens);
+  const contextWindow = getContextWindow(stats.model, stats.contextWindowOverride);
+  const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
+  const remainingPct = Math.max(
+    0,
+    Math.round(((thresholdTokens - stats.latestPromptTokens) / thresholdTokens) * 100),
+  );
+  return `${up}↑ ${down}↓ • ${remainingPct}% free`;
+}
+
 // Spinner is a no-op in Phase D — Ink renders its own animated status line.
 export function startSpinner(_message?: string | (() => string)): void {}
 export function stopSpinner(): void {}

--- a/src/output.ts
+++ b/src/output.ts
@@ -2,6 +2,7 @@ import type { CoreMessage } from 'ai';
 import { getContextWindow, COMPRESSION_THRESHOLD } from './context.js';
 import type { Step } from './plan-store.js';
 import { debugLog } from './logger.js';
+import { getThemeColors } from './theme.js';
 
 let toolDetailsVisible = false;
 
@@ -62,43 +63,102 @@ export function buildSpinnerMessage(stats: SpinnerStats): string {
   return `Thinking (${elapsed} | ${up}↑ ${down}↓ | ${remainingPct}% until compression)`;
 }
 
-/**
- * Compact status string for the always-on bottom-right status bar.
- * Omits elapsed time (only meaningful per-turn) and formats counts/headroom
- * the same way as `buildSpinnerMessage`.
- */
-export function buildStatusLine(stats: SpinnerStats): string {
-  const up = formatTokenCount(stats.totalPromptTokens);
-  const down = formatTokenCount(stats.totalCompletionTokens);
-  const contextWindow = getContextWindow(stats.model, stats.contextWindowOverride);
-  const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
-  const remainingPct = Math.max(
-    0,
-    Math.round(((thresholdTokens - stats.latestPromptTokens) / thresholdTokens) * 100),
-  );
-  return `${up}↑ ${down}↓ • ${remainingPct}% free`;
-}
-
 // Spinner is a no-op in Phase D — Ink renders its own animated status line.
 export function startSpinner(_message?: string | (() => string)): void {}
 export function stopSpinner(): void {}
+
+const BERNARD_BANNER = [
+  '██████╗ ███████╗██████╗ ███╗   ██╗ █████╗ ██████╗ ██████╗ ',
+  '██╔══██╗██╔════╝██╔══██╗████╗  ██║██╔══██╗██╔══██╗██╔══██╗',
+  '██████╔╝█████╗  ██████╔╝██╔██╗ ██║███████║██████╔╝██║  ██║',
+  '██╔══██╗██╔══╝  ██╔══██╗██║╚██╗██║██╔══██║██╔══██╗██║  ██║',
+  '██████╔╝███████╗██║  ██║██║ ╚████║██║  ██║██║  ██║██████╔╝',
+  '╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝ ',
+];
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+
+/**
+ * Wraps `text` in an ANSI color escape. Accepts a `#rrggbb` hex string
+ * (rendered as a truecolor 24-bit escape, supported by every modern terminal)
+ * or a named ANSI color from the small allowlist below. Unknown values fall
+ * through uncolored so the splash still renders on terminals without color.
+ */
+function colorize(text: string, color: string): string {
+  const hex = color.match(/^#([0-9a-f]{6})$/i);
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    const r = (n >> 16) & 0xff;
+    const g = (n >> 8) & 0xff;
+    const b = n & 0xff;
+    return `\x1b[38;2;${r};${g};${b}m${text}${RESET}`;
+  }
+  const named: Record<string, string> = {
+    black: '30',
+    red: '31',
+    green: '32',
+    yellow: '33',
+    blue: '34',
+    magenta: '35',
+    cyan: '36',
+    white: '37',
+    gray: '90',
+    whiteBright: '97',
+    redBright: '91',
+    greenBright: '92',
+    yellowBright: '93',
+    blueBright: '94',
+    magentaBright: '95',
+    cyanBright: '96',
+  };
+  const code = named[color];
+  return code ? `\x1b[${code}m${text}${RESET}` : text;
+}
+
+export interface WelcomeMcpSummary {
+  /** Total connected MCP servers. */
+  connected: number;
+  /** Number of failed-to-connect servers (rendered as a warning when > 0). */
+  failed: number;
+  /** Total tools surfaced across all connected servers. */
+  tools: number;
+}
 
 export function printWelcome(
   provider: string,
   model: string,
   version?: string,
   baseURL?: string,
+  mcp?: WelcomeMcpSummary,
 ): void {
-  const ver = version ? ` v${version}` : '';
-  console.log(`\n  Bernard${ver} — AI CLI Assistant`);
-  console.log(`  Provider: ${provider} | Model: ${model}`);
-  if (baseURL) {
-    console.log(`  Endpoint: ${baseURL}`);
+  const accent = getThemeColors().accent;
+
+  console.log();
+  for (const line of BERNARD_BANNER) {
+    console.log('  ' + colorize(line, accent));
+  }
+  console.log();
+  const ver = version ? `v${version}` : '';
+  const line1 = [ver, 'local AI CLI agent'].filter(Boolean).join('  ·  ');
+  const line2 = `${provider}  /  ${model}`;
+  const line3 = '/help for commands  ·  exit to quit';
+  console.log('  ' + colorize(line1, accent));
+  console.log('  ' + DIM + line2 + RESET);
+  if (baseURL) console.log('  ' + DIM + `endpoint  ${baseURL}` + RESET);
+  if (mcp && (mcp.connected > 0 || mcp.failed > 0)) {
+    const parts: string[] = [];
+    if (mcp.connected > 0) {
+      parts.push(`${mcp.connected} server${mcp.connected === 1 ? '' : 's'} · ${mcp.tools} tools`);
+    }
+    if (mcp.failed > 0) parts.push(`${mcp.failed} failed`);
+    console.log('  ' + DIM + `mcp       ${parts.join('  ·  ')}` + RESET);
   }
   if (process.env.BERNARD_DEBUG === 'true' || process.env.BERNARD_DEBUG === '1') {
-    console.log('  DEBUG mode enabled — logging to .logs/');
+    console.log('  ' + DIM + 'debug logging enabled' + RESET);
   }
-  console.log('  Type /help for commands, exit to quit\n');
+  console.log('  ' + DIM + line3 + RESET);
+  console.log();
 }
 
 // Render path is now Ink (StreamingAssistantMessage + ToolCallEvent components

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -492,8 +492,12 @@ export function augmentTools(
               debugLog(`cache:tool:miss`, { tool: toolName });
             }
             let envelope: ToolResult<unknown>;
+            debugLog(`augment:${toolName}:start`, undefined);
             try {
               envelope = await source.execute(args, execOptions as never);
+              debugLog(`augment:${toolName}:done`, {
+                ok: envelope.status === 'ok',
+              });
             } catch (thrown: unknown) {
               // Infrastructure-level throws (reconnect, network, etc.) are not
               // usage errors — don't record them as bad examples.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -98,10 +98,11 @@ import type {
   ValuePromptOptions,
   ValueResult,
 } from './menu-types.js';
-import { Thread } from './Thread.js';
+import { Thread, REWRITE_ICON } from './Thread.js';
 import { Prompt } from './Prompt.js';
 import { Spinner } from './Spinner.js';
 import { StatusBar } from './StatusBar.js';
+import { HintBar } from './HintBar.js';
 import { PlanStrip } from './PlanStrip.js';
 import { MenuOverlay } from './overlays/MenuOverlay.js';
 import { ConfirmDialog } from './overlays/ConfirmDialog.js';
@@ -234,6 +235,19 @@ export function App({
   const [pendingInfo, setPendingInfo] = useState<PendingInfo | null>(null);
   const [toast, setToast] = useState<ToastState | null>(null);
   const [bannerVisible, setBannerVisible] = useState<boolean>(!!alertBanner);
+  const [interrupted, setInterrupted] = useState(false);
+  const [slashActive, setSlashActive] = useState(false);
+  // Per-history-index timing for completed turns: drives the timestamp +
+  // duration footer under every assistant message in <Thread>. Stored as a
+  // ref because re-renders are already triggered by historyVersion bumps; the
+  // map is append-only across the session and cleared by /clear.
+  const turnTimingsRef = useRef<Map<number, { endedAt: number; durationMs: number }>>(
+    new Map(),
+  );
+  // history-index → user's original text when the rewriter substituted it.
+  // Lives outside React state because it's append-only and not React-reactive
+  // (history re-renders are driven by historyVersion bumps already).
+  const rewriteOriginalsRef = useRef<Map<number, string>>(new Map());
   const colors = getThemeColors();
 
   // Confirm-action session memo: `${toolName}:${stableHash(args)}` → true.
@@ -245,6 +259,10 @@ export function App({
   // Synchronous guard against double-Enter: setBusy schedules a re-render but
   // a second submit can land before Prompt sees `disabled={busy}` flip.
   const submittingRef = useRef(false);
+  // Turn-level abort controller. Esc aborts this controller (cancels the
+  // pre-turn pipeline) AND calls agent.abort() (cancels the agent loop once
+  // it's started). Reset to null in runAgentTurn's finally block.
+  const turnAbortRef = useRef<AbortController | null>(null);
   // Phase C (#214): one MessageStore per <App> lifecycle. Held in a ref so
   // re-renders don't reinstantiate it (which would unsubscribe consumers and
   // drop in-flight events). Registered with the framework's output-sink seam
@@ -294,11 +312,14 @@ export function App({
         return;
       }
       if (key.escape) {
+        debugLog('app:esc', { busy, activeOverlay, hasTurnAbort: !!turnAbortRef.current });
         if (activeOverlay) {
           closeOverlay();
           return;
         }
         if (busy) {
+          setInterrupted(true);
+          turnAbortRef.current?.abort();
           agent.abort();
         }
       }
@@ -328,8 +349,10 @@ export function App({
   // Attach a persistent SpinnerStats object so the framework's token-stats
   // hook accumulates usage across turns. <StatusBar> polls this for the
   // pinned bottom-right readout. We never null it out — totals carry across
-  // the whole session and only reset on REPL restart.
-  useEffect(() => {
+  // the whole session and only reset on REPL restart. Seeded synchronously
+  // during the first render so the status line is visible from the first
+  // paint instead of after the next interval tick.
+  if (!agent.spinnerStats) {
     agent.setSpinnerStats({
       startTime: Date.now(),
       totalPromptTokens: 0,
@@ -338,7 +361,7 @@ export function App({
       model: config.model,
       contextWindowOverride: config.tokenWindow || undefined,
     });
-  }, [agent, config.model, config.tokenWindow]);
+  }
 
   // Phase D (#215) ink-handlers bridge. The toolOptions callbacks built in
   // `src/index.ts` read from `getInkHandlers()` at call time, so this effect
@@ -508,6 +531,7 @@ export function App({
       historyStore.clear();
       provenanceHistoryStore.clear();
       agent.clearHistory();
+      turnTimingsRef.current.clear();
       // Wipe scrollback + visible region so the old transcript doesn't linger
       // above the cleared <Thread>. `\x1b[3J` clears scrollback, `\x1b[2J`
       // the visible region, `\x1b[H` homes the cursor. Ink repaints on the
@@ -1560,8 +1584,8 @@ export function App({
       },
       toggleRow(
         'promptRewriter',
-        'Prompt rewriter',
-        'Restructure your prompt for the active model family before each turn.',
+        `Prompt rewriter ${REWRITE_ICON}`,
+        `Restructure your prompt for the active model family before each turn. Rewritten messages are tagged with ${REWRITE_ICON} next to the timestamp in the transcript.`,
         'Prompt rewriter: on',
         'Prompt rewriter: off',
       ),
@@ -1571,7 +1595,13 @@ export function App({
         'Show full tool call args and results in the transcript.',
         'Tool details: on',
         'Tool details: off',
-        setToolDetailsVisible,
+        (value) => {
+          setToolDetailsVisible(value);
+          // <Thread> re-keys on historyVersion, so bumping it here forces a
+          // remount that picks up the new toolDetails flag on the visible
+          // transcript (not just future turns).
+          setHistoryVersion((v) => v + 1);
+        },
       ),
       toggleRow(
         'conciseMode',
@@ -1643,6 +1673,7 @@ export function App({
 
   async function runPreTurnPipeline(
     input: string,
+    signal: AbortSignal,
   ): Promise<{ agentInput: string; resolvedEntries: ResolvedEntry[] }> {
     // Per-turn RAG cache invalidation (#171). Must run before any resolver /
     // rewriter LLM call so they see only this turn's facts.
@@ -1659,7 +1690,7 @@ export function App({
             stores.memory,
             config,
             hints,
-            undefined,
+            signal,
             stores.rag,
             agent.getHistory(),
           );
@@ -1675,6 +1706,7 @@ export function App({
         }
       }
     }
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
 
     let agentInput = input;
     if (config.promptRewriter) {
@@ -1684,7 +1716,7 @@ export function App({
           config.model,
           config.customProviders?.[config.provider]?.sdk,
         );
-        const result = await rewritePrompt(input, profile, resolvedEntries, config);
+        const result = await rewritePrompt(input, profile, resolvedEntries, config, signal);
         if (result.status === 'rewritten') {
           agentInput = result.text;
           debugLog('app:prompt-rewritten', {
@@ -1697,6 +1729,7 @@ export function App({
         debugLog('app:prompt-rewriter', err instanceof Error ? err.message : String(err));
       }
     }
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
 
     return { agentInput, resolvedEntries };
   }
@@ -1709,16 +1742,55 @@ export function App({
     // Clear the previous turn's stream events so the in-flight
     // <StreamingAssistantMessage> renders only this turn's deltas.
     messageStore.reset();
+    setInterrupted(false);
     setBusy(true);
+    const turnStartedAt = Date.now();
+    let turnCompleted = false;
+    const controller = new AbortController();
+    turnAbortRef.current = controller;
     try {
-      const { agentInput, resolvedEntries } = await runPreTurnPipeline(input);
-      await agent.processInput(agentInput, images, resolvedEntries);
+      const { agentInput, resolvedEntries } = await runPreTurnPipeline(input, controller.signal);
+      if (controller.signal.aborted) return;
+      // `processInput` pushes the user message to `agent.history` synchronously
+      // (before its first internal await), so by the time the returned promise
+      // hits this microtask boundary the history already contains the new
+      // entry. Bumping `historyVersion` here makes the static <Thread> re-read
+      // and show the user message above the streaming assistant block instead
+      // of after the turn finishes.
+      const inflight = agent.processInput(agentInput, images, resolvedEntries);
+      // Capture the original text (pre-rewrite) so <UserMessage> can display
+      // it instead of the rewritten version that was dispatched to the model.
+      // The push has already happened — record at the resulting last index.
+      if (input !== agentInput) {
+        const idx = agent.getHistory().length - 1;
+        rewriteOriginalsRef.current.set(idx, input);
+      }
+      setHistoryVersion((v) => v + 1);
+      await inflight;
+      turnCompleted = !controller.signal.aborted;
     } catch (err) {
-      console.error('agent error:', err);
+      // AbortError on user-cancel is expected; don't dump it to the console.
+      const isAbort =
+        err instanceof Error && (err.name === 'AbortError' || controller.signal.aborted);
+      if (!isAbort) console.error('agent error:', err);
     } finally {
       persistAgentState({ agent, historyStore, provenanceHistoryStore });
       submittingRef.current = false;
+      turnAbortRef.current = null;
       setBusy(false);
+      if (turnCompleted) {
+        const endedAt = Date.now();
+        const history = agent.getHistory();
+        for (let i = history.length - 1; i >= 0; i--) {
+          if (history[i].role === 'assistant') {
+            turnTimingsRef.current.set(i, {
+              endedAt,
+              durationMs: endedAt - turnStartedAt,
+            });
+            break;
+          }
+        }
+      }
       setHistoryVersion((v) => v + 1);
     }
   }
@@ -1888,15 +1960,6 @@ export function App({
 
   return (
     <Box flexDirection="column" paddingX={2}>
-      <Box>
-        <Text color={colors.accent} bold>
-          bernard
-        </Text>
-        <Text dimColor>
-          {' '}
-          {config.provider}/{config.model}
-        </Text>
-      </Box>
       {bannerVisible && alertBanner && (
         <Box marginTop={1} borderStyle="single" borderColor={colors.warning} paddingX={1}>
           <Text color={colors.warning}>{alertBanner}</Text>
@@ -1907,6 +1970,10 @@ export function App({
         history={agent.getHistory()}
         messageStore={messageStore}
         busy={busy}
+        interrupted={interrupted}
+        rewriteOriginals={rewriteOriginalsRef.current}
+        turnTimings={turnTimingsRef.current}
+        toolDetails={config.toolDetails}
       />
       {busy && (
         <Box marginTop={1}>
@@ -1915,8 +1982,19 @@ export function App({
       )}
       <PlanStrip agent={agent} />
       {toast && <Toast message={toast.message} variant={toast.variant} />}
-      <Prompt disabled={busy || activeOverlay !== null} onSubmit={handleSubmit} />
-      <StatusBar agent={agent} />
+      <Prompt
+        disabled={busy || activeOverlay !== null}
+        onSubmit={handleSubmit}
+        onSlashActiveChange={setSlashActive}
+      />
+      <Box justifyContent="space-between">
+        <HintBar
+          busy={busy}
+          overlayActive={activeOverlay !== null}
+          slashActive={slashActive}
+        />
+        <StatusBar agent={agent} />
+      </Box>
       {activeOverlay === 'status' && (
         <StatusViewer
           agent={agent}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -241,9 +241,7 @@ export function App({
   // duration footer under every assistant message in <Thread>. Stored as a
   // ref because re-renders are already triggered by historyVersion bumps; the
   // map is append-only across the session and cleared by /clear.
-  const turnTimingsRef = useRef<Map<number, { endedAt: number; durationMs: number }>>(
-    new Map(),
-  );
+  const turnTimingsRef = useRef<Map<number, { endedAt: number; durationMs: number }>>(new Map());
   // history-index → user's original text when the rewriter substituted it.
   // Lives outside React state because it's append-only and not React-reactive
   // (history re-renders are driven by historyVersion bumps already).
@@ -349,19 +347,21 @@ export function App({
   // Attach a persistent SpinnerStats object so the framework's token-stats
   // hook accumulates usage across turns. <StatusBar> polls this for the
   // pinned bottom-right readout. We never null it out — totals carry across
-  // the whole session and only reset on REPL restart. Seeded synchronously
-  // during the first render so the status line is visible from the first
-  // paint instead of after the next interval tick.
-  if (!agent.spinnerStats) {
-    agent.setSpinnerStats({
-      startTime: Date.now(),
-      totalPromptTokens: 0,
-      totalCompletionTokens: 0,
-      latestPromptTokens: 0,
-      model: config.model,
-      contextWindowOverride: config.tokenWindow || undefined,
-    });
-  }
+  // the whole session and only reset on REPL restart. Seeded in a mount-time
+  // effect (StrictMode-safe; render-body side effects double-fire and would
+  // re-overwrite the object on every re-render including the StatusBar tick).
+  useEffect(() => {
+    if (!agent.spinnerStats) {
+      agent.setSpinnerStats({
+        startTime: Date.now(),
+        totalPromptTokens: 0,
+        totalCompletionTokens: 0,
+        latestPromptTokens: 0,
+        model: config.model,
+        contextWindowOverride: config.tokenWindow || undefined,
+      });
+    }
+  }, [agent, config.model, config.tokenWindow]);
 
   // Phase D (#215) ink-handlers bridge. The toolOptions callbacks built in
   // `src/index.ts` read from `getInkHandlers()` at call time, so this effect
@@ -532,6 +532,8 @@ export function App({
       provenanceHistoryStore.clear();
       agent.clearHistory();
       turnTimingsRef.current.clear();
+      rewriteOriginalsRef.current.clear();
+      setInterrupted(false);
       // Wipe scrollback + visible region so the old transcript doesn't linger
       // above the cleared <Thread>. `\x1b[3J` clears scrollback, `\x1b[2J`
       // the visible region, `\x1b[H` homes the cursor. Ink repaints on the
@@ -575,6 +577,10 @@ export function App({
         if (!result.compacted) {
           flashToast('Nothing to compact — conversation is already short enough.');
         } else {
+          // History indices shift after compaction; per-index maps would now
+          // attach to the wrong messages.
+          turnTimingsRef.current.clear();
+          rewriteOriginalsRef.current.clear();
           const pct = Math.round(
             ((result.tokensBefore - result.tokensAfter) / result.tokensBefore) * 100,
           );
@@ -823,6 +829,7 @@ export function App({
           config.provider = added.entry.name;
           config.model = added.entry.defaultModel;
           config.providerBaseUrl = undefined;
+          if (agent.spinnerStats) agent.spinnerStats.model = added.entry.defaultModel;
           savePreferences({
             provider: config.provider,
             model: config.model,
@@ -840,6 +847,7 @@ export function App({
         config.provider = value;
         config.model = getDefaultModel(config.provider, customProviders);
         config.providerBaseUrl = undefined;
+        if (agent.spinnerStats) agent.spinnerStats.model = config.model;
         savePreferences({
           provider: config.provider,
           model: config.model,
@@ -884,6 +892,10 @@ export function App({
       }
       if (chosenModel) {
         config.model = chosenModel;
+        // <StatusBar> computes the compression-headroom bar against this model
+        // via getContextWindow(stats.model). Without this refresh it would
+        // keep using the previous model's window after a /model switch.
+        if (agent.spinnerStats) agent.spinnerStats.model = chosenModel;
         savePreferences({
           provider: config.provider,
           model: config.model,
@@ -1801,6 +1813,7 @@ export function App({
       flashToast(`Maximum concurrent agents (${getMaxConcurrentAgents()}) reached.`, 'error');
       return;
     }
+    setInterrupted(false);
     setBusy(true);
     const ctx = agent.getContext();
     ctx.provenance.clear();
@@ -1988,11 +2001,7 @@ export function App({
         onSlashActiveChange={setSlashActive}
       />
       <Box justifyContent="space-between">
-        <HintBar
-          busy={busy}
-          overlayActive={activeOverlay !== null}
-          slashActive={slashActive}
-        />
+        <HintBar busy={busy} overlayActive={activeOverlay !== null} slashActive={slashActive} />
         <StatusBar agent={agent} />
       </Box>
       {activeOverlay === 'status' && (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -101,6 +101,7 @@ import type {
 import { Thread } from './Thread.js';
 import { Prompt } from './Prompt.js';
 import { Spinner } from './Spinner.js';
+import { StatusBar } from './StatusBar.js';
 import { PlanStrip } from './PlanStrip.js';
 import { MenuOverlay } from './overlays/MenuOverlay.js';
 import { ConfirmDialog } from './overlays/ConfirmDialog.js';
@@ -323,6 +324,21 @@ export function App({
     setOutputSink(messageStore);
     return () => setOutputSink(null);
   }, [messageStore]);
+
+  // Attach a persistent SpinnerStats object so the framework's token-stats
+  // hook accumulates usage across turns. <StatusBar> polls this for the
+  // pinned bottom-right readout. We never null it out — totals carry across
+  // the whole session and only reset on REPL restart.
+  useEffect(() => {
+    agent.setSpinnerStats({
+      startTime: Date.now(),
+      totalPromptTokens: 0,
+      totalCompletionTokens: 0,
+      latestPromptTokens: 0,
+      model: config.model,
+      contextWindowOverride: config.tokenWindow || undefined,
+    });
+  }, [agent, config.model, config.tokenWindow]);
 
   // Phase D (#215) ink-handlers bridge. The toolOptions callbacks built in
   // `src/index.ts` read from `getInkHandlers()` at call time, so this effect
@@ -1871,7 +1887,7 @@ export function App({
   }
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" paddingX={2}>
       <Box>
         <Text color={colors.accent} bold>
           bernard
@@ -1900,6 +1916,7 @@ export function App({
       <PlanStrip agent={agent} />
       {toast && <Toast message={toast.message} variant={toast.variant} />}
       <Prompt disabled={busy || activeOverlay !== null} onSubmit={handleSubmit} />
+      <StatusBar agent={agent} />
       {activeOverlay === 'status' && (
         <StatusViewer
           agent={agent}

--- a/src/ui/HintBar.tsx
+++ b/src/ui/HintBar.tsx
@@ -1,0 +1,56 @@
+import { Box, Text } from 'ink';
+import { getThemeColors } from '../theme.js';
+
+interface HintBarProps {
+  busy: boolean;
+  overlayActive: boolean;
+  slashActive: boolean;
+}
+
+interface Hint {
+  key: string;
+  label: string;
+}
+
+/**
+ * Renders contextual keystroke hints in the bottom-left, mirroring StatusBar
+ * on the right. Picks the hint set from the most-specific state first:
+ * overlay → busy → slash autocomplete → idle. The same physical row holds
+ * both bars so the chrome stays a single line.
+ */
+export function HintBar({ busy, overlayActive, slashActive }: HintBarProps) {
+  const colors = getThemeColors();
+  const hints = pickHints({ busy, overlayActive, slashActive });
+  return (
+    <Box>
+      {hints.map((hint, idx) => (
+        <Text key={hint.key} color={colors.muted}>
+          {idx > 0 ? '  ·  ' : ''}
+          <Text color={colors.accent}>{hint.key}</Text>
+          {' '}
+          {hint.label}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function pickHints(state: HintBarProps): Hint[] {
+  if (state.overlayActive) {
+    return [{ key: 'esc', label: 'close' }];
+  }
+  if (state.busy) {
+    return [{ key: 'esc', label: 'interrupt' }];
+  }
+  if (state.slashActive) {
+    return [
+      { key: '↑↓', label: 'select' },
+      { key: 'tab', label: 'complete' },
+      { key: '↵', label: 'run' },
+    ];
+  }
+  return [
+    { key: '/', label: 'commands' },
+    { key: 'shift+tab', label: 'status' },
+  ];
+}

--- a/src/ui/HintBar.tsx
+++ b/src/ui/HintBar.tsx
@@ -26,9 +26,7 @@ export function HintBar({ busy, overlayActive, slashActive }: HintBarProps) {
       {hints.map((hint, idx) => (
         <Text key={hint.key} color={colors.muted}>
           {idx > 0 ? '  ·  ' : ''}
-          <Text color={colors.accent}>{hint.key}</Text>
-          {' '}
-          {hint.label}
+          <Text color={colors.accent}>{hint.key}</Text> {hint.label}
         </Text>
       ))}
     </Box>

--- a/src/ui/Prompt.tsx
+++ b/src/ui/Prompt.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { getThemeColors } from '../theme.js';
-import { SlashHints } from './SlashHints.js';
+import { SlashHints, matchSlashCommands } from './SlashHints.js';
 
 interface PromptProps {
   /** When true, suppress key handling — used while an overlay is open. */
@@ -16,21 +16,55 @@ interface PromptProps {
  * emits `onSubmit(text)` on Enter; an empty buffer is rejected silently to
  * match the legacy prompt's behavior.
  *
- * Disabled while an overlay is open so the overlay can capture keystrokes
- * exclusively. Phase D will extend this with paste handling and history
- * navigation when the readline path is retired.
+ * Slash-command autocomplete: when the buffer starts with `/` and has no
+ * trailing args, a hint strip renders directly below the input. Up/Down
+ * arrows move the selection; Tab completes the highlighted name into the
+ * buffer (keeps focus so the user can add args); Enter submits the
+ * highlighted command. Once the user types a space, hints clear and Enter
+ * submits the literal buffer.
  */
 export function Prompt({ disabled = false, onSubmit }: PromptProps) {
   const [buffer, setBuffer] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const colors = getThemeColors();
+
+  const matches = useMemo(() => matchSlashCommands(buffer), [buffer]);
+  // Clamp selection whenever the match list shrinks (e.g. user typed another
+  // character and fewer commands match). Avoids dangling out-of-range cursor.
+  const clampedIndex = matches.length === 0 ? 0 : Math.min(selectedIndex, matches.length - 1);
 
   useInput(
     (input, key) => {
       if (key.return) {
+        // Highlighted slash command wins over the literal buffer.
+        if (matches.length > 0) {
+          const picked = matches[clampedIndex];
+          setBuffer('');
+          setSelectedIndex(0);
+          onSubmit(picked.name);
+          return;
+        }
         const text = buffer.trim();
         if (text.length === 0) return;
         setBuffer('');
+        setSelectedIndex(0);
         onSubmit(text);
+        return;
+      }
+      if (matches.length > 0 && key.upArrow) {
+        setSelectedIndex((i) => (i <= 0 ? matches.length - 1 : i - 1));
+        return;
+      }
+      if (matches.length > 0 && key.downArrow) {
+        setSelectedIndex((i) => (i >= matches.length - 1 ? 0 : i + 1));
+        return;
+      }
+      if (matches.length > 0 && key.tab) {
+        // Autocomplete: drop the highlighted command into the buffer and add a
+        // trailing space so the user can type args without re-typing the name.
+        const picked = matches[clampedIndex];
+        setBuffer(picked.name + ' ');
+        setSelectedIndex(0);
         return;
       }
       if (key.backspace || key.delete) {
@@ -41,6 +75,7 @@ export function Prompt({ disabled = false, onSubmit }: PromptProps) {
       // Ignore arrow / function keys — `input` is empty for those.
       if (input && !key.escape && !key.tab) {
         setBuffer((b) => b + input);
+        setSelectedIndex(0);
       }
     },
     { isActive: !disabled },
@@ -48,14 +83,18 @@ export function Prompt({ disabled = false, onSubmit }: PromptProps) {
 
   return (
     <Box flexDirection="column" marginTop={1}>
-      <SlashHints buffer={buffer} />
-      <Box>
+      <Box
+        borderStyle="round"
+        borderColor={disabled ? colors.muted : colors.accent}
+        paddingX={1}
+      >
         <Text color={colors.accent} bold>
           ›{' '}
         </Text>
         <Text>{buffer}</Text>
         {!disabled && <Text color={colors.accent}>▌</Text>}
       </Box>
+      <SlashHints matches={matches} selectedIndex={clampedIndex} />
     </Box>
   );
 }

--- a/src/ui/Prompt.tsx
+++ b/src/ui/Prompt.tsx
@@ -38,6 +38,13 @@ export function Prompt({ disabled = false, onSubmit, onSlashActiveChange }: Prom
   // character and fewer commands match). Avoids dangling out-of-range cursor.
   const clampedIndex = matches.length === 0 ? 0 : Math.min(selectedIndex, matches.length - 1);
 
+  // Keep the underlying state in sync with the clamped value so arrow-key
+  // handlers don't decrement from a stale high index (e.g. 19 → 18 → 17 …)
+  // when the list shrinks from 20 to 3.
+  useEffect(() => {
+    if (selectedIndex !== clampedIndex) setSelectedIndex(clampedIndex);
+  }, [selectedIndex, clampedIndex]);
+
   const slashActive = matches.length > 0;
   useEffect(() => {
     onSlashActiveChange?.(slashActive);
@@ -93,12 +100,14 @@ export function Prompt({ disabled = false, onSubmit, onSlashActiveChange }: Prom
 
   return (
     <Box flexDirection="column" marginTop={1}>
-      <Box
-        borderStyle="round"
-        borderColor={disabled ? colors.muted : colors.accent}
-        paddingX={1}
-      >
-        <Text><Text color={colors.accent} bold>{'› '}</Text><Text>{buffer}</Text>{!disabled ? <Text color={colors.accent}>{'▌'}</Text> : null}</Text>
+      <Box borderStyle="round" borderColor={disabled ? colors.muted : colors.accent} paddingX={1}>
+        <Text>
+          <Text color={colors.accent} bold>
+            {'› '}
+          </Text>
+          <Text>{buffer}</Text>
+          {!disabled ? <Text color={colors.accent}>{'▌'}</Text> : null}
+        </Text>
       </Box>
       <SlashHints matches={matches} selectedIndex={clampedIndex} />
     </Box>

--- a/src/ui/Prompt.tsx
+++ b/src/ui/Prompt.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { getThemeColors } from '../theme.js';
 import { SlashHints, matchSlashCommands } from './SlashHints.js';
@@ -8,6 +8,11 @@ interface PromptProps {
   disabled?: boolean;
   /** Called on Enter with the current buffer (trimmed of trailing newline). */
   onSubmit: (text: string) => void;
+  /**
+   * Fired whenever the slash-hint strip toggles. Lets the parent show the
+   * contextual hint bar without lifting the whole input buffer out of Prompt.
+   */
+  onSlashActiveChange?: (active: boolean) => void;
 }
 
 /**
@@ -23,7 +28,7 @@ interface PromptProps {
  * highlighted command. Once the user types a space, hints clear and Enter
  * submits the literal buffer.
  */
-export function Prompt({ disabled = false, onSubmit }: PromptProps) {
+export function Prompt({ disabled = false, onSubmit, onSlashActiveChange }: PromptProps) {
   const [buffer, setBuffer] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const colors = getThemeColors();
@@ -32,6 +37,11 @@ export function Prompt({ disabled = false, onSubmit }: PromptProps) {
   // Clamp selection whenever the match list shrinks (e.g. user typed another
   // character and fewer commands match). Avoids dangling out-of-range cursor.
   const clampedIndex = matches.length === 0 ? 0 : Math.min(selectedIndex, matches.length - 1);
+
+  const slashActive = matches.length > 0;
+  useEffect(() => {
+    onSlashActiveChange?.(slashActive);
+  }, [slashActive, onSlashActiveChange]);
 
   useInput(
     (input, key) => {
@@ -88,11 +98,7 @@ export function Prompt({ disabled = false, onSubmit }: PromptProps) {
         borderColor={disabled ? colors.muted : colors.accent}
         paddingX={1}
       >
-        <Text color={colors.accent} bold>
-          ›{' '}
-        </Text>
-        <Text>{buffer}</Text>
-        {!disabled && <Text color={colors.accent}>▌</Text>}
+        <Text><Text color={colors.accent} bold>{'› '}</Text><Text>{buffer}</Text>{!disabled ? <Text color={colors.accent}>{'▌'}</Text> : null}</Text>
       </Box>
       <SlashHints matches={matches} selectedIndex={clampedIndex} />
     </Box>

--- a/src/ui/SlashHints.tsx
+++ b/src/ui/SlashHints.tsx
@@ -7,46 +7,81 @@ export interface SlashCommand {
 }
 
 /**
- * The static set of slash commands the Ink shell wires through in Phase B.
- *
- * Only commands `<App>.handleSubmit` actually handles are listed here so a
- * suggestion can't fall through to `agent.processInput` and get sent to the
- * model as prose. Phase D ports the remaining commands from `src/repl.ts`
- * (`/profiles`, `/agent-options`, `/manage-profiles`, `/cron`, `/image`,
- * `/run-routine`, etc.) when the bespoke layer is deleted and adds their
- * entries here.
+ * Canonical slash-command catalogue surfaced to the autocomplete hint strip.
+ * Mirrors the rows rendered by `<HelpOverlay>` and every branch handled by
+ * `<App>.handleSubmit` — keep these in sync when adding a command. Items the
+ * user can't dispatch directly from the prompt (e.g. variants with required
+ * args) belong in the help screen, not here.
  */
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
-  { name: '/exit', description: 'Exit Bernard' },
-  { name: '/clear', description: 'Clear conversation history' },
+  { name: '/help', description: 'Show command list' },
+  { name: '/clear', description: 'Clear conversation (--save / -s to summarize first)' },
+  { name: '/compact', description: 'Compress conversation history in-place' },
+  { name: '/task', description: 'Run an isolated task (no history, structured output)' },
+  { name: '/image', description: 'Attach an image: /image <path> [prompt]' },
+  { name: '/memory', description: 'List persistent memories' },
+  { name: '/scratch', description: 'List session scratch notes' },
+  { name: '/mcp', description: 'List MCP servers and tools' },
+  { name: '/cron', description: 'Show cron jobs and daemon status' },
+  { name: '/rag', description: 'Toggle / inspect the RAG store' },
+  { name: '/facts', description: 'Show RAG facts in the current context window' },
+  { name: '/policy', description: 'Show last policy decision' },
+  { name: '/provider', description: 'Switch LLM provider' },
+  { name: '/model', description: 'Switch model for current provider' },
+  { name: '/theme', description: 'Switch color theme' },
+  { name: '/routines', description: 'List saved routines' },
+  { name: '/create-routine', description: 'Create a routine with guided AI assistance' },
+  { name: '/create-task', description: 'Create a task routine with guided AI assistance' },
+  { name: '/specialists', description: 'List specialist agents' },
+  { name: '/create-specialist', description: 'Create a specialist with guided AI assistance' },
+  { name: '/candidates', description: 'Review specialist suggestions' },
+  { name: '/options', description: 'View and set options (max-tokens, max-steps, …)' },
+  { name: '/agent-options', description: 'Configure agent behavior (toggles, thresholds)' },
+  { name: '/profiles', description: 'Switch / create settings profiles' },
+  { name: '/manage-profiles', description: 'Rename or delete saved profiles' },
+  { name: '/update', description: 'Check for and install updates' },
+  { name: '/exit', description: 'Quit Bernard' },
 ];
 
+/** Returns the subset of commands whose name prefix-matches the buffer. */
+export function matchSlashCommands(buffer: string): SlashCommand[] {
+  if (!buffer.startsWith('/')) return [];
+  // Hide hints once the user has started typing args (a space terminates the
+  // command token); they're past the picker at that point.
+  if (buffer.includes(' ')) return [];
+  const query = buffer.slice(1).toLowerCase();
+  return SLASH_COMMANDS.filter((c) => c.name.slice(1).toLowerCase().startsWith(query));
+}
+
 interface SlashHintsProps {
-  /** Current input buffer; hints render only when this starts with `/`. */
-  buffer: string;
+  /** Filtered match list, computed by the caller so navigation state agrees. */
+  matches: readonly SlashCommand[];
+  /** Currently-highlighted index. Out-of-range values render nothing highlighted. */
+  selectedIndex: number;
 }
 
 /**
- * Renders a small list of slash-command suggestions filtered by the current
- * input buffer. Mounted as a child of `<Prompt>` so it sits directly above
- * the input line — same UX as the legacy `redrawWithHints` path it replaces.
+ * Hint strip rendered under `<Prompt>`. The caller owns the filtered match
+ * list and the selection cursor so up/down navigation in the prompt stays in
+ * sync with what's displayed here.
  */
-export function SlashHints({ buffer }: SlashHintsProps) {
+export function SlashHints({ matches, selectedIndex }: SlashHintsProps) {
   const colors = getThemeColors();
-  if (!buffer.startsWith('/')) return null;
-  const query = buffer.slice(1).toLowerCase();
-  const matches = SLASH_COMMANDS.filter((c) => c.name.slice(1).toLowerCase().startsWith(query));
   if (matches.length === 0) return null;
   return (
     <Box flexDirection="column" marginLeft={2}>
-      {matches.map((cmd) => (
-        <Box key={cmd.name}>
-          <Text color={colors.accent} bold>
-            {cmd.name}
-          </Text>
-          <Text dimColor> — {cmd.description}</Text>
-        </Box>
-      ))}
+      {matches.map((cmd, idx) => {
+        const selected = idx === selectedIndex;
+        return (
+          <Box key={cmd.name}>
+            <Text color={selected ? colors.accent : undefined} bold={selected}>
+              {selected ? '› ' : '  '}
+              {cmd.name}
+            </Text>
+            <Text dimColor> — {cmd.description}</Text>
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { getThemeColors } from '../theme.js';
+import { buildStatusLine, type SpinnerStats } from '../output.js';
+import type { Agent } from '../agent.js';
+
+interface StatusBarProps {
+  agent: Agent;
+}
+
+/**
+ * Pinned bottom-right token / context-window readout. Polls `agent.spinnerStats`
+ * every 500 ms — cheap, and only mutated by the token-stats hook on step
+ * boundaries, so a poll-based refresh is fine (no subscription seam needed).
+ * Renders nothing until the agent has accumulated at least one step's usage.
+ */
+export function StatusBar({ agent }: StatusBarProps) {
+  const colors = getThemeColors();
+  const [, force] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => force((n) => n + 1), 500);
+    return () => clearInterval(id);
+  }, []);
+
+  const stats: SpinnerStats | null = agent.spinnerStats;
+  if (!stats || (stats.totalPromptTokens === 0 && stats.totalCompletionTokens === 0)) {
+    return null;
+  }
+  return (
+    <Box justifyContent="flex-end">
+      <Text color={colors.muted}>{buildStatusLine(stats)}</Text>
+    </Box>
+  );
+}

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,18 +1,23 @@
 import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { getThemeColors } from '../theme.js';
-import { buildStatusLine, type SpinnerStats } from '../output.js';
+import { formatTokenCount, type SpinnerStats } from '../output.js';
+import { getContextWindow, COMPRESSION_THRESHOLD } from '../context.js';
 import type { Agent } from '../agent.js';
 
 interface StatusBarProps {
   agent: Agent;
 }
 
+const BAR_WIDTH = 10;
+
 /**
  * Pinned bottom-right token / context-window readout. Polls `agent.spinnerStats`
  * every 500 ms — cheap, and only mutated by the token-stats hook on step
  * boundaries, so a poll-based refresh is fine (no subscription seam needed).
- * Renders nothing until the agent has accumulated at least one step's usage.
+ * The compression-headroom indicator is a `[████░░░░░░]` bar that gets louder
+ * as it fills: muted while there's >25% headroom, warning between 5%–25%, and
+ * the theme's accent color once <5% of the compression budget is left.
  */
 export function StatusBar({ agent }: StatusBarProps) {
   const colors = getThemeColors();
@@ -23,12 +28,32 @@ export function StatusBar({ agent }: StatusBarProps) {
   }, []);
 
   const stats: SpinnerStats | null = agent.spinnerStats;
-  if (!stats || (stats.totalPromptTokens === 0 && stats.totalCompletionTokens === 0)) {
-    return null;
-  }
+  if (!stats) return null;
+
+  const up = formatTokenCount(stats.totalPromptTokens);
+  const down = formatTokenCount(stats.totalCompletionTokens);
+  const contextWindow = getContextWindow(stats.model, stats.contextWindowOverride);
+  const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
+  const usedFrac = Math.min(1, Math.max(0, stats.latestPromptTokens / thresholdTokens));
+  const freePct = (1 - usedFrac) * 100;
+
+  const filledCount = Math.round(usedFrac * BAR_WIDTH);
+  const emptyCount = BAR_WIDTH - filledCount;
+
+  // Three-stop color ramp keyed to remaining compression headroom. The filled
+  // dots get progressively louder as the model's input window approaches the
+  // compression cliff; the empty trailing dots stay muted so the active
+  // portion pops.
+  const fillColor =
+    freePct > 25 ? colors.muted : freePct > 5 ? colors.warning : colors.accent;
+
   return (
     <Box justifyContent="flex-end">
-      <Text color={colors.muted}>{buildStatusLine(stats)}</Text>
+      <Text color={colors.muted}>
+        {up}↑ {down}↓{'   '}
+      </Text>
+      {filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}
+      {emptyCount > 0 && <Text color={colors.muted} dimColor>{'○'.repeat(emptyCount)}</Text>}
     </Box>
   );
 }

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -44,8 +44,7 @@ export function StatusBar({ agent }: StatusBarProps) {
   // dots get progressively louder as the model's input window approaches the
   // compression cliff; the empty trailing dots stay muted so the active
   // portion pops.
-  const fillColor =
-    freePct > 25 ? colors.muted : freePct > 5 ? colors.warning : colors.accent;
+  const fillColor = freePct > 25 ? colors.muted : freePct > 5 ? colors.warning : colors.accent;
 
   return (
     <Box justifyContent="flex-end">
@@ -53,7 +52,11 @@ export function StatusBar({ agent }: StatusBarProps) {
         {up}↑ {down}↓{'   '}
       </Text>
       {filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}
-      {emptyCount > 0 && <Text color={colors.muted} dimColor>{'○'.repeat(emptyCount)}</Text>}
+      {emptyCount > 0 && (
+        <Text color={colors.muted} dimColor>
+          {'○'.repeat(emptyCount)}
+        </Text>
+      )}
     </Box>
   );
 }

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -27,7 +27,33 @@ interface ThreadProps {
    */
   messageStore?: MessageStore;
   busy?: boolean;
+  /** Rendered as a dim notice below the transcript when the last turn was Esc-cancelled. */
+  interrupted?: boolean;
+  /**
+   * Per-history-index map of the user's original text when the rewriter
+   * replaced it before dispatch. `UserMessage` reads this to show the original
+   * (not the rewritten) text and tag it with the rewrite icon next to the
+   * timestamp. Same icon is used in `/agent-options` so the meaning is shared.
+   */
+  rewriteOriginals?: ReadonlyMap<number, string>;
+  /**
+   * Per-history-index timestamp + duration of completed turns. Rendered as a
+   * dim footer (`hh:mm · 1.2s`) under every assistant message that has an
+   * entry — mirrors the timestamp `<UserMessage>` shows under the outbound
+   * message. Owned by `<App>` so the footer persists across follow-up turns.
+   */
+  turnTimings?: ReadonlyMap<number, { endedAt: number; durationMs: number }>;
+  /**
+   * Whether to show full tool-call arguments and result bodies in the
+   * transcript. Tool names are always shown; only the args summary next to
+   * the name and the `↳ …` result row are suppressed when this is false.
+   * Mirrors the `Tool details` setting in `/agent-options`.
+   */
+  toolDetails?: boolean;
 }
+
+/** Icon used wherever the prompt-rewriter feature surfaces in the UI. */
+export const REWRITE_ICON = '✎';
 
 /**
  * Renders the conversation as a flowing list of message blocks. Reads the
@@ -38,13 +64,37 @@ interface ThreadProps {
  * from an in-memory message store so the in-flight assistant message updates
  * token-by-token. Phase B renders the message in bulk at turn end.
  */
-export function Thread({ history, messageStore, busy }: ThreadProps) {
+export function Thread({
+  history,
+  messageStore,
+  busy,
+  interrupted,
+  rewriteOriginals,
+  turnTimings,
+  toolDetails = false,
+}: ThreadProps) {
+  const colors = getThemeColors();
   return (
     <Box flexDirection="column">
       {history.map((msg, idx) => (
-        <MessageBlock key={idx} message={msg} />
+        <MessageBlock
+          key={idx}
+          message={msg}
+          rewriteOriginal={rewriteOriginals?.get(idx)}
+          timing={turnTimings?.get(idx)}
+          toolDetails={toolDetails}
+        />
       ))}
-      {busy && messageStore && <StreamingAssistantMessage store={messageStore} />}
+      {busy && messageStore && (
+        <StreamingAssistantMessage store={messageStore} toolDetails={toolDetails} />
+      )}
+      {!busy && interrupted && (
+        <Box marginTop={1}>
+          <Text color={colors.muted} italic>
+            ⏹ you interrupted
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -56,21 +106,47 @@ export function Thread({ history, messageStore, busy }: ThreadProps) {
  * by then the AI SDK history has the finished message and the static
  * `<AssistantMessage>` takes over rendering it.
  */
-export function StreamingAssistantMessage({ store }: { store: MessageStore }) {
+export function StreamingAssistantMessage({
+  store,
+  toolDetails = false,
+}: {
+  store: MessageStore;
+  toolDetails?: boolean;
+}) {
   const colors = getThemeColors();
   const events = useSyncExternalStore(store.subscribe, store.getSnapshot);
   if (events.length === 0) return null;
   const groups = groupByLabel(events);
   return (
     <Box flexDirection="column" marginTop={1}>
-      {groups.map((group, idx) => (
-        <Box key={idx} flexDirection="column">
-          <Text color={colors.accent} bold>
-            {group.label ?? 'bernard'}
-          </Text>
-          <StreamGroupBody events={group.events} />
-        </Box>
-      ))}
+      {groups.map((group, idx) => {
+        // Sub-agent groups (label set) keep the labeled header above the
+        // body. Main-agent groups (no label) inline the chevron with the
+        // first line of body content, mirroring the static AssistantMessage.
+        if (group.label !== undefined) {
+          // Sub-agent / wrapper output never appears in the static post-turn
+          // <Thread> (only main-agent assistant messages do). Mirror that
+          // when tool details are off so streaming doesn't briefly leak
+          // wrapper JSON / sub-agent text that vanishes once the turn ends.
+          if (!toolDetails) return null;
+          return (
+            <Box key={idx} flexDirection="column">
+              <Text color={colors.accent} bold>
+                {group.label}
+              </Text>
+              <StreamGroupBody events={group.events} toolDetails={toolDetails} />
+            </Box>
+          );
+        }
+        return (
+          <StreamGroupBody
+            key={idx}
+            events={group.events}
+            toolDetails={toolDetails}
+            inlineChevron
+          />
+        );
+      })}
     </Box>
   );
 }
@@ -101,8 +177,23 @@ function groupByLabel(events: readonly StreamEvent[]): EventGroup[] {
   return out;
 }
 
-function StreamGroupBody({ events }: { events: StreamEvent[] }) {
+function StreamGroupBody({
+  events,
+  toolDetails,
+  inlineChevron = false,
+}: {
+  events: StreamEvent[];
+  toolDetails: boolean;
+  /** When true, prepend `<❮ >` inline with the first emitted element. */
+  inlineChevron?: boolean;
+}) {
   const colors = getThemeColors();
+  const chevron = (
+    <Text color={colors.accent} bold>
+      {'❮  '}
+    </Text>
+  );
+  let chevronPending = inlineChevron;
   // Concatenate text-deltas into a single rolling string so we don't render
   // one <Text> per token (which Ink would lay out as separate lines).
   const elements: ReactNode[] = [];
@@ -110,7 +201,17 @@ function StreamGroupBody({ events }: { events: StreamEvent[] }) {
   let textKey = 0;
   const flushText = () => {
     if (textBuffer.length === 0) return;
-    elements.push(<Text key={`t-${textKey++}`}>{textBuffer}</Text>);
+    if (chevronPending) {
+      elements.push(
+        <Box key={`t-${textKey++}`}>
+          {chevron}
+          <Text>{textBuffer}</Text>
+        </Box>,
+      );
+      chevronPending = false;
+    } else {
+      elements.push(<Text key={`t-${textKey++}`}>{textBuffer}</Text>);
+    }
     textBuffer = '';
   };
   // Pair tool-calls with their results by callId so the result renders
@@ -135,31 +236,38 @@ function StreamGroupBody({ events }: { events: StreamEvent[] }) {
         const thought = extractThought(ev.args);
         if (thought) {
           elements.push(
-            <Text key={`c-${ev.callId}`} dimColor italic>
-              💭 {thought}
-            </Text>,
+            <Box key={`c-${ev.callId}`}>
+              {chevronPending && chevron}
+              <Text dimColor italic>
+                💭 {thought}
+              </Text>
+            </Box>,
           );
+          chevronPending = false;
         }
         continue;
       }
-      const argsSummary = summariseArgs(ev.args);
+      const argsSummary = toolDetails ? summariseArgs(ev.args) : '';
+      const headPrefix = chevronPending ? chevron : null;
       elements.push(
         <Box key={`c-${ev.callId}`} flexDirection="column">
           <Box>
+            {headPrefix}
             <Text color={colors.toolCall}>⚙ {ev.toolName}</Text>
             {argsSummary && <Text dimColor> {argsSummary}</Text>}
           </Box>
-          {resultsByCall.has(ev.callId) && (
+          {toolDetails && resultsByCall.has(ev.callId) && (
             <StreamingToolResult result={resultsByCall.get(ev.callId)!} />
           )}
         </Box>,
       );
+      chevronPending = false;
       continue;
     }
     // tool-result handled inline above; skip if it has a matching call.
     // If a result arrived without its call (shouldn't happen, but defensive),
     // render it as a standalone row so the user still sees it.
-    if (!callsById.has(ev.callId)) {
+    if (toolDetails && !callsById.has(ev.callId)) {
       flushText();
       elements.push(
         <Box key={`r-${ev.callId}`} marginLeft={2}>
@@ -171,6 +279,12 @@ function StreamGroupBody({ events }: { events: StreamEvent[] }) {
     }
   }
   flushText();
+  // Group produced no renderable content (e.g. only suppressed think events)
+  // but a chevron was promised — emit it on its own line so the assistant
+  // turn still shows up.
+  if (chevronPending) {
+    elements.push(<Box key="chev-only">{chevron}</Box>);
+  }
   return <>{elements}</>;
 }
 
@@ -189,68 +303,183 @@ function StreamingToolResult({
   );
 }
 
-function MessageBlock({ message }: { message: CoreMessage }) {
-  if (message.role === 'user') return <UserMessage message={message as CoreUserMessage} />;
+function MessageBlock({
+  message,
+  rewriteOriginal,
+  timing,
+  toolDetails,
+}: {
+  message: CoreMessage;
+  rewriteOriginal?: string;
+  timing?: { endedAt: number; durationMs: number };
+  toolDetails: boolean;
+}) {
+  if (message.role === 'user')
+    return (
+      <UserMessage message={message as CoreUserMessage} rewriteOriginal={rewriteOriginal} />
+    );
   if (message.role === 'assistant')
-    return <AssistantMessage message={message as CoreAssistantMessage} />;
-  if (message.role === 'tool') return <ToolResultMessage message={message as CoreToolMessage} />;
+    return (
+      <AssistantMessage
+        message={message as CoreAssistantMessage}
+        timing={timing}
+        toolDetails={toolDetails}
+      />
+    );
+  if (message.role === 'tool')
+    return toolDetails ? <ToolResultMessage message={message as CoreToolMessage} /> : null;
   // System messages are agent-internal; don't render in the thread.
   return null;
 }
 
-function UserMessage({ message }: { message: CoreUserMessage }) {
+function UserMessage({
+  message,
+  rewriteOriginal,
+}: {
+  message: CoreUserMessage;
+  rewriteOriginal?: string;
+}) {
   const colors = getThemeColors();
   const raw = extractUserText(message);
   const { body, timestamp } = parseUserMessage(raw);
+  // When the prompt-rewriter replaced the user's text before dispatch we want
+  // to surface the original to the user (the rewrite is an LLM-only detail).
+  // `rewriteOriginal` is plain text — strip the timestamp wrapper from `body`
+  // by replacing the body, leaving the parsed timestamp untouched.
+  const display = rewriteOriginal ?? body;
   return (
     <Box flexDirection="column" marginTop={1} alignItems="flex-end">
-      <Text color={colors.accent} bold>
-        you
-      </Text>
-      <Text>{body}</Text>
-      {timestamp && <Text dimColor>{formatFriendlyTimestamp(timestamp)}</Text>}
+      <Box>
+        <Text>{display}</Text>
+        <Text color={colors.accent} bold>
+          {' ❯'}
+        </Text>
+      </Box>
+      <Box>
+        {rewriteOriginal !== undefined && (
+          <Text dimColor>{REWRITE_ICON} </Text>
+        )}
+        {timestamp && <Text dimColor>{formatFriendlyTimestamp(timestamp)}</Text>}
+      </Box>
     </Box>
   );
 }
 
-function AssistantMessage({ message }: { message: CoreAssistantMessage }) {
+function AssistantMessage({
+  message,
+  timing,
+  toolDetails,
+}: {
+  message: CoreAssistantMessage;
+  timing?: { endedAt: number; durationMs: number };
+  toolDetails: boolean;
+}) {
   const colors = getThemeColors();
   const parts = normalizeAssistantContent(message.content);
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      <Text color={colors.accent} bold>
-        bernard
-      </Text>
-      {parts.map((part, idx) => {
-        if (part.type === 'text') return <Text key={idx}>{part.text}</Text>;
-        if (part.type === 'reasoning')
-          return (
-            <Text key={idx} dimColor italic>
+  const chevron = (
+    <Text color={colors.accent} bold>
+      {'❮  '}
+    </Text>
+  );
+  // The chevron mirrors the user's right-aligned `❯` and rides the first
+  // line of content. Walk parts in order and prepend it to the first
+  // renderable part; remaining parts render unchanged.
+  let chevronUsed = false;
+  const rendered: ReactNode[] = [];
+  for (let idx = 0; idx < parts.length; idx++) {
+    const part = parts[idx];
+    if (part.type === 'text') {
+      rendered.push(
+        chevronUsed ? (
+          <Text key={idx}>{part.text}</Text>
+        ) : (
+          <Box key={idx}>
+            {chevron}
+            <Text>{part.text}</Text>
+          </Box>
+        ),
+      );
+      chevronUsed = true;
+      continue;
+    }
+    if (part.type === 'reasoning') {
+      rendered.push(
+        chevronUsed ? (
+          <Text key={idx} dimColor italic>
+            {part.text}
+          </Text>
+        ) : (
+          <Box key={idx}>
+            {chevron}
+            <Text dimColor italic>
               {part.text}
             </Text>
-          );
-        if (part.type === 'tool-call') return <ToolCallBlock key={idx} part={part} />;
-        // 'redacted-reasoning' / unknown parts: skip silently.
-        return null;
-      })}
+          </Box>
+        ),
+      );
+      chevronUsed = true;
+      continue;
+    }
+    if (part.type === 'tool-call') {
+      // `think` with empty thought renders nothing — don't consume the
+      // chevron slot in that case.
+      if (part.toolName === 'think' && !extractThought(part.args)) continue;
+      rendered.push(
+        <ToolCallBlock
+          key={idx}
+          part={part}
+          toolDetails={toolDetails}
+          prefix={chevronUsed ? undefined : chevron}
+        />,
+      );
+      chevronUsed = true;
+      continue;
+    }
+    // 'redacted-reasoning' / unknown parts: skip silently.
+  }
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      {!chevronUsed && chevron}
+      {rendered}
+      {timing && (
+        <Box justifyContent="flex-end">
+          <Text dimColor>
+            {formatDuration(timing.durationMs)} ·{' '}
+            {formatFriendlyTimestamp(new Date(timing.endedAt))}
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }
 
-function ToolCallBlock({ part }: { part: ToolCallPart }) {
+function ToolCallBlock({
+  part,
+  toolDetails,
+  prefix,
+}: {
+  part: ToolCallPart;
+  toolDetails: boolean;
+  /** Optional inline node rendered before the `⚙ name` text (the chevron). */
+  prefix?: ReactNode;
+}) {
   const colors = getThemeColors();
   if (part.toolName === 'think') {
     const thought = extractThought(part.args);
     if (!thought) return null;
     return (
-      <Text dimColor italic>
-        💭 {thought}
-      </Text>
+      <Box>
+        {prefix}
+        <Text dimColor italic>
+          💭 {thought}
+        </Text>
+      </Box>
     );
   }
-  const argSummary = summariseArgs(part.args);
+  const argSummary = toolDetails ? summariseArgs(part.args) : '';
   return (
     <Box>
+      {prefix}
       <Text color={colors.toolCall}>⚙ {part.toolName}</Text>
       {argSummary && <Text dimColor> {argSummary}</Text>}
     </Box>
@@ -302,6 +531,21 @@ function parseUserMessage(raw: string): { body: string; timestamp: Date | null }
     };
   }
   return { body: text, timestamp: null };
+}
+
+/**
+ * Human-friendly elapsed time: `420ms`, `1.2s`, `47s`, `2m 3s`. Mirrors what
+ * a developer would scan for in the corner of a chat client — exact under a
+ * second, one decimal under ten, whole seconds up to a minute, then `m s`.
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 10) return `${seconds.toFixed(1)}s`;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds - m * 60);
+  return `${m}m ${s}s`;
 }
 
 function formatFriendlyTimestamp(date: Date): string {

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -131,6 +131,17 @@ function StreamGroupBody({ events }: { events: StreamEvent[] }) {
     }
     if (ev.kind === 'tool-call') {
       flushText();
+      if (ev.toolName === 'think') {
+        const thought = extractThought(ev.args);
+        if (thought) {
+          elements.push(
+            <Text key={`c-${ev.callId}`} dimColor italic>
+              💭 {thought}
+            </Text>,
+          );
+        }
+        continue;
+      }
       const argsSummary = summariseArgs(ev.args);
       elements.push(
         <Box key={`c-${ev.callId}`} flexDirection="column">
@@ -189,13 +200,15 @@ function MessageBlock({ message }: { message: CoreMessage }) {
 
 function UserMessage({ message }: { message: CoreUserMessage }) {
   const colors = getThemeColors();
-  const text = extractUserText(message);
+  const raw = extractUserText(message);
+  const { body, timestamp } = parseUserMessage(raw);
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={1} alignItems="flex-end">
       <Text color={colors.accent} bold>
         you
       </Text>
-      <Text>{text}</Text>
+      <Text>{body}</Text>
+      {timestamp && <Text dimColor>{formatFriendlyTimestamp(timestamp)}</Text>}
     </Box>
   );
 }
@@ -226,6 +239,15 @@ function AssistantMessage({ message }: { message: CoreAssistantMessage }) {
 
 function ToolCallBlock({ part }: { part: ToolCallPart }) {
   const colors = getThemeColors();
+  if (part.toolName === 'think') {
+    const thought = extractThought(part.args);
+    if (!thought) return null;
+    return (
+      <Text dimColor italic>
+        💭 {thought}
+      </Text>
+    );
+  }
   const argSummary = summariseArgs(part.args);
   return (
     <Box>
@@ -238,9 +260,11 @@ function ToolCallBlock({ part }: { part: ToolCallPart }) {
 function ToolResultMessage({ message }: { message: CoreToolMessage }) {
   const colors = getThemeColors();
   const parts = Array.isArray(message.content) ? message.content : [];
+  const visible = parts.filter((p: ToolResultPart) => p.toolName !== 'think');
+  if (visible.length === 0) return null;
   return (
     <Box flexDirection="column" marginLeft={2}>
-      {parts.map((part: ToolResultPart, idx) => {
+      {visible.map((part: ToolResultPart, idx) => {
         const snippet = renderResultSnippet(part.result);
         const isError = part.isError === true;
         return (
@@ -253,6 +277,49 @@ function ToolResultMessage({ message }: { message: CoreToolMessage }) {
       })}
     </Box>
   );
+}
+
+/**
+ * Strips the model-facing wrapper (`# Request` heading or `<user_request>`
+ * tags) and the leading `[ISO-timestamp]` injected by `timestampUserMessage`,
+ * returning the human-readable body plus the timestamp (if present) for
+ * separate rendering.
+ */
+function parseUserMessage(raw: string): { body: string; timestamp: Date | null } {
+  let text = raw;
+  if (text.startsWith('# Request\n')) {
+    text = text.slice('# Request\n'.length);
+  } else if (text.startsWith('<user_request>\n')) {
+    text = text.slice('<user_request>\n'.length);
+    if (text.endsWith('\n</user_request>')) text = text.slice(0, -'\n</user_request>'.length);
+  }
+  const m = text.match(/^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2})\] /);
+  if (m) {
+    const parsed = new Date(m[1]);
+    return {
+      body: text.slice(m[0].length),
+      timestamp: isNaN(parsed.getTime()) ? null : parsed,
+    };
+  }
+  return { body: text, timestamp: null };
+}
+
+function formatFriendlyTimestamp(date: Date): string {
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  const time = date.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  if (sameDay) return time;
+  const day = date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  return `${day} · ${time}`;
 }
 
 function extractUserText(message: CoreUserMessage): string {
@@ -270,6 +337,14 @@ type AssistantPart = TextPart | ToolCallPart | ReasoningPart | RedactedReasoning
 function normalizeAssistantContent(content: CoreAssistantMessage['content']): AssistantPart[] {
   if (typeof content === 'string') return [{ type: 'text', text: content }];
   return content as AssistantPart[];
+}
+
+function extractThought(args: unknown): string {
+  if (args && typeof args === 'object' && 'thought' in args) {
+    const t = (args as { thought: unknown }).thought;
+    if (typeof t === 'string') return t;
+  }
+  return '';
 }
 
 function summariseArgs(args: unknown): string {

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -315,9 +315,7 @@ function MessageBlock({
   toolDetails: boolean;
 }) {
   if (message.role === 'user')
-    return (
-      <UserMessage message={message as CoreUserMessage} rewriteOriginal={rewriteOriginal} />
-    );
+    return <UserMessage message={message as CoreUserMessage} rewriteOriginal={rewriteOriginal} />;
   if (message.role === 'assistant')
     return (
       <AssistantMessage
@@ -356,9 +354,7 @@ function UserMessage({
         </Text>
       </Box>
       <Box>
-        {rewriteOriginal !== undefined && (
-          <Text dimColor>{REWRITE_ICON} </Text>
-        )}
+        {rewriteOriginal !== undefined && <Text dimColor>{REWRITE_ICON} </Text>}
         {timestamp && <Text dimColor>{formatFriendlyTimestamp(timestamp)}</Text>}
       </Box>
     </Box>
@@ -542,9 +538,12 @@ function formatDuration(ms: number): string {
   if (ms < 1000) return `${Math.round(ms)}ms`;
   const seconds = ms / 1000;
   if (seconds < 10) return `${seconds.toFixed(1)}s`;
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  const m = Math.floor(seconds / 60);
-  const s = Math.round(seconds - m * 60);
+  // Round once, then carry over to minutes so we can't emit "60s" or
+  // "1m 60s" when the float happens to round up at the boundary.
+  const wholeSeconds = Math.round(seconds);
+  if (wholeSeconds < 60) return `${wholeSeconds}s`;
+  const m = Math.floor(wholeSeconds / 60);
+  const s = wholeSeconds - m * 60;
   return `${m}m ${s}s`;
 }
 

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -135,6 +135,8 @@ function makeAgent(spy: Partial<AgentSpy> = {}): Agent {
     getLastVerification: () => null,
     abort: () => {},
     setAlertContext: () => {},
+    setSpinnerStats: () => {},
+    spinnerStats: null,
   } as unknown as Agent;
 }
 

--- a/src/ui/__tests__/Prompt.test.tsx
+++ b/src/ui/__tests__/Prompt.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
 import { Prompt } from '../Prompt.js';
-import { ENTER, BACKSPACE, tick } from './_keys.js';
+import { ENTER, BACKSPACE, ARROW_DOWN, tick } from './_keys.js';
+
+const TAB = '\t';
 
 describe('<Prompt>', () => {
   it('echoes typed characters into the buffer', async () => {
@@ -64,5 +66,42 @@ describe('<Prompt>', () => {
     stdin.write('/ex');
     await tick();
     expect(lastFrame()).toContain('/exit');
+  });
+
+  it('Enter picks the highlighted slash command instead of the literal buffer', async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(createElement(Prompt, { onSubmit }));
+    await tick();
+    stdin.write('/ex');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onSubmit).toHaveBeenCalledWith('/exit');
+  });
+
+  it('Down arrow moves the slash-command selection', async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(createElement(Prompt, { onSubmit }));
+    await tick();
+    stdin.write('/');
+    await tick();
+    stdin.write(ARROW_DOWN);
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    // First match is /help; one ArrowDown lands on /clear.
+    expect(onSubmit).toHaveBeenCalledWith('/clear');
+  });
+
+  it('Tab autocompletes the highlighted command into the buffer', async () => {
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = render(createElement(Prompt, { onSubmit }));
+    await tick();
+    stdin.write('/ta');
+    await tick();
+    stdin.write(TAB);
+    await tick();
+    expect(lastFrame()).toContain('/task ');
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/__tests__/SlashHints.test.tsx
+++ b/src/ui/__tests__/SlashHints.test.tsx
@@ -28,17 +28,13 @@ describe('matchSlashCommands', () => {
 
 describe('<SlashHints>', () => {
   it('renders nothing when matches is empty', () => {
-    const { lastFrame } = render(
-      createElement(SlashHints, { matches: [], selectedIndex: 0 }),
-    );
+    const { lastFrame } = render(createElement(SlashHints, { matches: [], selectedIndex: 0 }));
     expect(lastFrame()).toBe('');
   });
 
   it('renders the supplied matches with the selected row highlighted', () => {
     const matches = matchSlashCommands('/c');
-    const { lastFrame } = render(
-      createElement(SlashHints, { matches, selectedIndex: 0 }),
-    );
+    const { lastFrame } = render(createElement(SlashHints, { matches, selectedIndex: 0 }));
     const frame = lastFrame() ?? '';
     for (const cmd of matches) expect(frame).toContain(cmd.name);
     // The selection marker prefixes only the highlighted row.

--- a/src/ui/__tests__/SlashHints.test.tsx
+++ b/src/ui/__tests__/SlashHints.test.tsx
@@ -1,36 +1,47 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
-import { SlashHints, SLASH_COMMANDS } from '../SlashHints.js';
+import { SlashHints, SLASH_COMMANDS, matchSlashCommands } from '../SlashHints.js';
 
-describe('<SlashHints>', () => {
-  it('renders nothing when buffer does not start with /', () => {
-    const { lastFrame } = render(createElement(SlashHints, { buffer: 'hello' }));
-    expect(lastFrame()).toBe('');
+describe('matchSlashCommands', () => {
+  it('returns nothing when buffer does not start with /', () => {
+    expect(matchSlashCommands('hello')).toEqual([]);
   });
 
-  it('renders all commands for an empty / buffer', () => {
-    const { lastFrame } = render(createElement(SlashHints, { buffer: '/' }));
-    const frame = lastFrame() ?? '';
-    for (const cmd of SLASH_COMMANDS) {
-      expect(frame).toContain(cmd.name);
-    }
+  it('returns every command for an empty / buffer', () => {
+    expect(matchSlashCommands('/')).toEqual([...SLASH_COMMANDS]);
   });
 
   it('filters by prefix as the user types', () => {
-    const { lastFrame } = render(createElement(SlashHints, { buffer: '/ex' }));
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('/exit');
-    expect(frame).not.toContain('/clear');
+    const matches = matchSlashCommands('/ex');
+    expect(matches.map((c) => c.name)).toEqual(['/exit']);
   });
 
-  it('renders nothing when no command matches the prefix', () => {
-    const { lastFrame } = render(createElement(SlashHints, { buffer: '/nope' }));
-    expect(lastFrame()).toBe('');
+  it('returns nothing once the user types args', () => {
+    expect(matchSlashCommands('/task foo')).toEqual([]);
   });
 
   it('matching is case-insensitive', () => {
-    const { lastFrame } = render(createElement(SlashHints, { buffer: '/EX' }));
-    expect(lastFrame()).toContain('/exit');
+    expect(matchSlashCommands('/EX').map((c) => c.name)).toEqual(['/exit']);
+  });
+});
+
+describe('<SlashHints>', () => {
+  it('renders nothing when matches is empty', () => {
+    const { lastFrame } = render(
+      createElement(SlashHints, { matches: [], selectedIndex: 0 }),
+    );
+    expect(lastFrame()).toBe('');
+  });
+
+  it('renders the supplied matches with the selected row highlighted', () => {
+    const matches = matchSlashCommands('/c');
+    const { lastFrame } = render(
+      createElement(SlashHints, { matches, selectedIndex: 0 }),
+    );
+    const frame = lastFrame() ?? '';
+    for (const cmd of matches) expect(frame).toContain(cmd.name);
+    // The selection marker prefixes only the highlighted row.
+    expect(frame).toContain(`› ${matches[0].name}`);
   });
 });

--- a/src/ui/__tests__/Thread.test.tsx
+++ b/src/ui/__tests__/Thread.test.tsx
@@ -6,19 +6,25 @@ import { Thread } from '../Thread.js';
 import { MessageStore } from '../message-store.js';
 
 describe('<Thread>', () => {
-  it('renders a user message with the "you" label', () => {
+  it('renders a user message with the right-side marker', () => {
     const history: CoreMessage[] = [{ role: 'user', content: 'hello bernard' }];
     const { lastFrame } = render(createElement(Thread, { history }));
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('you');
     expect(frame).toContain('hello bernard');
+    expect(frame).toContain('❯');
   });
 
-  it('renders an assistant message with the "bernard" label', () => {
+  it('renders an "interrupted" notice when the prop is set and not busy', () => {
+    const history: CoreMessage[] = [{ role: 'user', content: 'hi' }];
+    const { lastFrame } = render(createElement(Thread, { history, interrupted: true }));
+    expect(lastFrame() ?? '').toContain('you interrupted');
+  });
+
+  it('renders an assistant message with the chevron label', () => {
     const history: CoreMessage[] = [{ role: 'assistant', content: 'hi there' }];
     const { lastFrame } = render(createElement(Thread, { history }));
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('bernard');
+    expect(frame).toContain('❮');
     expect(frame).toContain('hi there');
   });
 
@@ -38,7 +44,7 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('plain output');
     expect(frame).toContain('thinking…');
@@ -60,7 +66,7 @@ describe('<Thread>', () => {
         ],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
     expect(lastFrame()).toContain('↳');
     expect(lastFrame()).toContain('file1');
   });
@@ -80,11 +86,44 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ shell');
     expect(frame).toContain('…');
     expect(frame).not.toContain(longCmd);
+  });
+
+  it('hides tool-call args and result bodies when toolDetails is off', () => {
+    const history: CoreMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'c1',
+            toolName: 'shell',
+            args: { cmd: 'ls' },
+          },
+        ] as unknown as CoreMessage['content'],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'c1',
+            toolName: 'shell',
+            result: 'file1\nfile2\n',
+          },
+        ],
+      },
+    ];
+    const { lastFrame } = render(createElement(Thread, { history }));
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('⚙ shell');
+    expect(frame).not.toContain('{"cmd":"ls"}');
+    expect(frame).not.toContain('↳');
+    expect(frame).not.toContain('file1');
   });
 
   it('skips system messages silently', () => {
@@ -98,7 +137,7 @@ describe('<Thread>', () => {
     expect(frame).toContain('hi');
   });
 
-  it('renders streaming text-deltas under the "bernard" label when busy', () => {
+  it('renders streaming text-deltas under the chevron label when busy', () => {
     const store = new MessageStore();
     store.append({ kind: 'text-delta', text: 'hello' });
     store.append({ kind: 'text-delta', text: ' world' });
@@ -106,7 +145,7 @@ describe('<Thread>', () => {
       createElement(Thread, { history: [], messageStore: store, busy: true }),
     );
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('bernard');
+    expect(frame).toContain('❮');
     expect(frame).toContain('hello world');
   });
 
@@ -115,25 +154,160 @@ describe('<Thread>', () => {
     store.append({ kind: 'tool-call', callId: 'c1', toolName: 'shell', args: { cmd: 'ls' } });
     store.append({ kind: 'tool-result', callId: 'c1', result: 'ok', isError: false });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, {
+        history: [],
+        messageStore: store,
+        busy: true,
+        toolDetails: true,
+      }),
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ shell');
     expect(frame).toContain('↳ ok');
   });
 
-  it('renders a sub-agent label distinct from bernard', () => {
+  it('renders a sub-agent label distinct from the main chevron', () => {
     const store = new MessageStore();
     store.append({ kind: 'text-delta', text: 'main says', agentLabel: undefined });
     store.append({ kind: 'text-delta', text: 'sub says', agentLabel: 'sub:1' });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, {
+        history: [],
+        messageStore: store,
+        busy: true,
+        toolDetails: true,
+      }),
     );
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('bernard');
+    expect(frame).toContain('❮');
     expect(frame).toContain('sub:1');
     expect(frame).toContain('main says');
     expect(frame).toContain('sub says');
+  });
+
+  it('hides streaming sub-agent / wrapper labels and bodies when toolDetails is off', () => {
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'main says', agentLabel: undefined });
+    store.append({ kind: 'text-delta', text: 'wrapper-json-blob', agentLabel: 'wrap:3' });
+    store.append({
+      kind: 'tool-call',
+      callId: 'c1',
+      toolName: 'web_read',
+      args: { url: 'https://example.com' },
+      agentLabel: 'wrap:3',
+    });
+    store.append({
+      kind: 'tool-result',
+      callId: 'c1',
+      result: '{"status":"ok"}',
+      isError: false,
+      agentLabel: 'wrap:3',
+    });
+    const { lastFrame } = render(
+      createElement(Thread, { history: [], messageStore: store, busy: true }),
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('main says');
+    expect(frame).not.toContain('wrap:3');
+    expect(frame).not.toContain('wrapper-json-blob');
+    expect(frame).not.toContain('web_read');
+    expect(frame).not.toContain('status');
+  });
+
+  it('hides streaming main-agent tool-call args and result snippets when toolDetails is off', () => {
+    const store = new MessageStore();
+    store.append({
+      kind: 'tool-call',
+      callId: 'c1',
+      toolName: 'shell',
+      args: { cmd: 'ls -la' },
+    });
+    store.append({
+      kind: 'tool-result',
+      callId: 'c1',
+      result: 'file1\nfile2',
+      isError: false,
+    });
+    const { lastFrame } = render(
+      createElement(Thread, { history: [], messageStore: store, busy: true }),
+    );
+    const frame = lastFrame() ?? '';
+    // Tool name still surfaces (helps the user see "what is bernard doing").
+    expect(frame).toContain('⚙ shell');
+    // …but no args, no result snippet, no `↳` rail.
+    expect(frame).not.toContain('ls -la');
+    expect(frame).not.toContain('file1');
+    expect(frame).not.toContain('↳');
+  });
+
+  it('hides streaming orphan tool-results when toolDetails is off', () => {
+    // A tool-result with no matching tool-call (defensive path in StreamGroupBody).
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'hi' });
+    store.append({
+      kind: 'tool-result',
+      callId: 'orphan-1',
+      result: 'leaked-result-body',
+      isError: false,
+    });
+    const { lastFrame } = render(
+      createElement(Thread, { history: [], messageStore: store, busy: true }),
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('hi');
+    expect(frame).not.toContain('leaked-result-body');
+    expect(frame).not.toContain('↳');
+  });
+
+  it('still renders streaming main-agent text when toolDetails is off', () => {
+    // Guard against an over-eager suppression breaking the primary stream.
+    const store = new MessageStore();
+    store.append({ kind: 'text-delta', text: 'streaming answer' });
+    const { lastFrame } = render(
+      createElement(Thread, { history: [], messageStore: store, busy: true }),
+    );
+    expect(lastFrame() ?? '').toContain('streaming answer');
+  });
+
+  it('hides static tool messages and tool-call args across multiple turns when toolDetails is off', () => {
+    // Static-view counterpart: confirms what the user sees after the turn ends.
+    const history: CoreMessage[] = [
+      { role: 'user', content: 'go' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'working' },
+          {
+            type: 'tool-call',
+            toolCallId: 'c1',
+            toolName: 'web_read',
+            args: { url: 'https://aaro.mil/' },
+          },
+        ] as unknown as CoreMessage['content'],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'c1',
+            toolName: 'web_read',
+            result: { status: 'ok', result: { content_excerpt: 'AARO Home' } },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'done' }] as unknown as CoreMessage['content'],
+      },
+    ];
+    const { lastFrame } = render(createElement(Thread, { history }));
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('⚙ web_read');
+    expect(frame).not.toContain('aaro.mil');
+    expect(frame).not.toContain('AARO Home');
+    expect(frame).not.toContain('↳');
+    expect(frame).not.toContain('"status"');
   });
 
   it('does not mount StreamingAssistantMessage when not busy', () => {


### PR DESCRIPTION
## Summary

REPL polish on top of the Ink cutover. Two commits land together — the first introduced the new pinned status bar, hint bar, slash picker, and friendlier messaging; the second fixes a handful of regressions and tightens the tool-details gate.

- **Prompt cursor follows wrapped text** (`src/ui/Prompt.tsx`): chevron / buffer / cursor are now nested inside a single parent `<Text>` so the cursor lands at the end of the *wrapped* line instead of pinning to row 1.
- **Per-message timestamp + duration** (`src/ui/Thread.tsx`, `src/ui/App.tsx`): replaced single `lastTurnTiming` with a per-history-index `turnTimings` map (backed by a ref on `<App>`). Every assistant message keeps its `1.2s · 9:42 PM` footer across follow-up turns; cleared on `/clear`.
- **Hide tool details in the streaming view** (`src/ui/Thread.tsx`): when `toolDetails` is off, suppress sub-agent / wrapper labeled groups (`wrap:N`, `sub:N`) entirely, matching what the static post-turn view shows. Pre-existing gates already hid main-agent args and `↳` result rails — those keep working.
- **HintBar + StatusBar** (`src/ui/HintBar.tsx`, `src/ui/StatusBar.tsx`): pinned bottom-right token / context-window readout with compression-headroom bar; contextual hint strip below the prompt.
- **Slash picker + Prompt polish** (`src/ui/SlashHints.tsx`, `src/ui/Prompt.tsx`): inline autocomplete (Up/Down/Tab/Enter) under the bordered input.
- **Framework plumbing** (`src/framework/runner.ts`, `src/framework/hooks/output.ts`, `src/framework/agents/run.ts`): main-agent streaming routed through the output sink, sub-agents/wrappers continue to bulk-emit; avoids double-rendering main-agent tool calls.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/ui/__tests__` — 17 files / 126 tests pass (5 new in `Thread.test.tsx` covering streaming + static `toolDetails=off`; updated sub-agent label test; expanded Prompt tests for slash picker)
- [ ] Manual: type a follow-up turn, confirm the prior assistant message keeps its `Xs · h:mm PM` footer
- [ ] Manual: type a long message, confirm the cursor block follows the wrapped buffer onto the next line
- [ ] Manual: `/agent-options` → Tool details = off, dispatch a turn that calls a wrapper specialist (e.g. `web_read` on an HTML page), confirm no `wrap:N` JSON leaks during streaming
- [ ] Manual: `/clear` resets the timing map (no stale footers re-appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)