### PR TITLE
fix(ui): dedupe model-provided "Other" in ask_user choices

### DIFF
--- a/src/tools/ask-user.ts
+++ b/src/tools/ask-user.ts
@@ -24,7 +24,7 @@ export function createAskUserTool(askUser: ToolOptions['askUser']) {
                 .min(2)
                 .optional()
                 .describe(
-                  'Optional list of answer labels. Provide 2+ entries; one-choice menus are rejected.',
+                  'Optional list of answer labels. Provide 2+ entries; one-choice menus are rejected. Do NOT include your own "Other"/"None of the above" entry — an escape-hatch option is appended automatically (control it via allow_other / other_label).',
                 ),
               allow_other: z
                 .boolean()

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -229,6 +229,14 @@ interface PendingBlock {
 type PendingDialog = PendingConfirm | PendingBlock;
 
 /**
+ * "Other"-shaped choice labels ("Other", "Other (I'll specify)", …).
+ * Models include these in `ask_user` choices despite the tool description
+ * saying not to (#230); `requestAskUser` dedupes against the auto-appended
+ * escape hatch and routes matching selections to the free-text input.
+ */
+const OTHER_RE = /^other\b/i;
+
+/**
  * Top-level Ink component. Owns the lifecycle of a Bernard REPL session:
  * turn submission, history versioning, overlay queueing, Shift-Tab cycling,
  * and Esc / Ctrl-C handling.
@@ -2219,13 +2227,21 @@ export function App({
       }
 
       // Choice question; append an "Other" escape hatch if requested.
+      // Models often include their own "Other" entry despite the tool
+      // description (#230) — when they do, skip the duplicate and treat
+      // the model's entry as the escape hatch instead.
       const otherLabel = q.otherLabel?.trim() || 'Other (type your own)';
       const entries: MenuEntry[] = q.choices.map((c) => ({ label: c }));
-      if (q.allowOther) entries.push({ label: otherLabel });
+      const hasModelOther = q.choices.some((c) => OTHER_RE.test(c.trim()));
+      const appendedHatch = q.allowOther && !hasModelOther;
+      if (appendedHatch) entries.push({ label: otherLabel });
       const result = await requestMenu(entries, { title: q.question });
       if (result.cancelled) return { cancelled: true, answered: answers };
 
-      if (q.allowOther && result.index === entries.length - 1) {
+      const pickedHatch =
+        (appendedHatch && result.index === entries.length - 1) ||
+        OTHER_RE.test(result.item.label.trim());
+      if (pickedHatch) {
         // User picked "Other" — gather free-form text.
         const free = await requestTextInput({ label: q.question });
         if (free.cancelled) return { cancelled: true, answered: answers };

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -66,6 +66,7 @@ process.env.BERNARD_HOME = TMP_HOME;
 
 // ── Imports under test (after mocks + env) ──────────────────────────────
 import { App, type AppStores } from '../App.js';
+import { getInkHandlers } from '../ink-handlers.js';
 import type { BernardConfig } from '../../config.js';
 import type { Agent } from '../../agent.js';
 import type { HistoryStore } from '../../history.js';
@@ -420,6 +421,91 @@ describe('<App> plain-text turn', () => {
     await submit(stdin, 'hi');
     await tick(40);
     expect(lastFrame()).not.toContain('CRON_ALERT — job foo');
+    unmount();
+  });
+});
+
+describe('<App> requestAskUser "Other" dedup (#230)', () => {
+  beforeEach(() => {
+    process.env.BERNARD_HOME = TMP_HOME;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not append the escape hatch when the model already provided an "Other" choice', async () => {
+    const { stdin, lastFrame, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      { question: 'How many kids?', choices: ['1 kid', '2 kids', 'Other'], allowOther: true },
+    ]);
+    await tick(40);
+    const frame = lastFrame()!;
+    expect(frame).toContain('How many kids?');
+    expect(frame).toContain('3. Other');
+    expect(frame).not.toContain('Other (type your own)');
+    expect(frame).not.toContain('4.');
+    // Selecting the model's "Other" routes to the free-text input.
+    stdin.write('3');
+    await tick(40);
+    expect(lastFrame()).not.toContain('1 kid'); // menu gone → text input
+    stdin.write('four kids');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: ['four kids'] });
+    unmount();
+  });
+
+  it('routes a model-provided "Other (I\'ll specify)" variant to free text even with allowOther false', async () => {
+    const { stdin, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      {
+        question: 'Pick one',
+        choices: ['A', "Other (I'll specify)"],
+        allowOther: false,
+      },
+    ]);
+    await tick(40);
+    stdin.write('2');
+    await tick(40);
+    stdin.write('custom answer');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: ['custom answer'] });
+    unmount();
+  });
+
+  it('still returns the label for a normal choice', async () => {
+    const { stdin, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      { question: 'Pick one', choices: ['A', 'B', 'Other'], allowOther: true },
+    ]);
+    await tick(40);
+    stdin.write('1');
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: ['A'] });
+    unmount();
+  });
+
+  it('still appends the escape hatch when no "Other"-shaped choice exists', async () => {
+    const { stdin, lastFrame, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      { question: 'Pick one', choices: ['A', 'B'], allowOther: true },
+    ]);
+    await tick(40);
+    expect(lastFrame()).toContain('Other (type your own)');
+    stdin.write('3');
+    await tick(40);
+    stdin.write('free text');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: ['free text'] });
     unmount();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #230 — when the model includes its own "Other" entry in `ask_user` choices, the REPL appended a second escape-hatch row (since `allow_other` defaults to `true`), rendering duplicate Other options:

```
> 1. 1 kid (1 bed)
  ...
  5. Other            ← model-provided, returned literal "Other" (dead end)
  6. Other (I'll specify)  ← auto-appended hatch
```

Worse, selecting the model-provided row returned the literal string `"Other"` with **no free-text follow-up** (routing was purely positional), so the agent got a useless answer and had to re-ask.

## Changes

- **`src/ui/App.tsx`** (`requestAskUser`): detect Other-shaped choices (`/^other\b/i`), skip appending the duplicate hatch when one exists, and route any Other-shaped selection to the free-text input — even when `allow_other: false`, since a literal "Other" answer is never useful. The appended hatch keeps its positional check (its label is customizable via `other_label` and may not match the regex).
- **`src/tools/ask-user.ts`**: `choices` schema description now tells the model not to include its own Other/None-of-the-above entry (belt-and-braces — the UI dedup is the real guarantee, since tool descriptions are advisory).

## Tests

Four new App-level tests in `src/ui/__tests__/App.test.tsx` drive the full path through the `ink-handlers` bridge → MenuOverlay → TextInputOverlay:

- model-provided "Other" → single row, routes to free text
- `Other (I'll specify)` variant with `allow_other: false` → still routes to free text
- normal choice still returns its label
- no Other-shaped choice → hatch still appended and routes to free text (existing behavior preserved)

Full suite: 140 files / 2743 tests green. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)