### PR TITLE
fix(ui): label status-bar token odometer as session-scoped + add ctx readout (#234)

### DIFF
--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -64,25 +64,26 @@ export function StatusBar({ agent }: StatusBarProps) {
           {'   '}
         </Text>
       )}
+      {/* The token readout + context gauge only render once real token stats
+          exist — before the first stats flush (strategy set, stats still null)
+          an all-empty bar would be visual noise. `session` is the cumulative
+          per-session odometer; `ctx` is the current input size (latest step's
+          prompt tokens) — the number the gauge actually depicts, so the two
+          can't be confused. */}
       {stats && (
-        <Text color={colors.muted}>
-          session {up}↑ {down}↓{'   '}
-        </Text>
-      )}
-      {/* Context gauge only renders once real token stats exist — before the
-          first stats flush (strategy set, stats still null) an all-empty bar
-          would be visual noise. The `ctx` readout is the current input size
-          (latest step's prompt tokens) — the number the gauge actually depicts,
-          so it can't be confused with the cumulative `session` odometer above. */}
-      {stats && (
-        <Text color={colors.muted}>ctx {formatTokenCount(stats.latestPromptTokens)} </Text>
-      )}
-      {stats && filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}
-      {stats && halfCount > 0 && <Text color={fillColor}>◐</Text>}
-      {stats && emptyCount > 0 && (
-        <Text color={colors.muted} dimColor>
-          {'○'.repeat(emptyCount)}
-        </Text>
+        <>
+          <Text color={colors.muted}>
+            session {up}↑ {down}↓{'   '}
+          </Text>
+          <Text color={colors.muted}>ctx {formatTokenCount(stats.latestPromptTokens)} </Text>
+          {filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}
+          {halfCount > 0 && <Text color={fillColor}>◐</Text>}
+          {emptyCount > 0 && (
+            <Text color={colors.muted} dimColor>
+              {'○'.repeat(emptyCount)}
+            </Text>
+          )}
+        </>
       )}
     </Box>
   );

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -66,12 +66,17 @@ export function StatusBar({ agent }: StatusBarProps) {
       )}
       {stats && (
         <Text color={colors.muted}>
-          {up}↑ {down}↓{'   '}
+          session {up}↑ {down}↓{'   '}
         </Text>
       )}
       {/* Context gauge only renders once real token stats exist — before the
           first stats flush (strategy set, stats still null) an all-empty bar
-          would be visual noise. */}
+          would be visual noise. The `ctx` readout is the current input size
+          (latest step's prompt tokens) — the number the gauge actually depicts,
+          so it can't be confused with the cumulative `session` odometer above. */}
+      {stats && (
+        <Text color={colors.muted}>ctx {formatTokenCount(stats.latestPromptTokens)} </Text>
+      )}
       {stats && filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}
       {stats && halfCount > 0 && <Text color={fillColor}>◐</Text>}
       {stats && emptyCount > 0 && (

--- a/src/ui/__tests__/StatusBar.test.tsx
+++ b/src/ui/__tests__/StatusBar.test.tsx
@@ -62,3 +62,21 @@ describe('<StatusBar> context gauge (half-dot resolution)', () => {
     expect(gauge(lastFrame() ?? '')).toBe('●●●●●●●●●●');
   });
 });
+
+describe('<StatusBar> token readout labels (#234)', () => {
+  it('labels the cumulative odometer as session-scoped', () => {
+    const { lastFrame } = render(createElement(StatusBar, { agent: stubAgent(0.55) }));
+    const frame = lastFrame() ?? '';
+    // The odometer must read "session ...↑ ...↓" so it can't be misread as the
+    // adjacent context gauge.
+    expect(frame).toMatch(/session\s+1\.2k↑\s+567↓/);
+  });
+
+  it('labels the gauge with the current context size (ctx)', () => {
+    const { lastFrame } = render(createElement(StatusBar, { agent: stubAgent(0.55) }));
+    const frame = lastFrame() ?? '';
+    // ctx reflects latestPromptTokens (0.55 * 1000 * COMPRESSION_THRESHOLD) and
+    // sits between the session odometer and the gauge glyphs.
+    expect(frame).toMatch(/ctx \S+ *●/);
+  });
+});

--- a/src/ui/__tests__/StatusBar.test.tsx
+++ b/src/ui/__tests__/StatusBar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
+import stripAnsi from 'strip-ansi';
 import { StatusBar } from '../StatusBar.js';
 import { COMPRESSION_THRESHOLD } from '../../context.js';
 import type { Agent } from '../../agent.js';
@@ -66,7 +67,9 @@ describe('<StatusBar> context gauge (half-dot resolution)', () => {
 describe('<StatusBar> token readout labels (#234)', () => {
   it('labels the cumulative odometer as session-scoped', () => {
     const { lastFrame } = render(createElement(StatusBar, { agent: stubAgent(0.55) }));
-    const frame = lastFrame() ?? '';
+    // Strip ANSI: Ink inserts color/reset codes between adjacent <Text> nodes,
+    // which would otherwise break regexes that span component boundaries.
+    const frame = stripAnsi(lastFrame() ?? '');
     // The odometer must read "session ...↑ ...↓" so it can't be misread as the
     // adjacent context gauge.
     expect(frame).toMatch(/session\s+1\.2k↑\s+567↓/);
@@ -74,7 +77,7 @@ describe('<StatusBar> token readout labels (#234)', () => {
 
   it('labels the gauge with the current context size (ctx)', () => {
     const { lastFrame } = render(createElement(StatusBar, { agent: stubAgent(0.55) }));
-    const frame = lastFrame() ?? '';
+    const frame = stripAnsi(lastFrame() ?? '');
     // ctx reflects latestPromptTokens (0.55 * 1000 * COMPRESSION_THRESHOLD) and
     // sits between the session odometer and the gauge glyphs.
     expect(frame).toMatch(/ctx \S+ *●/);


### PR DESCRIPTION
## Summary

Fixes #234. The status bar rendered the cumulative session token totals (`8527k↑ 17k↓`) directly beside the context-fullness dot gauge, so users reasonably misread the `↑` number as *current context usage* — when it's actually a session-long odometer that grows roughly quadratically as history is re-sent each step.

This is a self-contained display change in `src/ui/StatusBar.tsx` (both values already live on `agent.spinnerStats` — no data-layer changes):

- **Label the odometer as session-scoped** — `{up}↑ {down}↓` → `session {up}↑ {down}↓`, so it reads as a running session total rather than a context meter.
- **Add a `ctx <N>` readout before the gauge** — renders `formatTokenCount(stats.latestPromptTokens)`, the current input size that the gauge actually depicts. This is the number users want when asking "how full am I?".

Rendered result:

```
◇ normal   session 8.5M↑ 17k↓   ctx 92k ●●●●●◐○○○○
```

## Tests

Added two regression tests to `src/ui/__tests__/StatusBar.test.tsx` asserting the `session ` and `ctx ` labels (the existing tests only assert on gauge glyphs, so there was no readout-text coverage to break). `npm run build` is clean; all 7 tests in the file pass.

## Out of scope (follow-ups)

- The odometer's second problem from #234 — it *undercounts* true API usage because token accounting is attached to the main agent only (not sub-agents / tool-wrappers / pre-turn LLM calls). That's a larger hooks-layer change for a separate PR.
- The stale context-window denominator when a lineup is active, tracked separately in #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)