### PR TITLE
fix: route context-window/compression math through lineup-resolved main model (#233)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -25,6 +25,7 @@ import {
   isTokenOverflowError,
   getContextWindow,
 } from './context.js';
+import { resolveMainModel } from './model-policy.js';
 import type { BernardConfig } from './config.js';
 import type { MemoryStore } from './memory.js';
 import type { RAGStore, RAGSearchResult } from './rag.js';
@@ -385,6 +386,17 @@ export class Agent {
     this.ctx.provenance.clear();
 
     try {
+      // Context-window / compression math must follow the lineup-resolved main
+      // model, not the stale `config.model` base field (#233). Resolve once per
+      // turn and refresh `spinnerStats` so the status gauge and spinner pick up
+      // mid-session /lineups, /model, and /profiles switches (the App.tsx seed
+      // only fires once at mount).
+      const mainModelName = resolveMainModel(this.config);
+      if (this.spinnerStats) {
+        this.spinnerStats.model = mainModelName;
+        this.spinnerStats.contextWindowOverride = this.config.tokenWindow || undefined;
+      }
+
       // Check if context compression is needed
       const imageTokens = images ? images.length * IMAGE_TOKEN_ESTIMATE : 0;
       const newMessageEstimate = Math.ceil(wrappedInput.length / 4) + imageTokens;
@@ -392,7 +404,7 @@ export class Agent {
         shouldCompress(
           this.lastPromptTokens,
           newMessageEstimate,
-          this.config.model,
+          mainModelName,
           this.config.tokenWindow,
         )
       ) {
@@ -463,7 +475,7 @@ export class Agent {
       const systemForEstimate = buildMainSystemPrompt(this.ctx, inputBase, profile);
       const input: MainInput = { ...inputBase, systemPrompt: systemForEstimate };
       const HARD_LIMIT_RATIO = 0.9;
-      const contextWindow = getContextWindow(this.config.model, this.config.tokenWindow);
+      const contextWindow = getContextWindow(mainModelName, this.config.tokenWindow);
       // The per-turn `<system_provided_context>` message is no longer in the
       // SYSTEM prompt (issue #172) — account for it separately in the
       // preflight estimate so token budgeting stays accurate.

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -159,6 +159,23 @@ describe('resolveSiteModel — tier mapping per mode (anthropic lineup)', () => 
   });
 });
 
+describe('resolveMainModel — context-window source of truth (#233)', () => {
+  it('returns the lineup-resolved main model, not the stale config.model base field', async () => {
+    const { resolveMainModel } = await loadModule();
+    // base field is sonnet, but `balanced` re-tiers the main site to premium —
+    // window math must follow the model we actually talk to.
+    const config = makeConfig({ modelMode: 'balanced', model: 'claude-sonnet-4-5-20250929' });
+    expect(resolveMainModel(config)).toBe('claude-opus-4-6');
+    expect(resolveMainModel(config)).not.toBe(config.model);
+  });
+
+  it('agrees with resolveSiteModel(config, "main").modelName', async () => {
+    const { resolveMainModel, resolveSiteModel } = await loadModule();
+    const config = makeConfig({ modelMode: 'optimize-performance' });
+    expect(resolveMainModel(config)).toBe(resolveSiteModel(config, 'main').modelName);
+  });
+});
+
 describe('resolveSiteModel — openai lineup', () => {
   it('balanced picks gpt-5.2 / gpt-4.1 / gpt-4.1-mini', async () => {
     const { resolveSiteModel } = await loadModule();

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -120,6 +120,20 @@ const ALL_MODEL_SITES: readonly ModelSite[] = [
 ];
 
 /**
+ * The bare model-name string for the **main** agent under the active lineup /
+ * model-mode policy. Context-window and compression math (`getContextWindow`,
+ * `shouldCompress`) must resolve through this rather than reading the legacy
+ * `config.model` base field directly (#233): the lineup system leaves
+ * `config.model` in place only as a last-resort fallback, so when a lineup
+ * re-tiers the main site to a different model, `config.model` is stale and
+ * yields the wrong context window — i.e. a mistimed compression trigger and a
+ * status gauge measured against the wrong denominator.
+ */
+export function resolveMainModel(config: BernardConfig): string {
+  return resolveSiteModel(config, 'main').modelName;
+}
+
+/**
  * Resolves the effective (provider, model) for a given LLM call site.
  *
  * Precedence (highest to lowest):

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -83,7 +83,7 @@ import {
 import { runDefinition } from '../framework/agents/run.js';
 import { taskDefinition, type TaskInput } from '../framework/agents/task.js';
 import { generateText } from 'ai';
-import { resolveSiteModel, logSiteModelSnapshot } from '../model-policy.js';
+import { resolveSiteModel, resolveMainModel, logSiteModelSnapshot } from '../model-policy.js';
 import { serializeMessages, extractDomainFacts, SUMMARIZATION_PROMPT } from '../context.js';
 import { detectSpecialistCandidate } from '../specialist-detector.js';
 import { promoteCandidate } from '../candidate-bootstrap.js';
@@ -430,7 +430,11 @@ export function App({
         totalPromptTokens: 0,
         totalCompletionTokens: 0,
         latestPromptTokens: 0,
-        model: config.model,
+        // Lineup-resolved main model, not the stale `config.model` base field
+        // (#233) — the gauge denominator must follow the model we actually talk
+        // to. The agent loop also refreshes this each turn for mid-session
+        // lineup/model switches; this just seeds the first pre-turn render.
+        model: resolveMainModel(config),
         contextWindowOverride: config.tokenWindow || undefined,
       });
     }
@@ -1190,10 +1194,13 @@ export function App({
       saveOption(name, val);
       (config as unknown as Record<string, unknown>)[opt.configKey] = val;
       if (name === 'token-window') {
-        const modelWindow = getContextWindow(config.model);
+        // Validate against the lineup-resolved main model's window, not the
+        // stale base field (#233).
+        const mainModel = resolveMainModel(config);
+        const modelWindow = getContextWindow(mainModel);
         if (val > modelWindow) {
           flashToast(
-            `Set ${name} = ${val} (warning: exceeds ${config.model}'s context window ${modelWindow})`,
+            `Set ${name} = ${val} (warning: exceeds ${mainModel}'s context window ${modelWindow})`,
             'warning',
           );
           return;


### PR DESCRIPTION
## Summary

Fixes #233. The context-window / compression layer reads the legacy `config.model` base field, which the lineup system deliberately leaves in place only as a *fallback* (`resolveSiteModel` consults it only when no lineup applies). Dispatch already routes every `generateText` site through `resolveSiteModel`, but the **window math was never migrated** — so when a lineup or model-mode re-tiers the main site to a different model, every context-window computation uses the wrong window:

- **Compression trigger** (`agent.ts` `shouldCompress`) and the **preflight hard-limit + overflow-retry budget** (`getContextWindow`) compute against the stale model's window → compression fires too early, or (as in the reported gpt-5.2-under-a-grok-base case) far too late, risking a hard API context-overflow before Bernard ever compresses.
- **Status gauge / spinner** measure fullness against the wrong denominator → user sees "tons of headroom" when the budget is materially consumed.

Additionally, `spinnerStats` was seeded once at mount behind `if (!agent.spinnerStats)`, so even a plain `/model` or `/lineups` switch mid-session never updated `stats.model`.

## Changes

- **`src/model-policy.ts`** — add `resolveMainModel(config)`, a thin wrapper over `resolveSiteModel(config, 'main').modelName`. Single source of truth for "the model we actually talk to" in window math.
- **`src/agent.ts`** — resolve the main model once per turn; route both the `shouldCompress` trigger and the preflight `getContextWindow` (which feeds `hardLimit` and the overflow-retry ratio) through it. Refresh `spinnerStats.model` / `contextWindowOverride` each turn so the gauge/spinner auto-correct and pick up mid-session `/lineups`, `/model`, `/profiles` switches.
- **`src/ui/App.tsx`** — seed `spinnerStats.model` and the `/settings token-window` validation readout from `resolveMainModel(config)` instead of `config.model`.

`StatusBar.tsx` and `output.ts` read `stats.model`, so they become correct automatically once the seed + per-turn refresh feed the resolved model — no change needed there.

## Tests

Added `resolveMainModel` tests (`src/model-policy.test.ts`): asserts it returns the re-tiered main model (`balanced` → `claude-opus-4-6`, *not* the stale `config.model` base field) and agrees with `resolveSiteModel(config, 'main').modelName`. `npm run build` clean; full suite green (**2747 passed**).

## Notes

Complements #234 (status-bar token labels), which referenced this as the sibling gauge-denominator bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)