### PR TITLE
feat(ask_user): opt-in multi-select questions ("select all that apply") (#231)

### DIFF
--- a/src/tools/ask-user.test.ts
+++ b/src/tools/ask-user.test.ts
@@ -29,6 +29,7 @@ describe('ask_user tool', () => {
           choices: ['open', 'closed'],
           allowOther: true,
           otherLabel: undefined,
+          multiSelect: false,
         },
       ],
       undefined,
@@ -72,6 +73,30 @@ describe('ask_user tool', () => {
     const q = askUser.mock.calls[0][0][0];
     expect(q.choices).toBeUndefined();
     expect(q.allowOther).toBe(true);
+  });
+
+  it('normalizes multi_select=true to multiSelect when choices are present (#231)', async () => {
+    askUser.mockResolvedValue({ answers: [['open', 'closed']] });
+    const tool = createAskUserTool(askUser);
+    await tool.execute!(
+      {
+        questions: [
+          { question: 'which states?', choices: ['open', 'closed'], multi_select: true },
+        ],
+      } as any,
+      {} as any,
+    );
+    expect(askUser.mock.calls[0][0][0].multiSelect).toBe(true);
+  });
+
+  it('leaves multiSelect false for free-form questions even if multi_select is set', async () => {
+    askUser.mockResolvedValue({ answers: ['x'] });
+    const tool = createAskUserTool(askUser);
+    await tool.execute!(
+      { questions: [{ question: 'name?', multi_select: true }] } as any,
+      {} as any,
+    );
+    expect(askUser.mock.calls[0][0][0].multiSelect).toBe(false);
   });
 
   it('forwards other_label to the callback as otherLabel', async () => {

--- a/src/tools/ask-user.ts
+++ b/src/tools/ask-user.ts
@@ -13,7 +13,7 @@ export function createAskUserTool(askUser: ToolOptions['askUser']) {
   return attachMeta(
     tool({
       description:
-        'Ask the user one or more clarifying questions and wait for their answers. Use this whenever you need information only the user can provide (intent, preferences, missing arguments) — do NOT write the question as prose in your reply, since that gets no response back. Provide each question as an entry in `questions`; supply `choices` per question when the answer is constrained, otherwise the user gets a free-form prompt. Batch related questions in one call (e.g. title + body + labels) — the user sees a tab strip showing progress. Returns JSON: {"answers": ["...", "..."]} aligned by index, {"cancelled": true, "answered": [...]} with whatever was answered before cancel, or {"unavailable": true} if running headless.',
+        'Ask the user one or more clarifying questions and wait for their answers. Use this whenever you need information only the user can provide (intent, preferences, missing arguments) — do NOT write the question as prose in your reply, since that gets no response back. Provide each question as an entry in `questions`; supply `choices` per question when the answer is constrained, otherwise the user gets a free-form prompt. Set `multi_select: true` on a question whose answer can include more than one choice ("select all that apply") — the user then checks several boxes and that question\'s answer comes back as a JSON array. Batch related questions in one call (e.g. title + body + labels) — the user sees a tab strip showing progress. Returns JSON: {"answers": ["...", ["a","b"]]} aligned by index (a multi-select slot is an array), {"cancelled": true, "answered": [...]} with whatever was answered before cancel, or {"unavailable": true} if running headless.',
       parameters: z.object({
         questions: z
           .array(
@@ -38,6 +38,12 @@ export function createAskUserTool(askUser: ToolOptions['askUser']) {
                 .describe(
                   'Label for the appended escape-hatch option. Use this to make the wording specific to your question (e.g. "Other (I will specify title and body)"). Ignored when allow_other is false. Defaults to a generic "Other (type a custom answer)".',
                 ),
+              multi_select: z
+                .boolean()
+                .optional()
+                .describe(
+                  'When choices are given, let the user select MULTIPLE options ("select all that apply") instead of just one. Set true when the choices are independent and more than one can be true at once (e.g. desired features, applicable tags). This question\'s answer is returned as an array of the chosen labels. Default false.',
+                ),
             }),
           )
           .min(1)
@@ -55,6 +61,7 @@ export function createAskUserTool(askUser: ToolOptions['askUser']) {
           choices: q.choices,
           allowOther: q.choices && q.choices.length > 0 ? q.allow_other !== false : true,
           otherLabel: q.other_label,
+          multiSelect: q.choices && q.choices.length > 0 ? q.multi_select === true : false,
         }));
         const result = await askUser(normalised, execOptions?.abortSignal);
         return JSON.stringify(result);

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -35,10 +35,22 @@ export interface AskUserQuestion {
   allowOther: boolean;
   /** Optional label for the escape-hatch row; defaults to a generic "Other" wording. */
   otherLabel?: string;
+  /**
+   * When true and `choices` is present, the menu runs in multi-select mode
+   * ("select all that apply"): the user toggles checkboxes and commits the
+   * whole set at once. That question's answer comes back as a `string[]`.
+   */
+  multiSelect?: boolean;
 }
 
-/** Result of an `askUser` batch interaction. `answered` is aligned by index with the input questions. */
-export type AskUserBatchResult = { answers: string[] } | { cancelled: true; answered: string[] };
+/**
+ * Result of an `askUser` batch interaction. `answers`/`answered` are aligned by
+ * index with the input questions; a multi-select question contributes a
+ * `string[]` at its slot, every other question a plain `string`.
+ */
+export type AskUserBatchResult =
+  | { answers: (string | string[])[] }
+  | { cancelled: true; answered: (string | string[])[] };
 
 /**
  * Input passed to the read-only block callback (issue #179). Assembled by the

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -179,6 +179,7 @@ type Overlay =
   | 'status'
   | 'sources'
   | 'menu'
+  | 'multi-menu'
   | 'grid'
   | 'confirm'
   | 'help'
@@ -206,6 +207,18 @@ interface PendingMenu {
   resolve: (
     result: { cancelled: true } | { cancelled: false; index: number; item: MenuItem },
   ) => void;
+}
+
+/**
+ * Multi-select counterpart of {@link PendingMenu} (#231). Kept separate so the
+ * heavily-used single-select `requestMenu`/`PendingMenu` contract stays
+ * untouched; only the `ask_user` multi-select path uses this. Resolves with the
+ * checked items in row order.
+ */
+interface PendingMultiMenu {
+  entries: MenuEntry[];
+  options?: MenuOptions;
+  resolve: (result: { cancelled: true } | { cancelled: false; items: MenuItem[] }) => void;
 }
 
 interface PendingGrid {
@@ -268,6 +281,7 @@ export function App({
   const [busy, setBusy] = useState(false);
   const [historyVersion, setHistoryVersion] = useState(0);
   const [pendingMenu, setPendingMenu] = useState<PendingMenu | null>(null);
+  const [pendingMultiMenu, setPendingMultiMenu] = useState<PendingMultiMenu | null>(null);
   const [pendingGrid, setPendingGrid] = useState<PendingGrid | null>(null);
   const [pendingDialog, setPendingDialog] = useState<PendingDialog | null>(null);
   const [pendingTextInput, setPendingTextInput] = useState<PendingTextInput | null>(null);
@@ -2047,6 +2061,17 @@ export function App({
     });
   }
 
+  /** Multi-select sibling of {@link requestMenu} (#231). */
+  function requestMultiMenu(
+    entries: MenuEntry[],
+    options?: MenuOptions,
+  ): Promise<{ cancelled: true } | { cancelled: false; items: MenuItem[] }> {
+    return new Promise((resolve) => {
+      setPendingMultiMenu({ entries, options, resolve });
+      setActiveOverlay('multi-menu');
+    });
+  }
+
   function requestGridMenu(
     items: string[],
     options?: { title?: string; footer?: string; initialIndex?: number; currentItem?: string },
@@ -2214,7 +2239,7 @@ export function App({
     questions: AskUserQuestion[],
     signal?: AbortSignal,
   ): Promise<AskUserBatchResult> {
-    const answers: string[] = [];
+    const answers: (string | string[])[] = [];
     for (const q of questions) {
       if (signal?.aborted) return { cancelled: true, answered: answers };
 
@@ -2235,6 +2260,32 @@ export function App({
       const hasModelOther = q.choices.some((c) => OTHER_RE.test(c.trim()));
       const appendedHatch = q.allowOther && !hasModelOther;
       if (appendedHatch) entries.push({ label: otherLabel });
+
+      // Multi-select question (#231): toggle a checkbox set, commit at once.
+      // The answer is the array of chosen labels; an "Other"-shaped pick still
+      // routes to a free-text follow-up (same dedup behavior as single-select).
+      if (q.multiSelect) {
+        const result = await requestMultiMenu(entries, { title: q.question });
+        if (result.cancelled) return { cancelled: true, answered: answers };
+        const picked: string[] = [];
+        let pickedHatch = false;
+        for (const item of result.items) {
+          const isHatch =
+            (appendedHatch && entries.indexOf(item) === entries.length - 1) ||
+            OTHER_RE.test(item.label.trim());
+          if (isHatch) pickedHatch = true;
+          else picked.push(item.label);
+        }
+        if (pickedHatch) {
+          const free = await requestTextInput({ label: q.question });
+          if (free.cancelled) return { cancelled: true, answered: answers };
+          const typed = free.raw.trim();
+          if (typed) picked.push(typed);
+        }
+        answers.push(picked);
+        continue;
+      }
+
       const result = await requestMenu(entries, { title: q.question });
       if (result.cancelled) return { cancelled: true, answered: answers };
 
@@ -2306,6 +2357,24 @@ export function App({
           onCancel={() => {
             pendingMenu.resolve({ cancelled: true });
             setPendingMenu(null);
+            setActiveOverlay(null);
+          }}
+        />
+      )}
+      {activeOverlay === 'multi-menu' && pendingMultiMenu && (
+        <MenuOverlay
+          multiSelect
+          entries={pendingMultiMenu.entries}
+          options={pendingMultiMenu.options}
+          onSelect={() => {}}
+          onMultiSelect={(items) => {
+            pendingMultiMenu.resolve({ cancelled: false, items });
+            setPendingMultiMenu(null);
+            setActiveOverlay(null);
+          }}
+          onCancel={() => {
+            pendingMultiMenu.resolve({ cancelled: true });
+            setPendingMultiMenu(null);
             setActiveOverlay(null);
           }}
         />

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -250,6 +250,31 @@ type PendingDialog = PendingConfirm | PendingBlock;
 const OTHER_RE = /^other\b/i;
 
 /**
+ * Builds the menu entries for an `ask_user` choice question and a predicate for
+ * whether a selected item is the "Other" escape hatch. Shared by the single-
+ * and multi-select paths of `requestAskUser` so the #230 dedup rule lives in
+ * one place: append a hatch row only when the model didn't already supply an
+ * "Other"-shaped choice, and treat either the appended row (by identity — its
+ * label may be custom via `otherLabel`) or any `OTHER_RE`-matching label as the
+ * hatch. The matching selection routes to a free-text follow-up.
+ */
+function buildChoiceMenu(q: AskUserQuestion): {
+  entries: MenuEntry[];
+  isHatch: (item: MenuItem) => boolean;
+} {
+  const otherLabel = q.otherLabel?.trim() || 'Other (type your own)';
+  const entries: MenuEntry[] = (q.choices ?? []).map((c) => ({ label: c }));
+  const hasModelOther = (q.choices ?? []).some((c) => OTHER_RE.test(c.trim()));
+  const appendedHatch = q.allowOther && !hasModelOther;
+  if (appendedHatch) entries.push({ label: otherLabel });
+  const hatchRow = appendedHatch ? entries[entries.length - 1] : undefined;
+  return {
+    entries,
+    isHatch: (item) => item === hatchRow || OTHER_RE.test(item.label.trim()),
+  };
+}
+
+/**
  * Top-level Ink component. Owns the lifecycle of a Bernard REPL session:
  * turn submission, history versioning, overlay queueing, Shift-Tab cycling,
  * and Esc / Ctrl-C handling.
@@ -329,6 +354,10 @@ export function App({
     if (pendingMenu) {
       pendingMenu.resolve({ cancelled: true });
       setPendingMenu(null);
+    }
+    if (pendingMultiMenu) {
+      pendingMultiMenu.resolve({ cancelled: true });
+      setPendingMultiMenu(null);
     }
     if (pendingGrid) {
       pendingGrid.resolve({ cancelled: true });
@@ -2251,15 +2280,10 @@ export function App({
         continue;
       }
 
-      // Choice question; append an "Other" escape hatch if requested.
-      // Models often include their own "Other" entry despite the tool
-      // description (#230) — when they do, skip the duplicate and treat
-      // the model's entry as the escape hatch instead.
-      const otherLabel = q.otherLabel?.trim() || 'Other (type your own)';
-      const entries: MenuEntry[] = q.choices.map((c) => ({ label: c }));
-      const hasModelOther = q.choices.some((c) => OTHER_RE.test(c.trim()));
-      const appendedHatch = q.allowOther && !hasModelOther;
-      if (appendedHatch) entries.push({ label: otherLabel });
+      // Choice question. `buildChoiceMenu` appends an "Other" escape hatch when
+      // requested and dedupes against a model-supplied "Other" entry (#230);
+      // `isHatch` tells whether a picked row routes to free-text.
+      const { entries, isHatch } = buildChoiceMenu(q);
 
       // Multi-select question (#231): toggle a checkbox set, commit at once.
       // The answer is the array of chosen labels; an "Other"-shaped pick still
@@ -2267,16 +2291,8 @@ export function App({
       if (q.multiSelect) {
         const result = await requestMultiMenu(entries, { title: q.question });
         if (result.cancelled) return { cancelled: true, answered: answers };
-        const picked: string[] = [];
-        let pickedHatch = false;
-        for (const item of result.items) {
-          const isHatch =
-            (appendedHatch && entries.indexOf(item) === entries.length - 1) ||
-            OTHER_RE.test(item.label.trim());
-          if (isHatch) pickedHatch = true;
-          else picked.push(item.label);
-        }
-        if (pickedHatch) {
+        const picked = result.items.filter((item) => !isHatch(item)).map((item) => item.label);
+        if (result.items.some(isHatch)) {
           const free = await requestTextInput({ label: q.question });
           if (free.cancelled) return { cancelled: true, answered: answers };
           const typed = free.raw.trim();
@@ -2289,10 +2305,7 @@ export function App({
       const result = await requestMenu(entries, { title: q.question });
       if (result.cancelled) return { cancelled: true, answered: answers };
 
-      const pickedHatch =
-        (appendedHatch && result.index === entries.length - 1) ||
-        OTHER_RE.test(result.item.label.trim());
-      if (pickedHatch) {
+      if (isHatch(result.item)) {
         // User picked "Other" — gather free-form text.
         const free = await requestTextInput({ label: q.question });
         if (free.cancelled) return { cancelled: true, answered: answers };
@@ -2366,7 +2379,6 @@ export function App({
           multiSelect
           entries={pendingMultiMenu.entries}
           options={pendingMultiMenu.options}
-          onSelect={() => {}}
           onMultiSelect={(items) => {
             pendingMultiMenu.resolve({ cancelled: false, items });
             setPendingMultiMenu(null);

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -509,3 +509,84 @@ describe('<App> requestAskUser "Other" dedup (#230)', () => {
     unmount();
   });
 });
+
+describe('<App> requestAskUser multi-select (#231)', () => {
+  beforeEach(() => {
+    process.env.BERNARD_HOME = TMP_HOME;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes a multiSelect question to a checkbox menu and returns the chosen labels as an array', async () => {
+    const { stdin, lastFrame, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      {
+        question: 'Any must-haves?',
+        choices: ['Bunkhouse', 'Outdoor kitchen', 'Washer/dryer'],
+        allowOther: false,
+        multiSelect: true,
+      },
+    ]);
+    await tick(40);
+    const frame = lastFrame()!;
+    expect(frame).toContain('Any must-haves?');
+    expect(frame).toContain('[ ] 1. Bunkhouse');
+    expect(frame).toContain('Space toggle');
+    // toggle items 1 and 3, then commit
+    stdin.write('1');
+    await tick();
+    stdin.write('3');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: [['Bunkhouse', 'Washer/dryer']] });
+    unmount();
+  });
+
+  it('routes a toggled "Other" to free text and appends it to the array', async () => {
+    const { stdin, lastFrame, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      { question: 'Pick features', choices: ['A', 'B'], allowOther: true, multiSelect: true },
+    ]);
+    await tick(40);
+    expect(lastFrame()).toContain('Other (type your own)');
+    // toggle A (1) and the appended Other hatch (3), then commit
+    stdin.write('1');
+    await tick();
+    stdin.write('3');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    // menu replaced by free-text input
+    expect(lastFrame()).not.toContain('[ ] 1. A');
+    stdin.write('custom feature');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: [['A', 'custom feature']] });
+    unmount();
+  });
+
+  it('keeps index alignment when a batch mixes multi-select and single-select questions', async () => {
+    const { stdin, unmount } = renderApp();
+    await tick();
+    const pending = getInkHandlers()!.requestAskUser([
+      { question: 'Multi', choices: ['A', 'B'], allowOther: false, multiSelect: true },
+      { question: 'Single', choices: ['X', 'Y'], allowOther: false },
+    ]);
+    await tick(40);
+    // multi: toggle A then commit
+    stdin.write('1');
+    await tick();
+    stdin.write(ENTER);
+    await tick(40);
+    // single: pick Y
+    stdin.write('2');
+    await tick(40);
+    await expect(pending).resolves.toEqual({ answers: [['A'], 'Y'] });
+    unmount();
+  });
+});

--- a/src/ui/__tests__/MenuOverlay.test.tsx
+++ b/src/ui/__tests__/MenuOverlay.test.tsx
@@ -160,19 +160,17 @@ function mountMulti(opts?: {
   onMultiSelect?: ReturnType<typeof vi.fn>;
   onCancel?: ReturnType<typeof vi.fn>;
 }) {
-  const onSelect = vi.fn();
   const onMultiSelect = opts?.onMultiSelect ?? vi.fn();
   const onCancel = opts?.onCancel ?? vi.fn();
   const harness = render(
     createElement(MenuOverlay, {
       entries: opts?.entries ?? MULTI_ENTRIES,
       multiSelect: true,
-      onSelect,
       onMultiSelect,
       onCancel,
     }),
   );
-  return { ...harness, onSelect, onMultiSelect, onCancel };
+  return { ...harness, onMultiSelect, onCancel };
 }
 
 describe('<MenuOverlay> multi-select (#231)', () => {
@@ -243,5 +241,23 @@ describe('<MenuOverlay> multi-select (#231)', () => {
     await tick();
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onMultiSelect).not.toHaveBeenCalled();
+  });
+
+  it('Enter falls back to onCancel when onMultiSelect is missing (defensive)', async () => {
+    // The props type requires onMultiSelect in multi mode; this guards an
+    // untyped JS caller that forgot it, so Enter can never strand the overlay.
+    const onCancel = vi.fn();
+    const harness = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createElement(MenuOverlay, {
+        entries: MULTI_ENTRIES,
+        multiSelect: true,
+        onCancel,
+      } as any),
+    );
+    await tick();
+    harness.stdin.write(ENTER);
+    await tick();
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/__tests__/MenuOverlay.test.tsx
+++ b/src/ui/__tests__/MenuOverlay.test.tsx
@@ -3,7 +3,7 @@ import { render } from 'ink-testing-library';
 import { createElement } from 'react';
 import { MenuOverlay } from '../overlays/MenuOverlay.js';
 import type { MenuEntry } from '../menu-types.js';
-import { ESC, ENTER, ARROW_UP, ARROW_DOWN, CTRL_C, tick } from './_keys.js';
+import { ESC, ENTER, ARROW_UP, ARROW_DOWN, CTRL_C, SPACE, tick } from './_keys.js';
 
 const ENTRIES: MenuEntry[] = [
   { type: 'section', title: 'Built-in' },
@@ -150,5 +150,98 @@ describe('<MenuOverlay>', () => {
     expect(qIdx).toBeGreaterThanOrEqual(0);
     expect(qIdx).toBeLessThan(titleIdx);
     expect(titleIdx).toBeLessThan(itemIdx);
+  });
+});
+
+const MULTI_ENTRIES: MenuEntry[] = [{ label: 'A' }, { label: 'B' }, { label: 'C' }];
+
+function mountMulti(opts?: {
+  entries?: MenuEntry[];
+  onMultiSelect?: ReturnType<typeof vi.fn>;
+  onCancel?: ReturnType<typeof vi.fn>;
+}) {
+  const onSelect = vi.fn();
+  const onMultiSelect = opts?.onMultiSelect ?? vi.fn();
+  const onCancel = opts?.onCancel ?? vi.fn();
+  const harness = render(
+    createElement(MenuOverlay, {
+      entries: opts?.entries ?? MULTI_ENTRIES,
+      multiSelect: true,
+      onSelect,
+      onMultiSelect,
+      onCancel,
+    }),
+  );
+  return { ...harness, onSelect, onMultiSelect, onCancel };
+}
+
+describe('<MenuOverlay> multi-select (#231)', () => {
+  it('renders empty checkboxes and the multi-select footer hint', () => {
+    const { lastFrame } = mountMulti();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('[ ] 1. A');
+    expect(frame).toContain('[ ] 2. B');
+    expect(frame).toContain('Space toggle');
+    expect(frame).toContain('Enter confirm');
+  });
+
+  it('Space toggles the highlighted row without committing', async () => {
+    const { stdin, lastFrame, onMultiSelect, onCancel } = mountMulti();
+    await tick();
+    stdin.write(SPACE);
+    await tick();
+    expect(lastFrame() ?? '').toContain('[x] 1. A');
+    expect(onMultiSelect).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    // toggling again clears it
+    stdin.write(SPACE);
+    await tick();
+    expect(lastFrame() ?? '').toContain('[ ] 1. A');
+  });
+
+  it('a digit toggles the matching row instead of committing', async () => {
+    const { stdin, lastFrame, onMultiSelect } = mountMulti();
+    await tick();
+    stdin.write('2');
+    await tick();
+    expect(lastFrame() ?? '').toContain('[x] 2. B');
+    expect(lastFrame() ?? '').toContain('[ ] 1. A');
+    expect(onMultiSelect).not.toHaveBeenCalled();
+  });
+
+  it('Enter commits the checked set in row order', async () => {
+    const { stdin, onMultiSelect } = mountMulti();
+    await tick();
+    stdin.write('1');
+    await tick();
+    stdin.write('3');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onMultiSelect).toHaveBeenCalledTimes(1);
+    expect(onMultiSelect.mock.calls[0][0].map((i: { label: string }) => i.label)).toEqual([
+      'A',
+      'C',
+    ]);
+  });
+
+  it('Enter with nothing checked falls back to the highlighted row', async () => {
+    const { stdin, onMultiSelect } = mountMulti();
+    await tick();
+    stdin.write(ARROW_DOWN); // highlight row 2 (B)
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onMultiSelect).toHaveBeenCalledTimes(1);
+    expect(onMultiSelect.mock.calls[0][0].map((i: { label: string }) => i.label)).toEqual(['B']);
+  });
+
+  it('Esc still cancels in multi-select mode', async () => {
+    const { stdin, onCancel, onMultiSelect } = mountMulti();
+    await tick();
+    stdin.write(ESC);
+    await tick();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onMultiSelect).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/__tests__/_keys.ts
+++ b/src/ui/__tests__/_keys.ts
@@ -22,4 +22,6 @@ export const SHIFT_ENTER_CSIU = '\x1b[13;2u';
 export const META_ENTER = '\x1b\r';
 export const BACKSPACE = '';
 
+export const SPACE = ' ';
+
 export const tick = (ms = 10): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/ui/overlays/MenuOverlay.tsx
+++ b/src/ui/overlays/MenuOverlay.tsx
@@ -6,7 +6,8 @@ import type { MenuEntry, MenuItem, MenuOptions } from '../menu-types.js';
 interface MenuOverlayProps {
   entries: MenuEntry[];
   options?: MenuOptions;
-  onSelect: (index: number, item: MenuItem) => void;
+  /** Single-select commit. Optional because multi-select mode uses {@link onMultiSelect} instead. */
+  onSelect?: (index: number, item: MenuItem) => void;
   onCancel: () => void;
   /**
    * Optional external cancel signal. The legacy `selectFromMenu` accepts one
@@ -92,13 +93,17 @@ export function MenuOverlay({
       if (multiSelect) {
         // Commit the checked set in row order; fall back to the highlighted row
         // when nothing is checked so Enter is never a no-op.
-        const picked = items.filter((_, i) => checked.has(i));
-        const result = picked.length > 0 ? picked : items[highlight] ? [items[highlight]] : [];
-        onMultiSelect?.(result);
+        const picked =
+          checked.size > 0
+            ? items.filter((_, i) => checked.has(i))
+            : items[highlight]
+              ? [items[highlight]]
+              : [];
+        onMultiSelect?.(picked);
         return;
       }
       const item = items[highlight];
-      if (item) onSelect(highlight, item);
+      if (item) onSelect?.(highlight, item);
       return;
     }
     if (key.upArrow) {
@@ -120,7 +125,7 @@ export function MenuOverlay({
         // In multi-select a digit toggles that row's checkbox; in single-select
         // it commits immediately (unchanged behavior).
         if (multiSelect) toggle(idx);
-        else onSelect(idx, items[idx]);
+        else onSelect?.(idx, items[idx]);
       }
     }
   });

--- a/src/ui/overlays/MenuOverlay.tsx
+++ b/src/ui/overlays/MenuOverlay.tsx
@@ -16,6 +16,16 @@ interface MenuOverlayProps {
    * mid-turn.
    */
   signal?: AbortSignal;
+  /**
+   * Multi-select mode ("select all that apply"). When true, Space and digits
+   * toggle a per-row checkbox instead of committing, and Enter commits the
+   * whole checked set via {@link onMultiSelect} (falling back to the
+   * highlighted row when nothing is checked). When false/absent the overlay is
+   * the unchanged single-select menu. Issue #231.
+   */
+  multiSelect?: boolean;
+  /** Commit callback for multi-select mode — receives the checked items in row order. */
+  onMultiSelect?: (items: MenuItem[]) => void;
 }
 
 function isSection(entry: MenuEntry): entry is { type: 'section'; title: string } {
@@ -35,10 +45,28 @@ function isSection(entry: MenuEntry): entry is { type: 'section'; title: string 
  * items, never selectable. `options.headerLines` renders above the title so
  * the `ask_user` tab strip continues to work unchanged.
  */
-export function MenuOverlay({ entries, options, onSelect, onCancel, signal }: MenuOverlayProps) {
+export function MenuOverlay({
+  entries,
+  options,
+  onSelect,
+  onCancel,
+  signal,
+  multiSelect = false,
+  onMultiSelect,
+}: MenuOverlayProps) {
   const colors = getThemeColors();
   const items = entries.filter((e): e is MenuItem => !isSection(e));
   const [highlight, setHighlight] = useState(0);
+  // Set of *item* indices (sections excluded) currently checked. Multi-select only.
+  const [checked, setChecked] = useState<Set<number>>(() => new Set());
+
+  const toggle = (idx: number) =>
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
 
   useEffect(() => {
     if (!signal) return;
@@ -61,6 +89,14 @@ export function MenuOverlay({ entries, options, onSelect, onCancel, signal }: Me
       return;
     }
     if (key.return) {
+      if (multiSelect) {
+        // Commit the checked set in row order; fall back to the highlighted row
+        // when nothing is checked so Enter is never a no-op.
+        const picked = items.filter((_, i) => checked.has(i));
+        const result = picked.length > 0 ? picked : items[highlight] ? [items[highlight]] : [];
+        onMultiSelect?.(result);
+        return;
+      }
       const item = items[highlight];
       if (item) onSelect(highlight, item);
       return;
@@ -73,9 +109,19 @@ export function MenuOverlay({ entries, options, onSelect, onCancel, signal }: Me
       setHighlight((h) => Math.min(items.length - 1, h + 1));
       return;
     }
+    // Space toggles the highlighted row in multi-select mode (no-op otherwise).
+    if (multiSelect && input === ' ') {
+      toggle(highlight);
+      return;
+    }
     if (/^[1-9]$/.test(input)) {
       const idx = parseInt(input, 10) - 1;
-      if (idx < items.length) onSelect(idx, items[idx]);
+      if (idx < items.length) {
+        // In multi-select a digit toggles that row's checkbox; in single-select
+        // it commits immediately (unchanged behavior).
+        if (multiSelect) toggle(idx);
+        else onSelect(idx, items[idx]);
+      }
     }
   });
 
@@ -93,14 +139,28 @@ export function MenuOverlay({ entries, options, onSelect, onCancel, signal }: Me
           <Text> </Text>
         </>
       )}
-      <MenuList entries={entries} highlight={highlight} />
+      <MenuList entries={entries} highlight={highlight} multiSelect={multiSelect} checked={checked} />
       <Text> </Text>
-      <Text dimColor>↑/↓ move · Enter select · Esc cancel</Text>
+      <Text dimColor>
+        {multiSelect
+          ? '↑/↓ move · Space toggle · Enter confirm · Esc cancel'
+          : '↑/↓ move · Enter select · Esc cancel'}
+      </Text>
     </Box>
   );
 }
 
-function MenuList({ entries, highlight }: { entries: MenuEntry[]; highlight: number }) {
+function MenuList({
+  entries,
+  highlight,
+  multiSelect = false,
+  checked,
+}: {
+  entries: MenuEntry[];
+  highlight: number;
+  multiSelect?: boolean;
+  checked?: Set<number>;
+}) {
   const colors = getThemeColors();
   let itemIndex = 0;
   return (
@@ -119,7 +179,8 @@ function MenuList({ entries, highlight }: { entries: MenuEntry[]; highlight: num
         const activeMarker = entry.active ? ' (active)' : '';
         const annotation = entry.annotation ? ` ${entry.annotation}` : '';
         const isHighlighted = myIndex === highlight;
-        const label = `${n}. ${entry.label}${activeMarker}${annotation}`;
+        const checkbox = multiSelect ? `${checked?.has(myIndex) ? '[x]' : '[ ]'} ` : '';
+        const label = `${checkbox}${n}. ${entry.label}${activeMarker}${annotation}`;
         return (
           <Box key={`i-${idx}`} flexDirection="column">
             <Box>

--- a/src/ui/overlays/MenuOverlay.tsx
+++ b/src/ui/overlays/MenuOverlay.tsx
@@ -3,11 +3,9 @@ import { Box, Text, useInput } from 'ink';
 import { getThemeColors } from '../../theme.js';
 import type { MenuEntry, MenuItem, MenuOptions } from '../menu-types.js';
 
-interface MenuOverlayProps {
+interface MenuOverlayBaseProps {
   entries: MenuEntry[];
   options?: MenuOptions;
-  /** Single-select commit. Optional because multi-select mode uses {@link onMultiSelect} instead. */
-  onSelect?: (index: number, item: MenuItem) => void;
   onCancel: () => void;
   /**
    * Optional external cancel signal. The legacy `selectFromMenu` accepts one
@@ -17,17 +15,35 @@ interface MenuOverlayProps {
    * mid-turn.
    */
   signal?: AbortSignal;
-  /**
-   * Multi-select mode ("select all that apply"). When true, Space and digits
-   * toggle a per-row checkbox instead of committing, and Enter commits the
-   * whole checked set via {@link onMultiSelect} (falling back to the
-   * highlighted row when nothing is checked). When false/absent the overlay is
-   * the unchanged single-select menu. Issue #231.
-   */
-  multiSelect?: boolean;
-  /** Commit callback for multi-select mode — receives the checked items in row order. */
-  onMultiSelect?: (items: MenuItem[]) => void;
 }
+
+/**
+ * Single- vs multi-select is a discriminated union so the right commit callback
+ * is required by the type: `multiSelect: true` demands `onMultiSelect` (and
+ * forbids `onSelect`); the default single-select mode uses `onSelect`. This
+ * makes "set multiSelect but forget onMultiSelect" unrepresentable.
+ */
+type MenuOverlayProps = MenuOverlayBaseProps &
+  (
+    | {
+        multiSelect?: false;
+        /** Single-select commit — receives the highlighted/picked row. */
+        onSelect?: (index: number, item: MenuItem) => void;
+        onMultiSelect?: never;
+      }
+    | {
+        /**
+         * Multi-select mode ("select all that apply"). Space and digits toggle a
+         * per-row checkbox instead of committing; Enter commits the whole checked
+         * set via {@link onMultiSelect} (falling back to the highlighted row when
+         * nothing is checked). Issue #231.
+         */
+        multiSelect: true;
+        /** Commit callback for multi-select mode — receives the checked items in row order. */
+        onMultiSelect: (items: MenuItem[]) => void;
+        onSelect?: never;
+      }
+  );
 
 function isSection(entry: MenuEntry): entry is { type: 'section'; title: string } {
   return 'type' in entry && entry.type === 'section';
@@ -99,7 +115,11 @@ export function MenuOverlay({
             : items[highlight]
               ? [items[highlight]]
               : [];
-        onMultiSelect?.(picked);
+        // The discriminated-union props type requires onMultiSelect in
+        // multi-select mode; the fallback is belt-and-suspenders for untyped JS
+        // callers so a missing handler can never strand the overlay.
+        if (onMultiSelect) onMultiSelect(picked);
+        else onCancel();
         return;
       }
       const item = items[highlight];


### PR DESCRIPTION
## Summary

Closes #231. When the agent phrases an `ask_user` question as a multi-pick ("Any must-have for dogs? 1. Bunkhouse 2. Outdoor kitchen …"), the menu was **single-select** — the user could commit only one row, so the agent silently lost the rest of their preferences (or had to re-ask one at a time). This adds **opt-in multi-select**.

A question can now set `multi_select: true`; the menu then lets the user toggle a checkbox on each choice (Space / digit) and commit the whole checked set with Enter. That question's answer comes back as a `string[]`, index-aligned with the questions array.

```
Any must-haves?
> [x] 1. Bunkhouse
  [ ] 2. Outdoor kitchen
  [x] 3. Washer/dryer
↑/↓ move · Space toggle · Enter confirm · Esc cancel
```

## Changes

- **`src/tools/ask-user.ts` / `src/tools/types.ts`** — add `multi_select` to the per-question schema (normalized to `multiSelect`, only meaningful with `choices`); widen `AskUserBatchResult` `answers`/`answered` from `string[]` to `(string | string[])[]` so a multi-select slot contributes an array while every other question stays a plain string.
- **`src/ui/overlays/MenuOverlay.tsx`** — new multi-select mode: Space toggles the highlighted row, digits 1-9 toggle instead of commit, Enter commits the checked set (falls back to the highlighted row when nothing is checked), rows render `[x]`/`[ ]`, footer hint updates. **Single-select behavior is byte-for-byte unchanged.**
- **`src/ui/App.tsx`** — isolate the new path with a parallel `requestMultiMenu` + `PendingMultiMenu` + a `'multi-menu'` overlay variant that re-renders the same `<MenuOverlay>` in multi mode, so the heavily-used single-select `requestMenu`/`PendingMenu` contract is untouched (zero regression surface). In `requestAskUser`, `multiSelect` questions route through it; an "Other"-shaped toggle still routes to a free-text follow-up and appends the typed string — **preserving the #230 "Other" dedup behavior** in multi mode.

## Tests

- **MenuOverlay** — checkbox render + footer hint; Space toggles without committing; digit toggles the matching row; Enter commits the checked set in row order; Enter with nothing checked falls back to the highlighted row; Esc still cancels.
- **App `requestAskUser`** — a `multiSelect` question routes to the checkbox menu and resolves `{ answers: [['Bunkhouse','Washer/dryer']] }`; a toggled "Other" routes to free text and appends it; a mixed single+multi batch keeps index alignment (`{ answers: [['A'], 'Y'] }`).
- **ask-user schema** — `multi_select` normalization (true with choices → `multiSelect`, ignored for free-form).

`npm run build` clean; full suite green (**2756 passed**).

## Notes

Headless callers are unaffected (`ask_user` still returns `{unavailable: true}` with no interactive user). The tool's description mentions a tab strip that doesn't actually exist in the implementation — that's a pre-existing doc gap, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)