### PR TITLE
chore(license): relicense from MIT to PolyForm Noncommercial 1.0.0 (#209)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,133 @@
-MIT License
+# PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2025 phillt
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Required Notice: Copyright 2025 phillt (Felipe Tadeo)
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Acceptance
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -963,4 +963,17 @@ Bernard uses the [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers
 
 ## License
 
-MIT
+Bernard is licensed under the [PolyForm Noncommercial License 1.0.0](./LICENSE).
+
+**You may** use, copy, modify, fork, and share Bernard for any **noncommercial**
+purpose — personal projects, hobby use, research, experimentation, and use by
+nonprofits, schools, and government bodies.
+
+**You may not** use Bernard for commercial purposes. Commercial or for-profit
+use requires a separate commercial license.
+
+**Commercial licensing:** contact **contact@felipetadeo.dev**.
+
+> Note: PolyForm Noncommercial is a _source-available_ license, not an
+> OSI-approved open source license — the noncommercial restriction is
+> intentional.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "bernard-agent",
       "version": "0.9.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.1.0",
         "@ai-sdk/mcp": "^1.0.19",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://phillt.github.io/bernard/",
   "author": "phillt",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "cli",
     "ai",


### PR DESCRIPTION
Closes #209.

## What & why

Bernard shipped under the **MIT license**, which permits commercial use — the opposite of the project's intent. The goal: free for **personal/hobby/research use and forking**, but **commercial use prohibited** (monetized via a separate commercial license).

This relicenses the repo to **PolyForm Noncommercial 1.0.0** — a software-focused, source-available license with a clear noncommercial grant and a patent grant. It is a **deliberate non-OSI** license; the noncommercial restriction conflicts with OSI's "no field-of-use restrictions" criterion by design.

## Changes
- **`LICENSE`** — verbatim PolyForm Noncommercial 1.0.0 text + a `Required Notice:` line naming the licensor.
- **`package.json` / `package-lock.json`** (root only) — `license` → `PolyForm-Noncommercial-1.0.0` (valid SPDX id; dependency entries untouched).
- **`README.md`** — License section rewritten with a plain-English permitted/prohibited summary and the commercial-licensing contact (`contact@felipetadeo.dev`).

## Why PolyForm over the alternatives
- **CC BY-NC 4.0** — built for creative works, not software; ambiguous for code, no patent grant.
- **BSL 1.1** — restricts *production* use until a Change Date, then auto-opens; models "non-production," not "noncommercial," and adds config overhead. We don't want an eventual open-source conversion.
- **PolyForm Noncommercial** — purpose-built for software, explicit noncommercial permitted-purposes (personal/hobby/research + nonprofits/edu/gov), includes a patent grant.

## Verification
- `node -e "console.log(require('./package.json').license)"` → `PolyForm-Noncommercial-1.0.0`
- `npm pack --dry-run` → includes `LICENSE` (4.6kB), no SPDX warning
- No stray `MIT` left in first-party `*.json` / `*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)