### PR TITLE
fix(context): route window math through lineup-resolved main model (#233)

### DIFF
--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -18,6 +18,7 @@ import { MemoryStore } from './memory.js';
 import { printWarning, printInfo } from './output.js';
 import { getModelProfile } from './providers/index.js';
 import { assembleContext } from './framework/context.js';
+import * as modelPolicy from './model-policy.js';
 import { setOutputSink } from './framework/hooks/output-sink.js';
 
 vi.mock('node:fs', () => ({
@@ -852,6 +853,38 @@ describe('Agent', () => {
     await agent.processInput('Hello');
 
     expect(emergencyTruncate).toHaveBeenCalled();
+  });
+
+  it('window math uses the lineup-resolved main model, not the stale config.model base (#233)', async () => {
+    const { shouldCompress, getContextWindow } = await import('./context.js');
+    // Simulate an active lineup re-tiering `main` to a different model than the
+    // profile's base `config.model` (e.g. xAI base + OpenAI lineup).
+    const spy = vi.spyOn(modelPolicy, 'resolveMainModel').mockReturnValue('lineup-resolved-main');
+
+    mockGenerateText.mockResolvedValue({
+      response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
+      usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+    });
+
+    // Base field is deliberately different from the resolved main model.
+    const agent = makeAgent(makeConfig({ model: 'grok-4-fast-non-reasoning' }), toolOptions, store);
+    await agent.processInput('Hello');
+
+    // Both the compression preflight and the emergency-truncation window lookup
+    // must see the resolved main model, never the stale base field.
+    expect(shouldCompress).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      'lineup-resolved-main',
+      expect.anything(),
+    );
+    expect(getContextWindow).toHaveBeenCalledWith('lineup-resolved-main', expect.anything());
+    expect(getContextWindow).not.toHaveBeenCalledWith(
+      'grok-4-fast-non-reasoning',
+      expect.anything(),
+    );
+
+    spy.mockRestore();
   });
 
   it('catch-and-retry triggers on token overflow error', async () => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -25,6 +25,7 @@ import {
   isTokenOverflowError,
   getContextWindow,
 } from './context.js';
+import { resolveMainModel } from './model-policy.js';
 import type { BernardConfig } from './config.js';
 import type { MemoryStore } from './memory.js';
 import type { RAGStore, RAGSearchResult } from './rag.js';
@@ -385,6 +386,17 @@ export class Agent {
     this.ctx.provenance.clear();
 
     try {
+      // Resolve the model we're actually talking to for this turn (lineup +
+      // model-mode aware), not the stale `config.model` base field (#233).
+      // Refresh the spinner/status-gauge denominator here so mid-session
+      // `/model` / `/lineups` / `/profiles` switches take effect next turn —
+      // the App.tsx mount-seed only fires once.
+      const mainModel = resolveMainModel(this.config);
+      if (this.spinnerStats) {
+        this.spinnerStats.model = mainModel;
+        this.spinnerStats.contextWindowOverride = this.config.tokenWindow || undefined;
+      }
+
       // Check if context compression is needed
       const imageTokens = images ? images.length * IMAGE_TOKEN_ESTIMATE : 0;
       const newMessageEstimate = Math.ceil(wrappedInput.length / 4) + imageTokens;
@@ -392,7 +404,7 @@ export class Agent {
         shouldCompress(
           this.lastPromptTokens,
           newMessageEstimate,
-          this.config.model,
+          mainModel,
           this.config.tokenWindow,
         )
       ) {
@@ -463,7 +475,7 @@ export class Agent {
       const systemForEstimate = buildMainSystemPrompt(this.ctx, inputBase, profile);
       const input: MainInput = { ...inputBase, systemPrompt: systemForEstimate };
       const HARD_LIMIT_RATIO = 0.9;
-      const contextWindow = getContextWindow(this.config.model, this.config.tokenWindow);
+      const contextWindow = getContextWindow(mainModel, this.config.tokenWindow);
       // The per-turn `<system_provided_context>` message is no longer in the
       // SYSTEM prompt (issue #172) — account for it separately in the
       // preflight estimate so token budgeting stays accurate.

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -186,6 +186,30 @@ describe('resolveSiteModel — xai lineup', () => {
   });
 });
 
+describe('resolveMainModel (#233)', () => {
+  it('returns the same model name as resolveSiteModel(config, "main")', async () => {
+    const { resolveMainModel, resolveSiteModel } = await loadModule();
+    const config = makeConfig({ modelMode: 'balanced' });
+    expect(resolveMainModel(config)).toBe(resolveSiteModel(config, 'main').modelName);
+    expect(resolveMainModel(config)).toBe('claude-opus-4-6');
+  });
+
+  it('tracks the active lineup, not the stale config.model base field', async () => {
+    // The bug scenario: base fields still point at a large-window xAI model
+    // while an OpenAI-only optimize-performance lineup re-tiers main to gpt-5.2.
+    // Window math must follow the lineup, not config.model.
+    const { resolveMainModel } = await loadModule();
+    const config = makeConfig({
+      provider: 'xai',
+      model: 'grok-4-fast-non-reasoning',
+      activeLineupId: 'openai',
+      modelMode: 'optimize-performance',
+    });
+    expect(resolveMainModel(config)).toBe('gpt-5.2');
+    expect(resolveMainModel(config)).not.toBe(config.model);
+  });
+});
+
 describe('resolveSiteModel — precedence', () => {
   it('invocation override beats policy tier', async () => {
     const { resolveSiteModel } = await loadModule();

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -254,6 +254,17 @@ export function resolveSiteModel(
 }
 
 /**
+ * Model-name string for the `'main'` LLM call site, resolved through the
+ * active lineup + model-mode policy. Use this anywhere context-window /
+ * compression math needs the model Bernard is actually talking to — the
+ * legacy `config.model` base field is only a fallback and goes stale the
+ * moment a lineup re-tiers `main` to a different provider/model (#233).
+ */
+export function resolveMainModel(config: BernardConfig): string {
+  return resolveSiteModel(config, 'main').modelName;
+}
+
+/**
  * Loads the active lineup once per call. Cheap — `loadLineups()` is a
  * single small JSON read; we don't memoize so a `/lineup` edit takes effect
  * on the next turn without process restart.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -83,7 +83,7 @@ import {
 import { runDefinition } from '../framework/agents/run.js';
 import { taskDefinition, type TaskInput } from '../framework/agents/task.js';
 import { generateText } from 'ai';
-import { resolveSiteModel, logSiteModelSnapshot } from '../model-policy.js';
+import { resolveSiteModel, resolveMainModel, logSiteModelSnapshot } from '../model-policy.js';
 import { serializeMessages, extractDomainFacts, SUMMARIZATION_PROMPT } from '../context.js';
 import { detectSpecialistCandidate } from '../specialist-detector.js';
 import { promoteCandidate } from '../candidate-bootstrap.js';
@@ -473,7 +473,7 @@ export function App({
         totalPromptTokens: 0,
         totalCompletionTokens: 0,
         latestPromptTokens: 0,
-        model: config.model,
+        model: resolveMainModel(config),
         contextWindowOverride: config.tokenWindow || undefined,
       });
     }
@@ -1233,10 +1233,11 @@ export function App({
       saveOption(name, val);
       (config as unknown as Record<string, unknown>)[opt.configKey] = val;
       if (name === 'token-window') {
-        const modelWindow = getContextWindow(config.model);
+        const mainModel = resolveMainModel(config);
+        const modelWindow = getContextWindow(mainModel);
         if (val > modelWindow) {
           flashToast(
-            `Set ${name} = ${val} (warning: exceeds ${config.model}'s context window ${modelWindow})`,
+            `Set ${name} = ${val} (warning: exceeds ${mainModel}'s context window ${modelWindow})`,
             'warning',
           );
           return;


### PR DESCRIPTION
Closes #233.

## Problem
All context-window / compression math read the legacy `config.model` base field instead of the **lineup-resolved main-site model**. When a lineup is active (e.g. an OpenAI `optimize-performance` lineup → `gpt-5.2`, ~400k window) while the profile base still holds a different model (e.g. `xai grok-4-fast`, ~2M window), the window denominator is wrong:

- **Compression preflight** budgets against the wrong window → compression fires far too late (risking a hard API context-overflow) or too early.
- **Status-bar gauge** + the `/options` token-window warning show the wrong fullness/limit.
- `spinnerStats.model` was seeded **once at mount** and never refreshed, so a mid-session `/model` / `/lineups` / `/profiles` switch left the gauge stale.

## Fix
- **New `resolveMainModel(config)`** (`src/model-policy.ts`) — thin wrapper over the existing `resolveSiteModel(config, 'main').modelName`; single source of truth for "the model we're actually talking to."
- **`src/agent.ts`** (`processInput`) — resolve the main model once, refresh `spinnerStats.model` + `contextWindowOverride` **per turn**, and pass it to `shouldCompress` and `getContextWindow`.
- **`src/ui/App.tsx`** — seed the status-bar gauge from `resolveMainModel(config)`, and use it (label + number) for the token-window override warning.
- `StatusBar.tsx` / `output.ts` read `stats.model` and are fixed automatically by the seed + per-turn refresh — no edits needed.

## Out of scope
- Save-path / display readers of `config.model` (the profile **base** field) are intentionally left as-is.
- `bernard-1-0-0` has **pre-existing** lint/format debt unrelated to this change; this PR adds **no new** lint or prettier violations (verified on every touched file) and does not reformat the pre-existing debt.

## Verification
- `npm test` → **2760 passed** (2757 + 3 new).
- New tests: `resolveMainModel` no-lineup fallback + active-lineup re-tier (`model-policy.test.ts`); agent-layer wiring test asserting the window-math calls receive the resolved main model and **not** the stale base (`agent.test.ts`).
- `npm run build` clean; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)