### PR TITLE
fix(ui): per-turn token ↑/↓ readout + reset the bar on /clear & /compact (#234)

### DIFF
--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -15,7 +15,7 @@ import {
 import { buildContextMessage } from './context-message.js';
 import type { BernardConfig } from './config.js';
 import { MemoryStore } from './memory.js';
-import { printWarning, printInfo } from './output.js';
+import { printWarning, printInfo, type SpinnerStats } from './output.js';
 import { getModelProfile } from './providers/index.js';
 import { assembleContext } from './framework/context.js';
 import * as modelPolicy from './model-policy.js';
@@ -134,6 +134,17 @@ function makeAgent(
     alertContext: opts.alertContext,
     initialHistory: opts.initialHistory,
   });
+}
+
+function makeSpinnerStats(over: Partial<SpinnerStats> = {}): SpinnerStats {
+  return {
+    startTime: 0,
+    turnPromptTokens: 0,
+    turnCompletionTokens: 0,
+    latestPromptTokens: 0,
+    model: 'claude-sonnet-4-5-20250929',
+    ...over,
+  };
 }
 
 describe('buildSystemPrompt', () => {
@@ -1255,6 +1266,62 @@ describe('Agent', () => {
 
       const agent = makeAgent(makeConfig(), toolOptions, store);
       await expect(agent.compactHistory()).rejects.toThrow('LLM down');
+    });
+
+    it('drops the status-bar gauge to the post-compaction size immediately (#234)', async () => {
+      const { compressHistory, estimateHistoryTokens } = await import('./context.js');
+      const compressedHistory = [{ role: 'user' as const, content: 'summary' }];
+      vi.mocked(compressHistory).mockResolvedValueOnce(compressedHistory);
+      vi.mocked(estimateHistoryTokens).mockReturnValue(1234);
+
+      mockGenerateText.mockResolvedValue({
+        response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
+        usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+      });
+
+      const agent = makeAgent(makeConfig(), toolOptions, store);
+      const stats = makeSpinnerStats({ latestPromptTokens: 99_999 });
+      agent.setSpinnerStats(stats);
+      await agent.processInput('Hello');
+
+      await agent.compactHistory();
+      expect(stats.latestPromptTokens).toBe(1234);
+    });
+  });
+
+  describe('token-readout resets (#234)', () => {
+    it('zeroes the per-turn ↑/↓ odometer at the top of each turn', async () => {
+      mockGenerateText.mockResolvedValue({
+        response: { messages: [{ role: 'assistant', content: 'Hi!' }] },
+        usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+      });
+      const agent = makeAgent(makeConfig(), toolOptions, store);
+      const stats = makeSpinnerStats({ turnPromptTokens: 8_000, turnCompletionTokens: 400 });
+      agent.setSpinnerStats(stats);
+
+      await agent.processInput('Hello');
+
+      // The mocked generateText never fires onStepFinish, so the only movement is
+      // the per-turn reset — proving the readout is scoped to this turn, not the
+      // session.
+      expect(stats.turnPromptTokens).toBe(0);
+      expect(stats.turnCompletionTokens).toBe(0);
+    });
+
+    it('clearHistory empties the bar + odometer and compression-headroom fields', () => {
+      const agent = makeAgent(makeConfig(), toolOptions, store);
+      const stats = makeSpinnerStats({
+        latestPromptTokens: 50_000,
+        turnPromptTokens: 8_000,
+        turnCompletionTokens: 400,
+      });
+      agent.setSpinnerStats(stats);
+
+      agent.clearHistory();
+
+      expect(stats.latestPromptTokens).toBe(0);
+      expect(stats.turnPromptTokens).toBe(0);
+      expect(stats.turnCompletionTokens).toBe(0);
     });
   });
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -282,6 +282,12 @@ export class Agent {
   /** Attaches a spinner stats object that will be updated with token usage during generation. */
   setSpinnerStats(stats: SpinnerStats): void {
     this.spinnerStats = stats;
+    // Expose this Agent (a TokenStatsTarget) on the shared context so
+    // `runDefinition` can route non-main dispatches' usage into the same
+    // per-turn odometer (#234). Set here — the moment the Agent is fully wired
+    // for interactive use — rather than at context-assembly time when
+    // spinnerStats is still null.
+    this.ctx.statsTarget = this;
   }
 
   /** Updates the alert context injected into the system prompt (e.g., specialist candidates). */
@@ -395,6 +401,13 @@ export class Agent {
       if (this.spinnerStats) {
         this.spinnerStats.model = mainModel;
         this.spinnerStats.contextWindowOverride = this.config.tokenWindow || undefined;
+        // Reset the per-turn ↑/↓ odometer at the start of every turn (#234).
+        // This single reset point is what makes the readout per-turn: this
+        // turn's main-agent steps AND any sub-agents / tool-wrappers / PAC
+        // phases it spawns then accumulate into a fresh zero via the token
+        // hooks (main: tokenStatsHook; non-main: tokenTotalsHook).
+        this.spinnerStats.turnPromptTokens = 0;
+        this.spinnerStats.turnCompletionTokens = 0;
       }
 
       // Check if context compression is needed
@@ -791,6 +804,14 @@ export class Agent {
       this.lastPromptTokens = estimateHistoryTokens(this.history);
     }
     const tokensAfter = estimateHistoryTokens(this.history);
+    // Drop the status-bar gauge to the new (smaller) context size immediately
+    // rather than waiting for the next turn to re-measure it (#234). The
+    // compression input `lastPromptTokens` is already updated above; this is the
+    // gauge's separate per-step field. The per-turn ↑/↓ odometer is left alone —
+    // compaction happens between turns and the next turn resets it.
+    if (compacted && this.spinnerStats) {
+      this.spinnerStats.latestPromptTokens = tokensAfter;
+    }
     return { compacted, tokensBefore, tokensAfter };
   }
 
@@ -816,6 +837,18 @@ export class Agent {
     this.ctx.postWriteChecks.length = 0;
     this.ctx.verificationTracker.clear();
     this.lastRubric = null;
+    // Reset token accounting so the status bar reflects the now-empty
+    // conversation the moment /clear finishes, instead of lingering on the old
+    // fullness until the next turn runs (#234). `lastPromptTokens` is the
+    // compression input (zeroing it avoids a spurious compaction on the first
+    // post-clear turn); `lastStepPromptTokens` is the gauge's per-step source.
+    this.lastPromptTokens = 0;
+    this.lastStepPromptTokens = 0;
+    if (this.spinnerStats) {
+      this.spinnerStats.latestPromptTokens = 0; // empty the bar
+      this.spinnerStats.turnPromptTokens = 0;
+      this.spinnerStats.turnCompletionTokens = 0;
+    }
     if (this.ctx.policyDecision) {
       this.ctx = { ...this.ctx, policyDecision: undefined };
     }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -839,9 +839,11 @@ export class Agent {
     this.lastRubric = null;
     // Reset token accounting so the status bar reflects the now-empty
     // conversation the moment /clear finishes, instead of lingering on the old
-    // fullness until the next turn runs (#234). `lastPromptTokens` is the
-    // compression input (zeroing it avoids a spurious compaction on the first
-    // post-clear turn); `lastStepPromptTokens` is the gauge's per-step source.
+    // fullness until the next turn runs (#234). `lastPromptTokens` and
+    // `lastStepPromptTokens` both feed compression headroom (the latter is the
+    // per-step prompt size the next compaction reads); zeroing them avoids a
+    // spurious compaction on the first post-clear turn. The gauge's own source,
+    // `spinnerStats.latestPromptTokens`, is emptied separately below.
     this.lastPromptTokens = 0;
     this.lastStepPromptTokens = 0;
     if (this.spinnerStats) {

--- a/src/framework/agents/__tests__/run.test.ts
+++ b/src/framework/agents/__tests__/run.test.ts
@@ -331,6 +331,76 @@ describe('runDefinition framework-default context injection (issue #143)', () =>
   });
 });
 
+describe('runDefinition per-turn token totals hook (#234)', () => {
+  function makeTarget() {
+    return {
+      lastStepPromptTokens: 0,
+      spinnerStats: {
+        startTime: 0,
+        turnPromptTokens: 0,
+        turnCompletionTokens: 0,
+        latestPromptTokens: 0,
+        model: 'claude-x',
+      },
+    };
+  }
+
+  // Drive the mocked generateText to invoke onStepFinish with a usage payload so
+  // any composed step hooks (the appended tokenTotalsHook) actually fire.
+  function mockStepWithUsage(usage: { promptTokens: number; completionTokens: number }) {
+    (generateText as unknown as ReturnType<typeof vi.fn>).mockImplementation(async (arg: any) => {
+      if (arg.onStepFinish) {
+        await arg.onStepFinish({
+          text: '',
+          toolCalls: [],
+          toolResults: [],
+          usage,
+          response: { messages: [] },
+        });
+      }
+      return { text: 'final answer', steps: [], response: { messages: [] }, finishReason: 'stop' };
+    });
+  }
+
+  it('non-main dispatch bumps the per-turn odometer but leaves gauge + headroom alone', async () => {
+    const target = makeTarget();
+    const ctx = makeCtx();
+    ctx.statsTarget = target as any;
+    mockStepWithUsage({ promptTokens: 200, completionTokens: 30 });
+
+    await runDefinition(ctx, fakeDefinition({ id: 'sub' }), { text: 'x' });
+
+    expect(target.spinnerStats.turnPromptTokens).toBe(200);
+    expect(target.spinnerStats.turnCompletionTokens).toBe(30);
+    // Sub-agent work must not move the main-only context gauge...
+    expect(target.spinnerStats.latestPromptTokens).toBe(0);
+    // ...nor the main agent's compression-headroom field.
+    expect(target.lastStepPromptTokens).toBe(0);
+  });
+
+  it('main dispatch does NOT get a second totals hook (no double count)', async () => {
+    const target = makeTarget();
+    const ctx = makeCtx();
+    ctx.statsTarget = target as any;
+    mockStepWithUsage({ promptTokens: 200, completionTokens: 30 });
+
+    // The fake 'main' def carries no hooks of its own, so if the gate let the
+    // totals hook through the odometer would bump; it must stay at 0.
+    await runDefinition(ctx, fakeDefinition({ id: 'main' }), { text: 'x' });
+
+    expect(target.spinnerStats.turnPromptTokens).toBe(0);
+    expect(target.spinnerStats.turnCompletionTokens).toBe(0);
+  });
+
+  it('absent statsTarget (cron / headless) appends nothing and does not throw', async () => {
+    const ctx = makeCtx(); // no statsTarget
+    mockStepWithUsage({ promptTokens: 200, completionTokens: 30 });
+
+    const out = await runDefinition(ctx, fakeDefinition({ id: 'sub' }), { text: 'x' });
+    expect(out.formatted).toBe('final answer');
+  });
+});
+
 describe('DefinitionRegistry', () => {
   it('registers, looks up, and reports missing kinds', () => {
     const reg = new DefinitionRegistry();

--- a/src/framework/agents/__tests__/run.test.ts
+++ b/src/framework/agents/__tests__/run.test.ts
@@ -378,15 +378,16 @@ describe('runDefinition per-turn token totals hook (#234)', () => {
     expect(target.lastStepPromptTokens).toBe(0);
   });
 
-  it('main dispatch does NOT get a second totals hook (no double count)', async () => {
+  it('a fullTokenAccounting def does NOT get a second totals hook (no double count)', async () => {
     const target = makeTarget();
     const ctx = makeCtx();
     ctx.statsTarget = target as any;
     mockStepWithUsage({ promptTokens: 200, completionTokens: 30 });
 
-    // The fake 'main' def carries no hooks of its own, so if the gate let the
-    // totals hook through the odometer would bump; it must stay at 0.
-    await runDefinition(ctx, fakeDefinition({ id: 'main' }), { text: 'x' });
+    // The fake def carries no hooks of its own, so if the gate let the totals
+    // hook through the odometer would bump; the flag must keep it at 0 (the real
+    // main def installs tokenStatsHook itself).
+    await runDefinition(ctx, fakeDefinition({ fullTokenAccounting: true }), { text: 'x' });
 
     expect(target.spinnerStats.turnPromptTokens).toBe(0);
     expect(target.spinnerStats.turnCompletionTokens).toBe(0);

--- a/src/framework/agents/main.ts
+++ b/src/framework/agents/main.ts
@@ -192,6 +192,11 @@ export const mainAgentDefinition: AgentDefinition<MainInput, string> = {
   // activates when `setOutputSink` has registered a consumer.
   streaming: true,
 
+  // #234: this definition installs `tokenStatsHook` below (full per-turn
+  // accounting), so `runDefinition` must NOT also append `tokenTotalsHook` —
+  // that would double-count the main agent's tokens in the ↑/↓ odometer.
+  fullTokenAccounting: true,
+
   systemPrompt(_ctx, input) {
     // The Agent class pre-renders the prompt via `buildMainSystemPrompt` and
     // passes it through `input.systemPrompt` so a single `getModelProfile`

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -6,6 +6,7 @@ import { makeRepairHook } from '../../tool-call-repair.js';
 import { augmentTools } from '../../tools/augment.js';
 import type { AgentContext } from '../context.js';
 import { getOutputSink } from '../hooks/output-sink.js';
+import { tokenTotalsHook } from '../hooks/token-stats.js';
 import type { StepFinishPayload } from '../hooks/types.js';
 import { runAgent, type AgentResult, type AgentSpec } from '../runner.js';
 import type { IterateFn, IterateOpts, StrategyContext } from '../strategies/types.js';
@@ -137,6 +138,15 @@ export async function runDefinition<TInput, TFormatted>(
         },
       ]
     : def.hooks(ctx, input);
+  // Per-turn ↑/↓ odometer for non-main dispatches (#234). The main agent's
+  // `tokenStatsHook` already does full accounting (totals + gauge + compression
+  // headroom), so gating on `def.id !== 'main'` prevents double-counting it
+  // here; `ctx.statsTarget` being absent is the cron / headless exemption (the
+  // totals hook is simply not attached). Sub-agents / tool-wrappers / PAC
+  // phases thus add their tokens to the same per-turn odometer without
+  // disturbing the main-only context gauge.
+  const finalHooks =
+    def.id !== 'main' && ctx.statsTarget ? [...hooks, tokenTotalsHook(ctx.statsTarget)] : hooks;
   const baseMaxSteps = def.stepBudget(config, input);
   const prepareStep = def.prepareStep?.(ctx, input, baseMaxSteps);
   const repair = def.repairLabel
@@ -234,7 +244,7 @@ export async function runDefinition<TInput, TFormatted>(
     abortSignal: opts.abortSignal,
     prepareStep,
     repair,
-    hooks,
+    hooks: finalHooks,
     useStreaming,
     onTextDelta,
     onToolCallStart,

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -138,15 +138,17 @@ export async function runDefinition<TInput, TFormatted>(
         },
       ]
     : def.hooks(ctx, input);
-  // Per-turn ↑/↓ odometer for non-main dispatches (#234). The main agent's
-  // `tokenStatsHook` already does full accounting (totals + gauge + compression
-  // headroom), so gating on `def.id !== 'main'` prevents double-counting it
-  // here; `ctx.statsTarget` being absent is the cron / headless exemption (the
-  // totals hook is simply not attached). Sub-agents / tool-wrappers / PAC
-  // phases thus add their tokens to the same per-turn odometer without
-  // disturbing the main-only context gauge.
+  // Per-turn ↑/↓ odometer for non-main dispatches (#234). Definitions that do
+  // their own full accounting (`fullTokenAccounting` — the main agent, which
+  // installs `tokenStatsHook`) are skipped so they aren't double-counted;
+  // everyone else (sub / task / specialist / tool-wrapper / PAC) gets the
+  // totals-only hook so their tokens add to the same odometer without disturbing
+  // the main-only context gauge. `ctx.statsTarget` being absent is the cron /
+  // headless exemption (the hook is simply not attached).
   const finalHooks =
-    def.id !== 'main' && ctx.statsTarget ? [...hooks, tokenTotalsHook(ctx.statsTarget)] : hooks;
+    !def.fullTokenAccounting && ctx.statsTarget
+      ? [...hooks, tokenTotalsHook(ctx.statsTarget)]
+      : hooks;
   const baseMaxSteps = def.stepBudget(config, input);
   const prepareStep = def.prepareStep?.(ctx, input, baseMaxSteps);
   const repair = def.repairLabel

--- a/src/framework/agents/types.ts
+++ b/src/framework/agents/types.ts
@@ -171,4 +171,17 @@ export interface AgentDefinition<TInput = unknown, TFormatted = unknown> {
    * concurrent token streams in the terminal.
    */
   streaming?: boolean;
+
+  /**
+   * When `true`, this definition's `hooks()` already installs `tokenStatsHook`
+   * (full per-turn odometer + context gauge + compression headroom). Only the
+   * main-agent definition sets this. `runDefinition` reads it to decide whether
+   * to append the totals-only `tokenTotalsHook`: non-accounting definitions
+   * (sub / task / specialist / tool-wrapper / PAC phases) get it so their tokens
+   * land in the same per-turn ↑/↓ odometer, while the main agent is skipped to
+   * avoid double-counting. Keeping this a flag on the definition (rather than a
+   * hardcoded id check in `runDefinition`) keeps the accounting contract
+   * co-located with the hook wiring it describes. Issue #234.
+   */
+  fullTokenAccounting?: boolean;
 }

--- a/src/framework/context.ts
+++ b/src/framework/context.ts
@@ -8,6 +8,7 @@ import { ToolProfileStore } from '../tool-profiles.js';
 import type { RAGStore } from '../rag.js';
 import type { PolicyDecision } from '../policy/types.js';
 import type { ToolOptions } from '../tools/types.js';
+import type { TokenStatsTarget } from './hooks/token-stats.js';
 import { ProvenanceStore } from '../provenance.js';
 import { VerificationStore } from '../agent-status.js';
 import { VerificationTracker } from '../verification-tracker.js';
@@ -70,6 +71,16 @@ export interface AgentContext {
    * `Agent.processInput`. Issue #145 check 3.
    */
   postWriteChecks: Check[];
+  /**
+   * Shared per-turn token-stats accumulator, set by the `Agent` class once it
+   * is wired for interactive use (`setSpinnerStats` → `this`, which implements
+   * {@link TokenStatsTarget}). Shared by reference into sub-agent / tool-wrapper
+   * contexts so `runDefinition` can attach `tokenTotalsHook` to non-main
+   * dispatches — making the per-turn ↑/↓ odometer reflect the full turn cost,
+   * including offloaded sub-agent work. Absent for cron / headless runs (the
+   * totals hook is null-safe and simply not attached). Issue #234.
+   */
+  statsTarget?: TokenStatsTarget;
 }
 
 export interface AssembleContextInput {

--- a/src/framework/hooks/__tests__/token-stats.test.ts
+++ b/src/framework/hooks/__tests__/token-stats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
-import { tokenStatsHook, type TokenStatsTarget } from '../token-stats.js';
+import { tokenStatsHook, tokenTotalsHook, type TokenStatsTarget } from '../token-stats.js';
 import type { SpinnerStats } from '../../../output.js';
 
 beforeEach(() => {});
@@ -8,8 +8,8 @@ beforeEach(() => {});
 function makeStats(over: Partial<SpinnerStats> = {}): SpinnerStats {
   return {
     startTime: 0,
-    totalPromptTokens: 0,
-    totalCompletionTokens: 0,
+    turnPromptTokens: 0,
+    turnCompletionTokens: 0,
     latestPromptTokens: 0,
     model: 'claude-x',
     ...over,
@@ -32,7 +32,7 @@ describe('tokenStatsHook', () => {
   it('accumulates spinner stats when present', async () => {
     const target: TokenStatsTarget = {
       lastStepPromptTokens: 0,
-      spinnerStats: makeStats({ totalPromptTokens: 100, totalCompletionTokens: 50 }),
+      spinnerStats: makeStats({ turnPromptTokens: 100, turnCompletionTokens: 50 }),
     };
     const hook = tokenStatsHook(target);
     await hook.onStepFinish!({
@@ -41,8 +41,8 @@ describe('tokenStatsHook', () => {
       toolResults: [],
       usage: { promptTokens: 10, completionTokens: 5 },
     });
-    expect(target.spinnerStats!.totalPromptTokens).toBe(110);
-    expect(target.spinnerStats!.totalCompletionTokens).toBe(55);
+    expect(target.spinnerStats!.turnPromptTokens).toBe(110);
+    expect(target.spinnerStats!.turnCompletionTokens).toBe(55);
     expect(target.spinnerStats!.latestPromptTokens).toBe(10);
   });
 
@@ -63,5 +63,50 @@ describe('tokenStatsHook', () => {
     const hook = tokenStatsHook(target);
     await hook.onStepFinish!({ text: '', toolCalls: [], toolResults: [] });
     expect(target.lastStepPromptTokens).toBe(42);
+  });
+});
+
+describe('tokenTotalsHook', () => {
+  it('bumps only the per-turn odometer, never the gauge or compression headroom', async () => {
+    const target: TokenStatsTarget = {
+      lastStepPromptTokens: 0,
+      spinnerStats: makeStats({ turnPromptTokens: 100, turnCompletionTokens: 50 }),
+    };
+    const hook = tokenTotalsHook(target);
+    await hook.onStepFinish!({
+      text: '',
+      toolCalls: [],
+      toolResults: [],
+      usage: { promptTokens: 10, completionTokens: 5 },
+    });
+    expect(target.spinnerStats!.turnPromptTokens).toBe(110);
+    expect(target.spinnerStats!.turnCompletionTokens).toBe(55);
+    // Sub-agent steps must NOT disturb the main-only context gauge...
+    expect(target.spinnerStats!.latestPromptTokens).toBe(0);
+    // ...nor the main agent's compression-headroom field.
+    expect(target.lastStepPromptTokens).toBe(0);
+  });
+
+  it('no-ops when spinnerStats is null (cron / headless)', async () => {
+    const target: TokenStatsTarget = { lastStepPromptTokens: 0, spinnerStats: null };
+    const hook = tokenTotalsHook(target);
+    await hook.onStepFinish!({
+      text: '',
+      toolCalls: [],
+      toolResults: [],
+      usage: { promptTokens: 10, completionTokens: 5 },
+    });
+    expect(target.lastStepPromptTokens).toBe(0);
+  });
+
+  it('no-ops when usage is missing', async () => {
+    const target: TokenStatsTarget = {
+      lastStepPromptTokens: 0,
+      spinnerStats: makeStats({ turnPromptTokens: 7, turnCompletionTokens: 3 }),
+    };
+    const hook = tokenTotalsHook(target);
+    await hook.onStepFinish!({ text: '', toolCalls: [], toolResults: [] });
+    expect(target.spinnerStats!.turnPromptTokens).toBe(7);
+    expect(target.spinnerStats!.turnCompletionTokens).toBe(3);
   });
 });

--- a/src/framework/hooks/index.ts
+++ b/src/framework/hooks/index.ts
@@ -1,4 +1,4 @@
 export type { AgentHook, StepFinishPayload } from './types.js';
 export { outputHook } from './output.js';
-export { tokenStatsHook, type TokenStatsTarget } from './token-stats.js';
+export { tokenStatsHook, tokenTotalsHook, type TokenStatsTarget } from './token-stats.js';
 export { cronStepRecorderHook } from './cron-step-recorder.js';

--- a/src/framework/hooks/token-stats.ts
+++ b/src/framework/hooks/token-stats.ts
@@ -12,6 +12,18 @@ export interface TokenStatsTarget {
 }
 
 /**
+ * Adds one step's usage to the per-turn ↑/↓ odometer. The single mutation point
+ * shared by both hooks so the field names never drift between them.
+ */
+function accumulateTurnOdometer(
+  stats: SpinnerStats,
+  usage: { promptTokens: number; completionTokens: number },
+): void {
+  stats.turnPromptTokens += usage.promptTokens;
+  stats.turnCompletionTokens += usage.completionTokens;
+}
+
+/**
  * Full per-step accounting for the **main agent**. After each step:
  *  - writes the latest prompt-token count onto `target.lastStepPromptTokens`
  *    (used downstream for compression-headroom calculations);
@@ -30,8 +42,7 @@ export function tokenStatsHook(target: TokenStatsTarget): AgentHook {
       if (usage) {
         target.lastStepPromptTokens = usage.promptTokens;
         if (target.spinnerStats) {
-          target.spinnerStats.turnPromptTokens += usage.promptTokens;
-          target.spinnerStats.turnCompletionTokens += usage.completionTokens;
+          accumulateTurnOdometer(target.spinnerStats, usage);
           target.spinnerStats.latestPromptTokens = usage.promptTokens;
         }
       }
@@ -52,8 +63,7 @@ export function tokenTotalsHook(target: TokenStatsTarget): AgentHook {
   return {
     onStepFinish: ({ usage }) => {
       if (usage && target.spinnerStats) {
-        target.spinnerStats.turnPromptTokens += usage.promptTokens;
-        target.spinnerStats.turnCompletionTokens += usage.completionTokens;
+        accumulateTurnOdometer(target.spinnerStats, usage);
       }
     },
   };

--- a/src/framework/hooks/token-stats.ts
+++ b/src/framework/hooks/token-stats.ts
@@ -12,15 +12,17 @@ export interface TokenStatsTarget {
 }
 
 /**
- * Tracks per-step token usage for the main agent. After each step:
+ * Full per-step accounting for the **main agent**. After each step:
  *  - writes the latest prompt-token count onto `target.lastStepPromptTokens`
  *    (used downstream for compression-headroom calculations);
- *  - accumulates prompt + completion totals on `target.spinnerStats` when set;
- *  - restarts the thinking spinner between tool-call steps so the user sees
- *    live progress while another LLM call is in flight.
+ *  - accumulates the per-turn prompt + completion odometers on
+ *    `target.spinnerStats` when set;
+ *  - sets `latestPromptTokens` — the main agent's current context size, which
+ *    the status-bar gauge measures.
  *
- * Extracted from the verbatim block at the top of the main-agent
- * `onStepFinish` lambda; behavior is byte-identical to pre-Phase-C `agent.ts`.
+ * Only the main agent installs this hook. Sub-agents / tool-wrappers / PAC
+ * phases use {@link tokenTotalsHook} instead so their steps add to the per-turn
+ * odometer without disturbing the gauge or the compression math (#234).
  */
 export function tokenStatsHook(target: TokenStatsTarget): AgentHook {
   return {
@@ -28,10 +30,30 @@ export function tokenStatsHook(target: TokenStatsTarget): AgentHook {
       if (usage) {
         target.lastStepPromptTokens = usage.promptTokens;
         if (target.spinnerStats) {
-          target.spinnerStats.totalPromptTokens += usage.promptTokens;
-          target.spinnerStats.totalCompletionTokens += usage.completionTokens;
+          target.spinnerStats.turnPromptTokens += usage.promptTokens;
+          target.spinnerStats.turnCompletionTokens += usage.completionTokens;
           target.spinnerStats.latestPromptTokens = usage.promptTokens;
         }
+      }
+    },
+  };
+}
+
+/**
+ * Totals-only accounting for **non-main** dispatches (sub-agent, task,
+ * specialist, tool-wrapper, PAC phases). Adds each step's usage to the per-turn
+ * ↑/↓ odometer so it reflects the *full* turn cost — including work offloaded to
+ * ephemeral sub-agents — but deliberately leaves `latestPromptTokens` (the
+ * main-agent context gauge) and `lastStepPromptTokens` (main-agent compression
+ * headroom) untouched. No-ops when `spinnerStats` is null, so cron / headless
+ * dispatches (no stats target) cost nothing (#234).
+ */
+export function tokenTotalsHook(target: TokenStatsTarget): AgentHook {
+  return {
+    onStepFinish: ({ usage }) => {
+      if (usage && target.spinnerStats) {
+        target.spinnerStats.turnPromptTokens += usage.promptTokens;
+        target.spinnerStats.turnCompletionTokens += usage.completionTokens;
       }
     },
   };

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -31,8 +31,8 @@ describe('buildSpinnerMessage', () => {
   function makeStats(overrides: Partial<SpinnerStats> = {}): SpinnerStats {
     return {
       startTime: Date.now(),
-      totalPromptTokens: 0,
-      totalCompletionTokens: 0,
+      turnPromptTokens: 0,
+      turnCompletionTokens: 0,
       latestPromptTokens: 0,
       model: 'claude-sonnet-4-5-20250929',
       ...overrides,
@@ -48,8 +48,8 @@ describe('buildSpinnerMessage', () => {
     const msg = buildSpinnerMessage(
       makeStats({
         startTime: Date.now() - 1000,
-        totalPromptTokens: 1234,
-        totalCompletionTokens: 56,
+        turnPromptTokens: 1234,
+        turnCompletionTokens: 56,
         latestPromptTokens: 1234,
       }),
     );
@@ -61,16 +61,16 @@ describe('buildSpinnerMessage', () => {
   it('honors contextWindowOverride', () => {
     const small = buildSpinnerMessage(
       makeStats({
-        totalPromptTokens: 5000,
-        totalCompletionTokens: 100,
+        turnPromptTokens: 5000,
+        turnCompletionTokens: 100,
         latestPromptTokens: 5000,
         contextWindowOverride: 10_000,
       }),
     );
     const large = buildSpinnerMessage(
       makeStats({
-        totalPromptTokens: 5000,
-        totalCompletionTokens: 100,
+        turnPromptTokens: 5000,
+        turnCompletionTokens: 100,
         latestPromptTokens: 5000,
         contextWindowOverride: 1_000_000,
       }),
@@ -83,8 +83,8 @@ describe('buildSpinnerMessage', () => {
   it('clamps remainingPct to 0 when the latest prompt exceeds the threshold', () => {
     const msg = buildSpinnerMessage(
       makeStats({
-        totalPromptTokens: 999_999,
-        totalCompletionTokens: 1,
+        turnPromptTokens: 999_999,
+        turnCompletionTokens: 1,
         latestPromptTokens: 999_999,
         contextWindowOverride: 10_000,
       }),

--- a/src/output.ts
+++ b/src/output.ts
@@ -19,11 +19,21 @@ export function isToolDetailsVisible(): boolean {
   return toolDetailsVisible;
 }
 
-/** Cumulative token-usage statistics displayed alongside the thinking spinner. */
+/**
+ * Token-usage statistics displayed alongside the thinking spinner / status bar.
+ *
+ * `turnPromptTokens` / `turnCompletionTokens` are **per-turn** odometers: reset
+ * at the top of every `Agent.processInput` and accumulated across the full turn
+ * — main-agent steps *and* the sub-agents / tool-wrappers / PAC phases spawned
+ * during the turn (the work offloaded off the main context still cost tokens).
+ * `latestPromptTokens` is the **main agent's** most-recent prompt size and is
+ * what the context gauge measures — sub-agent steps never touch it, so the bar
+ * tracks only the main agent's context fullness (#234).
+ */
 export interface SpinnerStats {
   startTime: number;
-  totalPromptTokens: number;
-  totalCompletionTokens: number;
+  turnPromptTokens: number;
+  turnCompletionTokens: number;
   latestPromptTokens: number;
   model: string;
   contextWindowOverride?: number;
@@ -46,12 +56,12 @@ function formatElapsed(ms: number): string {
 export function buildSpinnerMessage(stats: SpinnerStats): string {
   const elapsed = formatElapsed(Date.now() - stats.startTime);
 
-  if (stats.totalPromptTokens === 0 && stats.totalCompletionTokens === 0) {
+  if (stats.turnPromptTokens === 0 && stats.turnCompletionTokens === 0) {
     return `Thinking (${elapsed})`;
   }
 
-  const up = formatTokenCount(stats.totalPromptTokens);
-  const down = formatTokenCount(stats.totalCompletionTokens);
+  const up = formatTokenCount(stats.turnPromptTokens);
+  const down = formatTokenCount(stats.turnCompletionTokens);
   const contextWindow = getContextWindow(stats.model, stats.contextWindowOverride);
   const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
   const remainingPct = Math.max(

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -18,6 +18,7 @@ import { CandidateStore, type CandidateStoreReader } from '../specialist-candida
 import type { CorrectionCandidateStore } from '../correction-candidates.js';
 import { ToolProfileStore } from '../tool-profiles.js';
 import type { AgentContext } from '../framework/context.js';
+import type { TokenStatsTarget } from '../framework/hooks/token-stats.js';
 import type { PolicyDecision } from '../policy/types.js';
 import { ProvenanceStore } from '../provenance.js';
 import { VerificationStore } from '../agent-status.js';
@@ -130,6 +131,13 @@ export interface ToolWrapperDeps {
   verificationTracker?: VerificationTracker;
   postWriteChecks?: Check[];
   /**
+   * Parent turn's per-turn token-stats target. Forwarded so a tool-wrapper /
+   * specialist dispatch's steps land in the same per-turn ↑/↓ odometer as the
+   * main agent and its sub-agents — the readout reflects the *full* turn cost,
+   * including work offloaded to wrappers. Absent for cron / headless. Issue #234.
+   */
+  statsTarget?: TokenStatsTarget;
+  /**
    * Parent turn's policy decision. Forwarded so the inner wrapper
    * inherits the user's `toolMode` (#179) — otherwise the augment layer
    * defaults to `'write'` and any write tool the wrapper calls bypasses
@@ -157,6 +165,7 @@ export function ctxToToolWrapperDeps(ctx: AgentContext): ToolWrapperDeps {
     verification: ctx.verification,
     verificationTracker: ctx.verificationTracker,
     postWriteChecks: ctx.postWriteChecks,
+    statsTarget: ctx.statsTarget,
     policyDecision: ctx.policyDecision,
   };
 }
@@ -180,6 +189,7 @@ export function depsToCtx(deps: ToolWrapperDeps): AgentContext {
     verification: deps.verification ?? new VerificationStore(),
     verificationTracker: deps.verificationTracker ?? new VerificationTracker(),
     postWriteChecks: deps.postWriteChecks ?? [],
+    ...(deps.statsTarget ? { statsTarget: deps.statsTarget } : {}),
     ...(deps.policyDecision ? { policyDecision: deps.policyDecision } : {}),
   };
 }

--- a/src/tools/tool-wrapper-run.ts
+++ b/src/tools/tool-wrapper-run.ts
@@ -189,8 +189,11 @@ export function depsToCtx(deps: ToolWrapperDeps): AgentContext {
     verification: deps.verification ?? new VerificationStore(),
     verificationTracker: deps.verificationTracker ?? new VerificationTracker(),
     postWriteChecks: deps.postWriteChecks ?? [],
-    ...(deps.statsTarget ? { statsTarget: deps.statsTarget } : {}),
-    ...(deps.policyDecision ? { policyDecision: deps.policyDecision } : {}),
+    // Both optional on AgentContext; an explicit `undefined` is identical to an
+    // absent key for every consumer (all guard with `?.`), so assign directly
+    // rather than allocating a throwaway spread object on each wrapper dispatch.
+    statsTarget: deps.statsTarget,
+    policyDecision: deps.policyDecision,
   };
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -460,18 +460,19 @@ export function App({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- session boundaries are per-mount, not per-config-change
   }, [agent]);
 
-  // Attach a persistent SpinnerStats object so the framework's token-stats
-  // hook accumulates usage across turns. <StatusBar> polls this for the
-  // pinned bottom-right readout. We never null it out — totals carry across
-  // the whole session and only reset on REPL restart. Seeded in a mount-time
-  // effect (StrictMode-safe; render-body side effects double-fire and would
-  // re-overwrite the object on every re-render including the StatusBar tick).
+  // Attach a persistent SpinnerStats object the framework's token-stats hooks
+  // mutate in place. <StatusBar> polls this for the pinned bottom-right readout.
+  // We never null it out — the object lives for the whole session; its per-turn
+  // ↑/↓ odometer (`turnPromptTokens`/`turnCompletionTokens`) is reset at the top
+  // of every turn by `Agent.processInput` (#234). Seeded in a mount-time effect
+  // (StrictMode-safe; render-body side effects double-fire and would re-overwrite
+  // the object on every re-render including the StatusBar tick).
   useEffect(() => {
     if (!agent.spinnerStats) {
       agent.setSpinnerStats({
         startTime: Date.now(),
-        totalPromptTokens: 0,
-        totalCompletionTokens: 0,
+        turnPromptTokens: 0,
+        turnCompletionTokens: 0,
         latestPromptTokens: 0,
         model: resolveMainModel(config),
         contextWindowOverride: config.tokenWindow || undefined,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -460,8 +460,8 @@ export function App({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- session boundaries are per-mount, not per-config-change
   }, [agent]);
 
-  // Attach a persistent SpinnerStats object the framework's token-stats hooks
-  // mutate in place. <StatusBar> polls this for the pinned bottom-right readout.
+  // Attach a persistent SpinnerStats object that the framework's token-stats
+  // hooks mutate in place. <StatusBar> polls this for the pinned bottom-right readout.
   // We never null it out — the object lives for the whole session; its per-turn
   // ↑/↓ odometer (`turnPromptTokens`/`turnCompletionTokens`) is reset at the top
   // of every turn by `Agent.processInput` (#234). Seeded in a mount-time effect

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -32,8 +32,8 @@ export function StatusBar({ agent }: StatusBarProps) {
   const strategy = agent.currentStrategy;
   if (!stats && !strategy) return null;
 
-  const up = stats ? formatTokenCount(stats.totalPromptTokens) : '0';
-  const down = stats ? formatTokenCount(stats.totalCompletionTokens) : '0';
+  const up = stats ? formatTokenCount(stats.turnPromptTokens) : '0';
+  const down = stats ? formatTokenCount(stats.turnCompletionTokens) : '0';
   const contextWindow = stats ? getContextWindow(stats.model, stats.contextWindowOverride) : 1;
   const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
   const usedFrac = stats ? Math.min(1, Math.max(0, stats.latestPromptTokens / thresholdTokens)) : 0;
@@ -66,14 +66,15 @@ export function StatusBar({ agent }: StatusBarProps) {
       )}
       {/* The token readout + context gauge only render once real token stats
           exist — before the first stats flush (strategy set, stats still null)
-          an all-empty bar would be visual noise. `session` is the cumulative
-          per-session odometer; `ctx` is the current input size (latest step's
-          prompt tokens) — the number the gauge actually depicts, so the two
-          can't be confused. */}
+          an all-empty bar would be visual noise. `turn` is the per-turn
+          odometer (full turn cost — main agent plus any sub-agents / wrappers /
+          PAC it spawns — reset each turn); `ctx` is the current main-agent input
+          size (latest step's prompt tokens) — the number the gauge actually
+          depicts, so the two can't be confused. */}
       {stats && (
         <>
           <Text color={colors.muted}>
-            session {up}↑ {down}↓{'   '}
+            turn {up}↑ {down}↓{'   '}
           </Text>
           <Text color={colors.muted}>ctx {formatTokenCount(stats.latestPromptTokens)} </Text>
           {filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}

--- a/src/ui/__tests__/StatusBar.test.tsx
+++ b/src/ui/__tests__/StatusBar.test.tsx
@@ -18,8 +18,8 @@ function stubAgent(usedFrac: number): Agent {
   return {
     spinnerStats: {
       startTime: 0,
-      totalPromptTokens: 1234,
-      totalCompletionTokens: 567,
+      turnPromptTokens: 1234,
+      turnCompletionTokens: 567,
       latestPromptTokens: usedFrac * budget,
       model: 'test-model',
       contextWindowOverride: contextWindow,
@@ -65,21 +65,21 @@ describe('<StatusBar> context gauge (half-dot resolution)', () => {
 });
 
 describe('<StatusBar> token readout labels (#234)', () => {
-  it('labels the cumulative odometer as session-scoped', () => {
+  it('labels the per-turn odometer as turn-scoped', () => {
     const { lastFrame } = render(createElement(StatusBar, { agent: stubAgent(0.55) }));
     // Strip ANSI: Ink inserts color/reset codes between adjacent <Text> nodes,
     // which would otherwise break regexes that span component boundaries.
     const frame = stripAnsi(lastFrame() ?? '');
-    // The odometer must read "session ...↑ ...↓" so it can't be misread as the
+    // The odometer must read "turn ...↑ ...↓" so it can't be misread as the
     // adjacent context gauge.
-    expect(frame).toMatch(/session\s+1\.2k↑\s+567↓/);
+    expect(frame).toMatch(/turn\s+1\.2k↑\s+567↓/);
   });
 
   it('labels the gauge with the current context size (ctx)', () => {
     const { lastFrame } = render(createElement(StatusBar, { agent: stubAgent(0.55) }));
     const frame = stripAnsi(lastFrame() ?? '');
     // ctx reflects latestPromptTokens (0.55 * 1000 * COMPRESSION_THRESHOLD) and
-    // sits between the session odometer and the gauge glyphs.
+    // sits between the per-turn odometer and the gauge glyphs.
     expect(frame).toMatch(/ctx \S+ *●/);
   });
 });


### PR DESCRIPTION
## What & why

The status bar showed `8527k↑ 17k↓` next to a near-empty context gauge. Issue #234 read that as the gauge *undercounting* sub-agent tokens — but the gauge is **main-agent-only by design**: sub-agents / tool-wrappers / PAC are ephemeral and exist precisely to absorb token work *off* the main context, so folding them into the gauge would defeat the point.

The actual defect is the side **↑/↓ odometer**: it accumulated across every step of every turn since REPL start and never reset, ballooning into the millions until it read like a broken context meter. Per product decision it should be **per-turn** and reflect the **full turn cost** — i.e. include the sub-agents/wrappers/PAC spawned during the turn (that offloaded work still cost tokens and the user wants to see it).

Two adjacent freshness bugs are folded in: the **bar didn't reset on `/clear` or `/compact`** — it only updated when the agent next ran.

## Changes

- **Per-turn odometer.** Rename `SpinnerStats.total{Prompt,Completion}Tokens` → `turn{...}`; reset at the top of every `processInput` turn. StatusBar prefix `session` → `turn`.
- **Full turn cost.** Split the token hooks: main keeps `tokenStatsHook` (odometer + gauge + compression headroom); non-main dispatches get a new `tokenTotalsHook` that bumps **only** the per-turn odometer — never `latestPromptTokens` (the main-only gauge) or `lastStepPromptTokens` (main's compression math). Wired in `runDefinition` for `def.id !== 'main'` when the shared `ctx.statsTarget` is present (cron/headless has none → exempt for free).
- **Bar resets immediately.** `clearHistory()` empties the bar + odometer + compression-input fields; `compactHistory()` drops the gauge to the compacted size. StatusBar polls every 500 ms so the reset shows within a frame.

## Out of scope (deliberate)

- **The gauge stays main-agent-only** — correct by design; the issue's "the bar undercounts sub-agents" premise is wrong.
- **Pre-turn (rewriter / reference-resolver / reference-lookup) and compressor / repair direct `generateText` sites** bypass `runDefinition`, and the pre-turn ones fire before the per-turn reset. Single-shot, ≤768 tokens each — a minor known gap, noted as a possible follow-up rather than threading a stats handle through ~5 standalone signatures here.
- Pre-existing lint/format debt on `bernard-1-0-0` left untouched.

## Verification

- `npm run build` — clean.
- `npm test` — 2769 pass. New/updated coverage: `tokenTotalsHook` (bumps only the odometer; no-ops on null stats / missing usage); `runDefinition` (non-main bumps the per-turn odometer but not gauge/headroom, main isn't double-counted, absent statsTarget appends nothing); `agent` (per-turn reset, `clearHistory` zeroing, `compactHistory` gauge drop); StatusBar `turn` label; `output` renamed fields.
- `npx prettier --check` on touched files — clean (the one App.tsx warning is pre-existing debt on unrelated lines).
- `npm run lint` — identical to the `bernard-1-0-0` baseline (142 problems / 2 pre-existing errors); **zero new violations**.

Resolves #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)