### PR TITLE
fix(ui): make terminal scrollback usable — finalized history → Ink <Static> (#232)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1970,16 +1970,25 @@ export function App({
    * commit only picks up newer messages.
    */
   function commitNewHistory(opts?: {
-    /** Pre-rewrite text, attached to the newest user message in the slice. */
+    /** Pre-rewrite text, attached to the just-pushed user message in the slice. */
     rewriteForLastUser?: string;
-    /** Timing footer, attached to the assistant message at this history index. */
+    /** Timing footer, attached to the last assistant message in the slice. */
     timing?: { endedAt: number; durationMs: number };
-    assistantIndex?: number;
   }): void {
     const history = agent.getHistory();
     const start = committedLenRef.current;
     if (start >= history.length) return;
     const toolDetails = config.toolDetails;
+    // The rewrite original belongs to the just-pushed user message and the
+    // timing footer to the turn's assistant message — i.e. the last of each
+    // role in the slice. Resolve both targets here so callers only pass the
+    // payloads, not history indices to keep in sync.
+    let lastUserIdx = -1;
+    let lastAssistantIdx = -1;
+    for (let i = start; i < history.length; i++) {
+      if (history[i].role === 'user') lastUserIdx = i;
+      else if (history[i].role === 'assistant') lastAssistantIdx = i;
+    }
     const appended: StaticItem[] = [];
     for (let i = start; i < history.length; i++) {
       const message = history[i];
@@ -1987,10 +1996,10 @@ export function App({
         key: String(itemKeyRef.current++),
         message,
         rewriteOriginal:
-          opts?.rewriteForLastUser !== undefined && message.role === 'user'
+          opts?.rewriteForLastUser !== undefined && i === lastUserIdx
             ? opts.rewriteForLastUser
             : undefined,
-        timing: opts?.timing && i === opts.assistantIndex ? opts.timing : undefined,
+        timing: opts?.timing && i === lastAssistantIdx ? opts.timing : undefined,
         toolDetails,
       });
     }
@@ -2054,25 +2063,14 @@ export function App({
       submittingRef.current = false;
       turnAbortRef.current = null;
       setBusy(false);
-      // Commit the assistant message (+ any tool messages) added this turn,
-      // attaching the timing footer to the last assistant message when the
-      // turn ran to completion (an aborted turn gets no footer, same as
+      // Commit the assistant message (+ any tool messages) added this turn.
+      // commitNewHistory attaches the timing footer to the turn's assistant
+      // message itself; an aborted turn passes no timing (no footer, same as
       // before). This append + setBusy(false) land in the same React 18 batch,
       // so the streaming view freezes into scrollback in a single render.
-      let timing: { endedAt: number; durationMs: number } | undefined;
-      let assistantIndex: number | undefined;
-      if (turnCompleted) {
-        const endedAt = Date.now();
-        const history = agent.getHistory();
-        for (let i = history.length - 1; i >= 0; i--) {
-          if (history[i].role === 'assistant') {
-            assistantIndex = i;
-            timing = { endedAt, durationMs: endedAt - turnStartedAt };
-            break;
-          }
-        }
-      }
-      commitNewHistory({ timing, assistantIndex });
+      const endedAt = Date.now();
+      const timing = turnCompleted ? { endedAt, durationMs: endedAt - turnStartedAt } : undefined;
+      commitNewHistory({ timing });
     }
   }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -82,7 +82,7 @@ import {
 } from '../image.js';
 import { runDefinition } from '../framework/agents/run.js';
 import { taskDefinition, type TaskInput } from '../framework/agents/task.js';
-import { generateText } from 'ai';
+import { generateText, type CoreMessage } from 'ai';
 import { resolveSiteModel, resolveMainModel, logSiteModelSnapshot } from '../model-policy.js';
 import { serializeMessages, extractDomainFacts, SUMMARIZATION_PROMPT } from '../context.js';
 import { detectSpecialistCandidate } from '../specialist-detector.js';
@@ -317,6 +317,13 @@ export function App({
   // Number of `agent.getHistory()` messages already committed to `staticItems`.
   // Each commit appends `history.slice(committedLen)` and advances this.
   const committedLenRef = useRef(0);
+  // The history ARRAY reference we last committed against. Normal appends mutate
+  // the same array in place (push), so the reference is stable; but
+  // `Agent.processInput` REASSIGNS `this.history` to a new, shorter array when
+  // automatic context compression / emergency truncation fires mid-turn. When
+  // that happens the length cursor above is meaningless for the new array, so
+  // we re-anchor against this turn's user message instead of slicing blindly.
+  const historyRef = useRef<CoreMessage[] | null>(null);
   // Monotonic source for `StaticItem.key`. Deliberately NOT the history index:
   // /compact shrinks history, so index-based keys would collide with already
   // emitted items. A counter never repeats.
@@ -663,6 +670,9 @@ export function App({
       // scrollback, `\x1b[2J` the visible region, `\x1b[H` homes the cursor.
       setStaticItems([]);
       committedLenRef.current = 0;
+      // clearHistory() reassigns this.history to a fresh []; track the new
+      // reference so the next commit doesn't mistake it for a mid-turn replace.
+      historyRef.current = agent.getHistory();
       process.stdout.write('\x1b[3J\x1b[2J\x1b[H');
       setStaticEpoch((e) => e + 1);
       flashToast('Conversation history cleared.', 'success');
@@ -727,12 +737,14 @@ export function App({
         if (!result.compacted) {
           flashToast('Nothing to compact — conversation is already short enough.');
         } else {
-          // Compaction shrinks history; resync the commit boundary to the new
-          // length so future turns index correctly. The already-printed
-          // transcript stays in scrollback (it genuinely happened) and Static
-          // keeps appending below — monotonic item keys can't collide even
-          // though history indices shifted, so no remount is needed.
+          // Compaction reassigns this.history to a new, shorter array; resync
+          // the commit boundary to its length AND track the new reference so
+          // the next commit doesn't re-anchor as if it were a mid-turn replace.
+          // The already-printed transcript stays in scrollback (it genuinely
+          // happened) and Static keeps appending below — monotonic item keys
+          // can't collide even though history indices shifted, so no remount.
           committedLenRef.current = agent.getHistory().length;
+          historyRef.current = agent.getHistory();
           const pct = Math.round(
             ((result.tokensBefore - result.tokensAfter) / result.tokensBefore) * 100,
           );
@@ -1976,6 +1988,26 @@ export function App({
     timing?: { endedAt: number; durationMs: number };
   }): void {
     const history = agent.getHistory();
+    // If the agent replaced its history array mid-turn (auto-compression /
+    // emergency truncation in processInput, which reassigns `this.history` to a
+    // shorter array — #243 review), the length cursor points past the end of
+    // the new array and the slice below would silently drop this turn's
+    // assistant + tool output. Re-anchor on this turn's user message instead:
+    // compression always keeps the most recent user message, so everything
+    // after the last user message is the still-uncommitted turn output (the
+    // user message itself was already committed at turn start). Guard on a
+    // non-null prior ref so the first-ever commit still emits initial history.
+    if (historyRef.current !== null && historyRef.current !== history) {
+      let lastUserIdx = -1;
+      for (let i = history.length - 1; i >= 0; i--) {
+        if (history[i].role === 'user') {
+          lastUserIdx = i;
+          break;
+        }
+      }
+      committedLenRef.current = lastUserIdx + 1;
+    }
+    historyRef.current = history;
     const start = committedLenRef.current;
     if (start >= history.length) return;
     const toolDetails = config.toolDetails;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -113,7 +113,7 @@ import type {
   ValuePromptOptions,
   ValueResult,
 } from './menu-types.js';
-import { Thread, REWRITE_ICON } from './Thread.js';
+import { Thread, REWRITE_ICON, type StaticItem } from './Thread.js';
 import { Prompt } from './Prompt.js';
 import { Spinner } from './Spinner.js';
 import { StatusBar } from './StatusBar.js';
@@ -304,7 +304,23 @@ export function App({
   const { exit } = useApp();
   const [activeOverlay, setActiveOverlay] = useState<Overlay | null>(null);
   const [busy, setBusy] = useState(false);
-  const [historyVersion, setHistoryVersion] = useState(0);
+  // Append-only log of finalized turns, rendered through Ink's `<Static>` so
+  // each entry becomes terminal scrollback that is never repainted (#232).
+  // `<App>` commits to this at turn boundaries; the streaming message and the
+  // rest of the UI stay in the dynamic region.
+  const [staticItems, setStaticItems] = useState<StaticItem[]>([]);
+  // Bumped only by /clear to remount <Thread> and reset <Static>'s internal
+  // high-water cursor (Static only appends — it cannot un-print, so the reset
+  // has to come from a fresh mount). Normal turns never touch this, so they no
+  // longer remount the whole transcript the way the old historyVersion key did.
+  const [staticEpoch, setStaticEpoch] = useState(0);
+  // Number of `agent.getHistory()` messages already committed to `staticItems`.
+  // Each commit appends `history.slice(committedLen)` and advances this.
+  const committedLenRef = useRef(0);
+  // Monotonic source for `StaticItem.key`. Deliberately NOT the history index:
+  // /compact shrinks history, so index-based keys would collide with already
+  // emitted items. A counter never repeats.
+  const itemKeyRef = useRef(0);
   const [pendingMenu, setPendingMenu] = useState<PendingMenu | null>(null);
   const [pendingMultiMenu, setPendingMultiMenu] = useState<PendingMultiMenu | null>(null);
   const [pendingGrid, setPendingGrid] = useState<PendingGrid | null>(null);
@@ -315,15 +331,6 @@ export function App({
   const [bannerVisible, setBannerVisible] = useState<boolean>(!!alertBanner);
   const [interrupted, setInterrupted] = useState(false);
   const [slashActive, setSlashActive] = useState(false);
-  // Per-history-index timing for completed turns: drives the timestamp +
-  // duration footer under every assistant message in <Thread>. Stored as a
-  // ref because re-renders are already triggered by historyVersion bumps; the
-  // map is append-only across the session and cleared by /clear.
-  const turnTimingsRef = useRef<Map<number, { endedAt: number; durationMs: number }>>(new Map());
-  // history-index → user's original text when the rewriter substituted it.
-  // Lives outside React state because it's append-only and not React-reactive
-  // (history re-renders are driven by historyVersion bumps already).
-  const rewriteOriginalsRef = useRef<Map<number, string>>(new Map());
   const colors = getThemeColors();
 
   // Confirm-action session memo: `${toolName}:${stableHash(args)}` → true.
@@ -648,15 +655,16 @@ export function App({
       historyStore.clear();
       provenanceHistoryStore.clear();
       agent.clearHistory();
-      turnTimingsRef.current.clear();
-      rewriteOriginalsRef.current.clear();
       setInterrupted(false);
-      // Wipe scrollback + visible region so the old transcript doesn't linger
-      // above the cleared <Thread>. `\x1b[3J` clears scrollback, `\x1b[2J`
-      // the visible region, `\x1b[H` homes the cursor. Ink repaints on the
-      // next setHistoryVersion bump below.
+      // Reset the append-only log and remount <Thread> (via the epoch bump) so
+      // <Static>'s internal high-water cursor resets to 0 — Static only
+      // appends, so an empty `items` array alone wouldn't un-print the old
+      // transcript. The escape wipes the physical terminal: `\x1b[3J` clears
+      // scrollback, `\x1b[2J` the visible region, `\x1b[H` homes the cursor.
+      setStaticItems([]);
+      committedLenRef.current = 0;
       process.stdout.write('\x1b[3J\x1b[2J\x1b[H');
-      setHistoryVersion((v) => v + 1);
+      setStaticEpoch((e) => e + 1);
       flashToast('Conversation history cleared.', 'success');
       return;
     }
@@ -719,10 +727,12 @@ export function App({
         if (!result.compacted) {
           flashToast('Nothing to compact — conversation is already short enough.');
         } else {
-          // History indices shift after compaction; per-index maps would now
-          // attach to the wrong messages.
-          turnTimingsRef.current.clear();
-          rewriteOriginalsRef.current.clear();
+          // Compaction shrinks history; resync the commit boundary to the new
+          // length so future turns index correctly. The already-printed
+          // transcript stays in scrollback (it genuinely happened) and Static
+          // keeps appending below — monotonic item keys can't collide even
+          // though history indices shifted, so no remount is needed.
+          committedLenRef.current = agent.getHistory().length;
           const pct = Math.round(
             ((result.tokensBefore - result.tokensAfter) / result.tokensBefore) * 100,
           );
@@ -732,7 +742,6 @@ export function App({
           );
         }
         persistAgentState({ agent, historyStore, provenanceHistoryStore });
-        setHistoryVersion((v) => v + 1);
       } catch (err) {
         flashToast(
           `Compaction failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -1806,10 +1815,11 @@ export function App({
         'Tool details: off',
         (value) => {
           setToolDetailsVisible(value);
-          // <Thread> re-keys on historyVersion, so bumping it here forces a
-          // remount that picks up the new toolDetails flag on the visible
-          // transcript (not just future turns).
-          setHistoryVersion((v) => v + 1);
+          // Finalized transcript items snapshot toolDetails at commit time and
+          // are written to scrollback once (#232), so a toggle can't retroapply
+          // to already-printed turns — it takes effect on subsequent turns. The
+          // in-flight streaming message reads config.toolDetails live, so the
+          // current turn still responds.
         },
       ),
       toggleRow(
@@ -1950,6 +1960,44 @@ export function App({
     return { agentInput, resolvedEntries };
   }
 
+  /**
+   * Freeze every history message added since the last commit into the
+   * append-only `staticItems` log (#232). Called at the two turn boundaries
+   * where the per-message extras are known: at turn start for the just-pushed
+   * user message (its pre-rewrite original), and at turn end for the assistant
+   * message (its timing footer). Each item snapshots `config.toolDetails` and
+   * gets a fresh monotonic key, then `committedLenRef` advances so the next
+   * commit only picks up newer messages.
+   */
+  function commitNewHistory(opts?: {
+    /** Pre-rewrite text, attached to the newest user message in the slice. */
+    rewriteForLastUser?: string;
+    /** Timing footer, attached to the assistant message at this history index. */
+    timing?: { endedAt: number; durationMs: number };
+    assistantIndex?: number;
+  }): void {
+    const history = agent.getHistory();
+    const start = committedLenRef.current;
+    if (start >= history.length) return;
+    const toolDetails = config.toolDetails;
+    const appended: StaticItem[] = [];
+    for (let i = start; i < history.length; i++) {
+      const message = history[i];
+      appended.push({
+        key: String(itemKeyRef.current++),
+        message,
+        rewriteOriginal:
+          opts?.rewriteForLastUser !== undefined && message.role === 'user'
+            ? opts.rewriteForLastUser
+            : undefined,
+        timing: opts?.timing && i === opts.assistantIndex ? opts.timing : undefined,
+        toolDetails,
+      });
+    }
+    committedLenRef.current = history.length;
+    setStaticItems((prev) => [...prev, ...appended]);
+  }
+
   async function runAgentTurn(input: string, images?: ImageAttachment[]): Promise<void> {
     // Drop a second Enter that arrives before the busy re-render has propagated
     // to <Prompt disabled={busy}>. Without this, two turns can run concurrently.
@@ -1970,18 +2018,13 @@ export function App({
       // `processInput` pushes the user message to `agent.history` synchronously
       // (before its first internal await), so by the time the returned promise
       // hits this microtask boundary the history already contains the new
-      // entry. Bumping `historyVersion` here makes the static <Thread> re-read
-      // and show the user message above the streaming assistant block instead
-      // of after the turn finishes.
+      // entry. Committing it here shows the user message in the transcript
+      // (above the streaming assistant block) immediately instead of after the
+      // turn finishes. When the rewriter substituted the text, pass the
+      // original so <UserMessage> displays it (the rewrite is an LLM-only
+      // detail) rather than the dispatched version.
       const inflight = agent.processInput(agentInput, images, resolvedEntries);
-      // Capture the original text (pre-rewrite) so <UserMessage> can display
-      // it instead of the rewritten version that was dispatched to the model.
-      // The push has already happened — record at the resulting last index.
-      if (input !== agentInput) {
-        const idx = agent.getHistory().length - 1;
-        rewriteOriginalsRef.current.set(idx, input);
-      }
-      setHistoryVersion((v) => v + 1);
+      commitNewHistory({ rewriteForLastUser: input !== agentInput ? input : undefined });
       await inflight;
       turnCompleted = !controller.signal.aborted;
     } catch (err) {
@@ -2001,8 +2044,9 @@ export function App({
           const body = [`⚠ Agent error: ${message}`, stack, cause && `Caused by:\n${cause}`]
             .filter(Boolean)
             .join('\n\n');
+          // The finally-block commit freezes this into the transcript along
+          // with anything else added this turn — no separate bump needed.
           agent.getHistory().push({ role: 'assistant', content: body });
-          setHistoryVersion((v) => v + 1);
         }
       }
     } finally {
@@ -2010,20 +2054,25 @@ export function App({
       submittingRef.current = false;
       turnAbortRef.current = null;
       setBusy(false);
+      // Commit the assistant message (+ any tool messages) added this turn,
+      // attaching the timing footer to the last assistant message when the
+      // turn ran to completion (an aborted turn gets no footer, same as
+      // before). This append + setBusy(false) land in the same React 18 batch,
+      // so the streaming view freezes into scrollback in a single render.
+      let timing: { endedAt: number; durationMs: number } | undefined;
+      let assistantIndex: number | undefined;
       if (turnCompleted) {
         const endedAt = Date.now();
         const history = agent.getHistory();
         for (let i = history.length - 1; i >= 0; i--) {
           if (history[i].role === 'assistant') {
-            turnTimingsRef.current.set(i, {
-              endedAt,
-              durationMs: endedAt - turnStartedAt,
-            });
+            assistantIndex = i;
+            timing = { endedAt, durationMs: endedAt - turnStartedAt };
             break;
           }
         }
       }
-      setHistoryVersion((v) => v + 1);
+      commitNewHistory({ timing, assistantIndex });
     }
   }
 
@@ -2327,14 +2376,12 @@ export function App({
         </Box>
       )}
       <Thread
-        key={historyVersion}
-        history={agent.getHistory()}
+        key={staticEpoch}
+        staticItems={staticItems}
         messageStore={messageStore}
         busy={busy}
         interrupted={interrupted}
-        rewriteOriginals={rewriteOriginalsRef.current}
-        turnTimings={turnTimingsRef.current}
-        toolDetails={config.toolDetails}
+        streamingToolDetails={config.toolDetails}
       />
       {busy && (
         <Box marginTop={1}>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import { getThemeColors } from '../theme.js';
 import { formatTokenCount, type SpinnerStats } from '../output.js';
@@ -11,10 +11,27 @@ interface StatusBarProps {
 
 const BAR_WIDTH = 10;
 
+/** Serialize the fields StatusBar actually renders, for change detection. */
+function snapshotStats(stats: SpinnerStats | null, strategy: string | null): string {
+  if (!stats) return `null|${strategy ?? ''}`;
+  return [
+    stats.turnPromptTokens,
+    stats.turnCompletionTokens,
+    stats.latestPromptTokens,
+    stats.model,
+    stats.contextWindowOverride ?? '',
+    strategy ?? '',
+  ].join('|');
+}
+
 /**
  * Pinned bottom-right token / context-window readout. Polls `agent.spinnerStats`
  * every 500 ms — cheap, and only mutated by the token-stats hook on step
  * boundaries, so a poll-based refresh is fine (no subscription seam needed).
+ * The poll only forces a re-render when a rendered value actually changed
+ * (#232): when the agent is idle nothing mutates `spinnerStats`, so the
+ * snapshot is stable and the dynamic region stops repainting — which is what
+ * lets the terminal hold its scroll position while idle.
  * The compression-headroom indicator is a `●●●◐○○○○○○` dot gauge (half-dot
  * resolution) that gets louder as it fills: muted while there's >25% headroom,
  * warning between 5%–25%, and the theme's accent color once <5% of the
@@ -23,10 +40,17 @@ const BAR_WIDTH = 10;
 export function StatusBar({ agent }: StatusBarProps) {
   const colors = getThemeColors();
   const [, force] = useState(0);
+  const lastSnapshotRef = useRef<string>(snapshotStats(agent.spinnerStats, agent.currentStrategy));
   useEffect(() => {
-    const id = setInterval(() => force((n) => n + 1), 500);
+    const id = setInterval(() => {
+      const snap = snapshotStats(agent.spinnerStats, agent.currentStrategy);
+      if (snap !== lastSnapshotRef.current) {
+        lastSnapshotRef.current = snap;
+        force((n) => n + 1);
+      }
+    }, 500);
     return () => clearInterval(id);
-  }, []);
+  }, [agent]);
 
   const stats: SpinnerStats | null = agent.spinnerStats;
   const strategy = agent.currentStrategy;

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -1,5 +1,5 @@
 import { useSyncExternalStore, type ReactNode } from 'react';
-import { Box, Text, useStdout } from 'ink';
+import { Box, Static, Text, useStdout } from 'ink';
 import type {
   CoreMessage,
   CoreUserMessage,
@@ -18,77 +18,98 @@ import { truncate } from '../text.js';
 import { renderMarkdown } from './markdown.js';
 import type { MessageStore, StreamEvent } from './message-store.js';
 
+/**
+ * One finalized transcript entry. `<App>` builds these at turn boundaries and
+ * appends them to the append-only log it feeds into `<Static>` (#232). Each
+ * item snapshots everything `<MessageBlock>` needs at commit time — the
+ * rewrite original (known at turn start) and the timing footer (known at turn
+ * end) — because a Static item is written to terminal scrollback once and can
+ * never be re-rendered. `toolDetails` is captured per-item for the same
+ * reason: toggling the setting only affects subsequent turns.
+ */
+export interface StaticItem {
+  /** Stable, monotonic id (never the history index — that shifts on /compact). */
+  key: string;
+  message: CoreMessage;
+  rewriteOriginal?: string;
+  timing?: { endedAt: number; durationMs: number };
+  toolDetails: boolean;
+}
+
 interface ThreadProps {
-  history: CoreMessage[];
+  /**
+   * Append-only log of finalized turns (#232). Rendered through Ink's
+   * `<Static>` so each entry is written to terminal scrollback exactly once
+   * and never repainted — that is what makes scrolling up hold position.
+   */
+  staticItems: StaticItem[];
   /**
    * Phase C (#214): when `busy === true`, `<Thread>` mounts a
    * `<StreamingAssistantMessage>` below the static history that subscribes
    * to `messageStore` and renders per-token deltas + inline tool-call /
    * tool-result blocks as they arrive. Omitted (or `busy === false`) means
-   * the static-history `<Thread>` path runs identically to Phase B.
+   * only the finalized `<Static>` log renders.
    */
   messageStore?: MessageStore;
   busy?: boolean;
   /** Rendered as a dim notice below the transcript when the last turn was Esc-cancelled. */
   interrupted?: boolean;
   /**
-   * Per-history-index map of the user's original text when the rewriter
-   * replaced it before dispatch. `UserMessage` reads this to show the original
-   * (not the rewritten) text and tag it with the rewrite icon next to the
-   * timestamp. Same icon is used in `/agent-options` so the meaning is shared.
+   * Whether the in-flight `<StreamingAssistantMessage>` shows full tool-call
+   * arguments and result bodies. Read live from `config.toolDetails` so the
+   * current turn responds to a mid-turn toggle; finalized items carry their
+   * own snapshot in `StaticItem.toolDetails`.
    */
-  rewriteOriginals?: ReadonlyMap<number, string>;
-  /**
-   * Per-history-index timestamp + duration of completed turns. Rendered as a
-   * dim footer (`hh:mm · 1.2s`) under every assistant message that has an
-   * entry — mirrors the timestamp `<UserMessage>` shows under the outbound
-   * message. Owned by `<App>` so the footer persists across follow-up turns.
-   */
-  turnTimings?: ReadonlyMap<number, { endedAt: number; durationMs: number }>;
-  /**
-   * Whether to show full tool-call arguments and result bodies in the
-   * transcript. Tool names are always shown; only the args summary next to
-   * the name and the `↳ …` result row are suppressed when this is false.
-   * Mirrors the `Tool details` setting in `/agent-options`.
-   */
-  toolDetails?: boolean;
+  streamingToolDetails?: boolean;
 }
 
 /** Icon used wherever the prompt-rewriter feature surfaces in the UI. */
 export const REWRITE_ICON = '✎';
 
 /**
- * Renders the conversation as a flowing list of message blocks. Reads the
- * AI SDK's `CoreMessage[]` shape directly — same array `Agent.getHistory()`
- * returns. Re-renders when `<App>` bumps `historyVersion` after a turn ends.
- *
- * Streaming-output migration (Phase C) will keep this component but feed it
- * from an in-memory message store so the in-flight assistant message updates
- * token-by-token. Phase B renders the message in bulk at turn end.
+ * Renders the conversation. Finalized turns flow through Ink's `<Static>`
+ * (#232): each `StaticItem` is written to terminal scrollback exactly once and
+ * is never repainted, so scrolling up holds position even as the dynamic
+ * region below (streaming message, spinner, prompt, status bar) keeps
+ * repainting. `<App>` owns the append-only `staticItems` log and appends to it
+ * at turn boundaries; only `/clear` remounts this component (via a key bump)
+ * to reset `<Static>`'s internal high-water cursor.
  */
 export function Thread({
-  history,
+  staticItems,
   messageStore,
   busy,
   interrupted,
-  rewriteOriginals,
-  turnTimings,
-  toolDetails = false,
+  streamingToolDetails = false,
 }: ThreadProps) {
   const colors = getThemeColors();
+  const { stdout } = useStdout();
+  // Ink's <Static> hoists its output to the top, OUTSIDE the App's outer
+  // paddingX={2} box and WITHOUT stretching items to the terminal width.
+  // Two consequences each item must compensate for: (1) percentage widths
+  // (UserMessage right-aligns with width="85%") collapse without an explicit
+  // parent width, and (2) static rows would start at column 0 while the
+  // dynamic region (streaming message, prompt) is indented by 2. Give every
+  // item the full terminal width + matching horizontal padding so finalized
+  // turns line up with the live region. Width is captured at commit time;
+  // already-printed rows don't rewrap on resize (an accepted Static tradeoff).
+  const itemWidth = stdout?.columns ?? 80;
   return (
     <Box flexDirection="column">
-      {history.map((msg, idx) => (
-        <MessageBlock
-          key={idx}
-          message={msg}
-          rewriteOriginal={rewriteOriginals?.get(idx)}
-          timing={turnTimings?.get(idx)}
-          toolDetails={toolDetails}
-        />
-      ))}
+      <Static items={staticItems}>
+        {(item) => (
+          <Box key={item.key} width={itemWidth} flexDirection="column" paddingX={2}>
+            <MessageBlock
+              message={item.message}
+              rewriteOriginal={item.rewriteOriginal}
+              timing={item.timing}
+              toolDetails={item.toolDetails}
+            />
+          </Box>
+        )}
+      </Static>
       {busy && messageStore && (
-        <StreamingAssistantMessage store={messageStore} toolDetails={toolDetails} />
+        <StreamingAssistantMessage store={messageStore} toolDetails={streamingToolDetails} />
       )}
       {!busy && interrupted && (
         <Box marginTop={1}>
@@ -347,7 +368,7 @@ function StreamingToolResult({
   );
 }
 
-function MessageBlock({
+export function MessageBlock({
   message,
   rewriteOriginal,
   timing,

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -114,17 +114,25 @@ interface AgentSpy {
   compactHistory: ReturnType<typeof vi.fn>;
 }
 
-function makeAgent(spy: Partial<AgentSpy> = {}, history: CoreMessage[] = []): Agent {
+function makeAgent(
+  spy: Partial<AgentSpy> = {},
+  history: CoreMessage[] = [],
+  // Optional holder so a test can REPLACE the history array reference mid-turn
+  // (what Agent.processInput does on auto-compression). When omitted, history is
+  // a stable in-place array.
+  holder?: { current: CoreMessage[] },
+): Agent {
+  const box = holder ?? { current: history };
   const stubs: AgentSpy = {
     processInput: vi.fn(async () => {}),
     clearHistory: vi.fn(() => {
-      history.length = 0;
+      box.current.length = 0;
     }),
     compactHistory: vi.fn(async () => ({ compacted: false })),
     ...spy,
   };
   return {
-    getHistory: () => history,
+    getHistory: () => box.current,
     clearHistory: stubs.clearHistory,
     compactHistory: stubs.compactHistory,
     processInput: stubs.processInput,
@@ -178,6 +186,8 @@ interface HarnessOptions {
   config?: Partial<BernardConfig>;
   /** Live history array `getHistory()` returns; mutate it from `processInput`. */
   history?: CoreMessage[];
+  /** Holder whose `.current` `getHistory()` returns; swap it to simulate a mid-turn replace. */
+  holder?: { current: CoreMessage[] };
 }
 
 function renderApp(opts: HarnessOptions = {}) {
@@ -203,7 +213,7 @@ function renderApp(opts: HarnessOptions = {}) {
   const config = makeConfig(opts.config);
   const utils = render(
     createElement(App, {
-      agent: makeAgent(agentSpy, opts.history),
+      agent: makeAgent(agentSpy, opts.history, opts.holder),
       config,
       historyStore,
       provenanceHistoryStore,
@@ -446,6 +456,39 @@ describe('<App> Static transcript (#232)', () => {
     // History was emptied by clearHistory(); a new turn must commit cleanly.
     await submit(stdin, 'second turn');
     expect(lastFrame() ?? '').toContain('answer for second turn');
+    unmount();
+  });
+
+  it('commits the turn output when history is replaced mid-turn by compression (#243)', async () => {
+    // Reproduces the Copilot review bug: a length-based commit cursor strands
+    // the turn's assistant message when processInput compresses (reassigns) the
+    // history array to a SHORTER one mid-turn. Seed a long prior history so the
+    // stale cursor (its length after the user push) ends up past the end of the
+    // compressed array — the unfixed code would no-op and drop the answer.
+    const prior: CoreMessage[] = Array.from({ length: 12 }, (_, i) => ({
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `prior ${i}`,
+    }));
+    const holder = { current: [...prior] };
+    const processInput = vi.fn(async (text: string) => {
+      // turn start (synchronous, before any await): push the user message onto
+      // the current array — this is what the turn-start commit sees.
+      holder.current.push({ role: 'user', content: `[2026-01-01T00:00:00+00:00] ${text}` });
+      await Promise.resolve();
+      // mid-turn auto-compression: replace history with a much shorter array
+      // that keeps a summary + the most recent user message, then append the
+      // assistant reply (as the real agent loop does).
+      holder.current = [
+        { role: 'assistant', content: 'context summary' },
+        { role: 'user', content: `[2026-01-01T00:00:00+00:00] ${text}` },
+        { role: 'assistant', content: 'answer survives compression' },
+      ];
+    });
+    const { stdin, lastFrame, unmount } = renderApp({ holder, agent: { processInput } });
+    await tick();
+    await submit(stdin, 'trigger compression');
+    expect(processInput).toHaveBeenCalled();
+    expect(lastFrame() ?? '').toContain('answer survives compression');
     unmount();
   });
 });

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -67,6 +67,7 @@ process.env.BERNARD_HOME = TMP_HOME;
 // ── Imports under test (after mocks + env) ──────────────────────────────
 import { App, type AppStores } from '../App.js';
 import { getInkHandlers } from '../ink-handlers.js';
+import type { CoreMessage } from 'ai';
 import type { BernardConfig } from '../../config.js';
 import type { Agent } from '../../agent.js';
 import type { HistoryStore } from '../../history.js';
@@ -113,15 +114,17 @@ interface AgentSpy {
   compactHistory: ReturnType<typeof vi.fn>;
 }
 
-function makeAgent(spy: Partial<AgentSpy> = {}): Agent {
+function makeAgent(spy: Partial<AgentSpy> = {}, history: CoreMessage[] = []): Agent {
   const stubs: AgentSpy = {
     processInput: vi.fn(async () => {}),
-    clearHistory: vi.fn(),
+    clearHistory: vi.fn(() => {
+      history.length = 0;
+    }),
     compactHistory: vi.fn(async () => ({ compacted: false })),
     ...spy,
   };
   return {
-    getHistory: () => [],
+    getHistory: () => history,
     clearHistory: stubs.clearHistory,
     compactHistory: stubs.compactHistory,
     processInput: stubs.processInput,
@@ -173,6 +176,8 @@ interface HarnessOptions {
   agent?: Partial<AgentSpy>;
   alertBanner?: string;
   config?: Partial<BernardConfig>;
+  /** Live history array `getHistory()` returns; mutate it from `processInput`. */
+  history?: CoreMessage[];
 }
 
 function renderApp(opts: HarnessOptions = {}) {
@@ -198,7 +203,7 @@ function renderApp(opts: HarnessOptions = {}) {
   const config = makeConfig(opts.config);
   const utils = render(
     createElement(App, {
-      agent: makeAgent(agentSpy),
+      agent: makeAgent(agentSpy, opts.history),
       config,
       historyStore,
       provenanceHistoryStore,
@@ -388,6 +393,59 @@ describe('<App> /clear', () => {
     await submit(stdin, '/clear --bogus');
     expect(lastFrame()).toContain('Usage: /clear');
     expect(agentSpy.clearHistory).not.toHaveBeenCalled();
+    unmount();
+  });
+});
+
+describe('<App> Static transcript (#232)', () => {
+  beforeEach(() => {
+    process.env.BERNARD_HOME = TMP_HOME;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('commits the user then assistant message into the transcript after a turn', async () => {
+    // Stateful history: processInput pushes the user + assistant messages the
+    // way the real Agent does, so App.commitNewHistory has something to freeze
+    // into the <Static> log.
+    const history: CoreMessage[] = [];
+    const processInput = vi.fn(async (text: string) => {
+      history.push({ role: 'user', content: `[2026-01-01T00:00:00+00:00] ${text}` });
+      history.push({ role: 'assistant', content: 'committed answer' });
+    });
+    const { stdin, lastFrame, unmount } = renderApp({ history, agent: { processInput } });
+    await tick();
+    await submit(stdin, 'render me');
+    const frame = lastFrame() ?? '';
+    expect(processInput).toHaveBeenCalled();
+    expect(frame).toContain('render me');
+    expect(frame).toContain('committed answer');
+    unmount();
+  });
+
+  it('/clear resets the commit boundary so a post-clear turn still commits', async () => {
+    // The physical scrollback wipe (`\x1b[3J\x1b[2J\x1b[H`) goes to the real
+    // process.stdout, not ink-testing-library's buffer, and Ink's <Static>
+    // never un-prints — so a `not.toContain` on the old text isn't observable
+    // in this harness (a real terminal clears it). What IS observable, and is
+    // the actual regression risk, is that /clear resets committedLenRef to 0
+    // so the NEXT turn re-commits from a fresh history without index drift.
+    const history: CoreMessage[] = [];
+    const processInput = vi.fn(async (text: string) => {
+      history.push({ role: 'user', content: `[2026-01-01T00:00:00+00:00] ${text}` });
+      history.push({ role: 'assistant', content: `answer for ${text}` });
+    });
+    const { stdin, lastFrame, agentSpy, unmount } = renderApp({ history, agent: { processInput } });
+    await tick();
+    await submit(stdin, 'first turn');
+    expect(lastFrame() ?? '').toContain('answer for first turn');
+    await submit(stdin, '/clear');
+    expect(agentSpy.clearHistory).toHaveBeenCalled();
+    expect(lastFrame() ?? '').toContain('Conversation history cleared');
+    // History was emptied by clearHistory(); a new turn must commit cleanly.
+    await submit(stdin, 'second turn');
+    expect(lastFrame() ?? '').toContain('answer for second turn');
     unmount();
   });
 });

--- a/src/ui/__tests__/StatusBar.test.tsx
+++ b/src/ui/__tests__/StatusBar.test.tsx
@@ -83,3 +83,18 @@ describe('<StatusBar> token readout labels (#234)', () => {
     expect(frame).toMatch(/ctx \S+ *●/);
   });
 });
+
+describe('<StatusBar> idle-tick guard (#232)', () => {
+  it('still refreshes the readout when spinnerStats changes between polls', async () => {
+    // The poll only forces a re-render when a rendered value actually moved
+    // (#232). This guards the positive path: an in-place mutation of the
+    // stable spinnerStats object (exactly how the token hooks update it) must
+    // surface on the next poll, so the equality snapshot can't be over-eager.
+    const agent = stubAgent(0.55);
+    const { lastFrame } = render(createElement(StatusBar, { agent }));
+    expect(stripAnsi(lastFrame() ?? '')).toMatch(/turn\s+1\.2k↑/);
+    (agent.spinnerStats as { turnPromptTokens: number }).turnPromptTokens = 2222;
+    await new Promise((r) => setTimeout(r, 600)); // past the 500ms poll interval
+    expect(stripAnsi(lastFrame() ?? '')).toMatch(/turn\s+2\.2k↑/);
+  });
+});

--- a/src/ui/__tests__/Thread.test.tsx
+++ b/src/ui/__tests__/Thread.test.tsx
@@ -3,13 +3,32 @@ import { render } from 'ink-testing-library';
 import { createElement } from 'react';
 import stripAnsi from 'strip-ansi';
 import type { CoreMessage } from 'ai';
-import { Thread } from '../Thread.js';
+import { Thread, type StaticItem } from '../Thread.js';
 import { MessageStore } from '../message-store.js';
+
+/**
+ * Build the append-only `staticItems` log <Thread> now renders through
+ * <Static> (#232). Each finalized message snapshots its own `toolDetails`;
+ * `extras` lets a test attach a timing footer or rewrite original to a
+ * specific index.
+ */
+function items(
+  history: CoreMessage[],
+  toolDetails = false,
+  extras?: Record<number, Partial<StaticItem>>,
+): StaticItem[] {
+  return history.map((message, i) => ({
+    key: String(i),
+    message,
+    toolDetails,
+    ...(extras?.[i] ?? {}),
+  }));
+}
 
 describe('<Thread>', () => {
   it('renders a user message with the right-side marker', () => {
     const history: CoreMessage[] = [{ role: 'user', content: 'hello bernard' }];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('hello bernard');
     expect(frame).toContain('❯');
@@ -17,16 +36,46 @@ describe('<Thread>', () => {
 
   it('renders an "interrupted" notice when the prop is set and not busy', () => {
     const history: CoreMessage[] = [{ role: 'user', content: 'hi' }];
-    const { lastFrame } = render(createElement(Thread, { history, interrupted: true }));
+    const { lastFrame } = render(
+      createElement(Thread, { staticItems: items(history), interrupted: true }),
+    );
     expect(lastFrame() ?? '').toContain('you interrupted');
   });
 
   it('renders an assistant message with the chevron label', () => {
     const history: CoreMessage[] = [{ role: 'assistant', content: 'hi there' }];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('❮');
     expect(frame).toContain('hi there');
+  });
+
+  it('renders the per-item timing footer under an assistant message', () => {
+    const history: CoreMessage[] = [{ role: 'assistant', content: 'done' }];
+    const { lastFrame } = render(
+      createElement(Thread, {
+        staticItems: items(history, false, {
+          0: { timing: { endedAt: new Date('2026-01-01T12:00:00Z').getTime(), durationMs: 1200 } },
+        }),
+      }),
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('done');
+    // 1200ms → "1.2s" per formatDuration.
+    expect(frame).toContain('1.2s');
+  });
+
+  it('shows the rewrite original (not the dispatched text) with the rewrite icon', () => {
+    const history: CoreMessage[] = [{ role: 'user', content: 'REWRITTEN dispatched text' }];
+    const { lastFrame } = render(
+      createElement(Thread, {
+        staticItems: items(history, false, { 0: { rewriteOriginal: 'original ask' } }),
+      }),
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('original ask');
+    expect(frame).not.toContain('REWRITTEN dispatched text');
+    expect(frame).toContain('✎');
   });
 
   it('renders structured assistant content (text + reasoning + tool-call)', () => {
@@ -45,7 +94,7 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history, true) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('plain output');
     expect(frame).toContain('thinking…');
@@ -67,7 +116,7 @@ describe('<Thread>', () => {
         ],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history, true) }));
     expect(lastFrame()).toContain('↳');
     expect(lastFrame()).toContain('file1');
   });
@@ -87,7 +136,7 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history, true) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ shell');
     expect(frame).toContain('…');
@@ -119,7 +168,7 @@ describe('<Thread>', () => {
         ],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ shell');
     expect(frame).not.toContain('{"cmd":"ls"}');
@@ -132,7 +181,7 @@ describe('<Thread>', () => {
       { role: 'system', content: 'YOU ARE BERNARD' },
       { role: 'user', content: 'hi' },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = lastFrame() ?? '';
     expect(frame).not.toContain('YOU ARE BERNARD');
     expect(frame).toContain('hi');
@@ -143,7 +192,7 @@ describe('<Thread>', () => {
     store.append({ kind: 'text-delta', text: 'hello' });
     store.append({ kind: 'text-delta', text: ' world' });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: true }),
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('❮');
@@ -156,10 +205,10 @@ describe('<Thread>', () => {
     store.append({ kind: 'tool-result', callId: 'c1', result: 'ok', isError: false });
     const { lastFrame } = render(
       createElement(Thread, {
-        history: [],
+        staticItems: [],
         messageStore: store,
         busy: true,
-        toolDetails: true,
+        streamingToolDetails: true,
       }),
     );
     const frame = lastFrame() ?? '';
@@ -173,10 +222,10 @@ describe('<Thread>', () => {
     store.append({ kind: 'text-delta', text: 'sub says', agentLabel: 'sub:1' });
     const { lastFrame } = render(
       createElement(Thread, {
-        history: [],
+        staticItems: [],
         messageStore: store,
         busy: true,
-        toolDetails: true,
+        streamingToolDetails: true,
       }),
     );
     const frame = lastFrame() ?? '';
@@ -205,7 +254,7 @@ describe('<Thread>', () => {
       agentLabel: 'wrap:3',
     });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: true }),
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('main says');
@@ -230,7 +279,7 @@ describe('<Thread>', () => {
       isError: false,
     });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: true }),
     );
     const frame = lastFrame() ?? '';
     // Tool name still surfaces (helps the user see "what is bernard doing").
@@ -252,7 +301,7 @@ describe('<Thread>', () => {
       isError: false,
     });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: true }),
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('hi');
@@ -265,7 +314,7 @@ describe('<Thread>', () => {
     const store = new MessageStore();
     store.append({ kind: 'text-delta', text: 'streaming answer' });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: true }),
     );
     expect(lastFrame() ?? '').toContain('streaming answer');
   });
@@ -302,7 +351,7 @@ describe('<Thread>', () => {
         content: [{ type: 'text', text: 'done' }] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ web_read');
     expect(frame).not.toContain('aaro.mil');
@@ -315,7 +364,7 @@ describe('<Thread>', () => {
     const store = new MessageStore();
     store.append({ kind: 'text-delta', text: 'should not render' });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: false }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: false }),
     );
     const frame = lastFrame() ?? '';
     expect(frame).not.toContain('should not render');
@@ -341,7 +390,7 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history, true) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ plan');
     expect(frame).toContain('1. Run the tests');
@@ -362,7 +411,7 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history, toolDetails: true }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history, true) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('step 1 → done · verified by run');
   });
@@ -384,17 +433,15 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ plan');
     expect(frame).not.toContain('hidden step');
   });
 
   it('renders assistant markdown formatted (no literal ** delimiters)', () => {
-    const history: CoreMessage[] = [
-      { role: 'assistant', content: 'some **bold text** here' },
-    ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const history: CoreMessage[] = [{ role: 'assistant', content: 'some **bold text** here' }];
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = stripAnsi(lastFrame() ?? '');
     expect(frame).toContain('❮'); // chevron regression guard
     expect(frame).toContain('bold text');
@@ -402,10 +449,8 @@ describe('<Thread>', () => {
   });
 
   it('renders assistant headings without the # prefix', () => {
-    const history: CoreMessage[] = [
-      { role: 'assistant', content: '# Big Title\n\nbody text' },
-    ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const history: CoreMessage[] = [{ role: 'assistant', content: '# Big Title\n\nbody text' }];
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = stripAnsi(lastFrame() ?? '');
     expect(frame).toContain('Big Title');
     expect(frame).not.toContain('# Big Title');
@@ -417,7 +462,7 @@ describe('<Thread>', () => {
     store.append({ kind: 'text-delta', text: 'streamed **bo' });
     store.append({ kind: 'text-delta', text: 'ld**' });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true }),
+      createElement(Thread, { staticItems: [], messageStore: store, busy: true }),
     );
     const frame = stripAnsi(lastFrame() ?? '');
     expect(frame).toContain('❮');
@@ -435,7 +480,7 @@ describe('<Thread>', () => {
         ] as unknown as CoreMessage['content'],
       },
     ];
-    const { lastFrame } = render(createElement(Thread, { history }));
+    const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));
     const frame = stripAnsi(lastFrame() ?? '');
     expect(frame).toContain('**scratchpad**');
     expect(frame).toContain('answer');
@@ -452,9 +497,19 @@ describe('<Thread>', () => {
         steps: [{ description: 'streamed step', verification: 'v' }],
       },
     });
-    store.append({ kind: 'tool-result', callId: 'p4', result: 'Plan created with 1 steps.', isError: false });
+    store.append({
+      kind: 'tool-result',
+      callId: 'p4',
+      result: 'Plan created with 1 steps.',
+      isError: false,
+    });
     const { lastFrame } = render(
-      createElement(Thread, { history: [], messageStore: store, busy: true, toolDetails: true }),
+      createElement(Thread, {
+        staticItems: [],
+        messageStore: store,
+        busy: true,
+        streamingToolDetails: true,
+      }),
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⚙ plan');


### PR DESCRIPTION
Fixes #232.

## Problem

Scrolling up to read older responses was nearly impossible — the viewport snapped back to the bottom within ~500ms, every time, during *and between* turns.

Two compounding root causes:
1. **The entire transcript lived in Ink's dynamic region.** `<Thread>` mapped the full `CoreMessage[]` on every render and was keyed by `historyVersion`, so each turn boundary *remounted and repainted the whole conversation*. When the transcript is taller than the terminal, Ink reprints the full tree and the terminal resets scroll to the bottom.
2. **A perpetual idle timer.** `StatusBar` forced a re-render every 500ms unconditionally, repainting the dynamic region twice a second even while idle.

## Fix

### Part A — finalized history → Ink `<Static>` (the real fix)
Ink's `<Static>` writes each item to terminal scrollback exactly once and never repaints it, so scrolling up holds position while the small dynamic region (streaming message, spinner, prompt, status bar) keeps updating at the bottom.

- `<App>` owns an **append-only `staticItems` log** and commits to it at the two turn boundaries where per-message extras are known — the rewrite original at turn start, the timing footer at turn end.
- **Monotonic item keys** (not the history index) so `/compact`'s index shift can't collide with already-emitted items.
- **`/clear`** resets the log and bumps a `staticEpoch` key to remount `<Thread>` — the only way to reset `<Static>`'s internal high-water cursor — alongside the existing `\x1b[3J\x1b[2J\x1b[H` scrollback wipe.
- **`/compact`** just resyncs the commit boundary; the prior transcript stays in scrollback (it genuinely happened) and new turns keep appending below. This is *better* than the old behavior, which re-rendered everything.
- Removes `historyVersion` plus the two index-keyed ref maps (`turnTimings` / `rewriteOriginals`) — they only existed to support full re-render; their data is now captured into each item at commit time.
- Each `<Static>` item gets an **explicit full terminal width + `paddingX`** so `UserMessage`'s `width="85%"` right-align resolves correctly and rows line up with the dynamic region (Static hoists its output outside the App's outer padding box and does not stretch children — caught while porting, would have wrapped user messages badly otherwise).

### Part B — stop idle StatusBar churn
The 500ms poll now snapshots the rendered scalar fields and only forces a re-render when one actually changed. An idle session mutates nothing, so the dynamic region stops repainting entirely.

## Accepted tradeoffs (per the issue)
Standard for Static-based CLIs: `/theme` won't recolor already-printed messages, terminal resize won't rewrap them, and toggling **Tool details** only affects subsequent turns. The in-flight streaming message still reads `config.toolDetails` live.

## Tests
- `Thread.test.tsx` reworked to the new `staticItems` API; adds coverage for the per-item timing footer and the rewrite-original display.
- `App.test.tsx` adds a stateful-history harness verifying a turn commits user + assistant into the transcript, and that `/clear` resets the commit boundary so a post-clear turn still commits.
- `StatusBar.test.tsx` adds an idle-tick-guard test (a `spinnerStats` mutation still surfaces on the next poll).
- Full suite green (2774). Build clean. Verified up front that `ink-testing-library`'s `lastFrame()` captures `<Static>` output.

Pre-existing lint/format debt on `bernard-1-0-0` (App.tsx prettier spots, the `react-hooks/exhaustive-deps` disable, MenuOverlay test `any`, Thread.tsx `formatPlanLines` wrap) is untouched — this PR adds **zero** new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)