### PR TITLE
fix(ui): Shift-Tab viewers replace the thread + scrollable history (#211)

### DIFF
--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -25,6 +25,12 @@ describe('formatTokenCount', () => {
     expect(formatTokenCount(12345)).toBe('12k');
     expect(formatTokenCount(99999)).toBe('100k');
   });
+
+  it('renders non-finite token counts as 0 (no "NaNk" in the footer)', () => {
+    expect(formatTokenCount(NaN)).toBe('0');
+    expect(formatTokenCount(undefined as unknown as number)).toBe('0');
+    expect(formatTokenCount(Infinity)).toBe('0');
+  });
 });
 
 describe('buildSpinnerMessage', () => {
@@ -42,6 +48,28 @@ describe('buildSpinnerMessage', () => {
   it('returns "Thinking (Xs)" when no tokens have flowed yet', () => {
     const msg = buildSpinnerMessage(makeStats({ startTime: Date.now() - 5000 }));
     expect(msg).toMatch(/^Thinking \(\d+s\)$/);
+  });
+
+  it('treats non-finite token counts as 0 — never emits NaN', () => {
+    const nan = NaN as number;
+    const allNaN = buildSpinnerMessage(
+      makeStats({
+        startTime: Date.now() - 1000,
+        turnPromptTokens: nan,
+        turnCompletionTokens: nan,
+        latestPromptTokens: nan,
+      }),
+    );
+    // No usage yet → the bare "Thinking" form, and no "NaN" anywhere.
+    expect(allNaN).toMatch(/^Thinking \(\d+s\)$/);
+    expect(allNaN).not.toContain('NaN');
+
+    // Tokens present but latest is NaN → percentage must still be a number.
+    const partialNaN = buildSpinnerMessage(
+      makeStats({ turnPromptTokens: 1234, turnCompletionTokens: 56, latestPromptTokens: nan }),
+    );
+    expect(partialNaN).not.toContain('NaN');
+    expect(partialNaN).toMatch(/\d+% until compression/);
   });
 
   it('includes up / down counts and a remaining-percentage tail when populated', () => {

--- a/src/output.ts
+++ b/src/output.ts
@@ -39,7 +39,15 @@ export interface SpinnerStats {
   contextWindowOverride?: number;
 }
 
+/** Token counts can arrive NaN/undefined when a turn errors early; treat those as 0. */
+export function finiteOr0(n: number): number {
+  return Number.isFinite(n) ? n : 0;
+}
+
 export function formatTokenCount(n: number): string {
+  // Token fields can be NaN/undefined when a turn errors before any usage is
+  // reported — render those as 0 rather than letting "NaNk" reach the footer.
+  if (!Number.isFinite(n)) return '0';
   if (n < 1000) return String(n);
   const k = n / 1000;
   return k >= 10 ? `${Math.round(k)}k` : `${k.toFixed(1)}k`;
@@ -55,18 +63,23 @@ function formatElapsed(ms: number): string {
 
 export function buildSpinnerMessage(stats: SpinnerStats): string {
   const elapsed = formatElapsed(Date.now() - stats.startTime);
+  // Coalesce non-finite token fields (a turn can error before usage is
+  // reported) so NaN never leaks into the readout or the percentage.
+  const promptTokens = finiteOr0(stats.turnPromptTokens);
+  const completionTokens = finiteOr0(stats.turnCompletionTokens);
+  const latestPromptTokens = finiteOr0(stats.latestPromptTokens);
 
-  if (stats.turnPromptTokens === 0 && stats.turnCompletionTokens === 0) {
+  if (promptTokens === 0 && completionTokens === 0) {
     return `Thinking (${elapsed})`;
   }
 
-  const up = formatTokenCount(stats.turnPromptTokens);
-  const down = formatTokenCount(stats.turnCompletionTokens);
+  const up = formatTokenCount(promptTokens);
+  const down = formatTokenCount(completionTokens);
   const contextWindow = getContextWindow(stats.model, stats.contextWindowOverride);
   const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
   const remainingPct = Math.max(
     0,
-    Math.round(((thresholdTokens - stats.latestPromptTokens) / thresholdTokens) * 100),
+    Math.round(((thresholdTokens - latestPromptTokens) / thresholdTokens) * 100),
   );
 
   return `Thinking (${elapsed} | ${up}↑ ${down}↓ | ${remainingPct}% until compression)`;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2453,7 +2453,7 @@ export function App({
         <SourcesViewer
           agent={agent}
           onClose={() => setActiveOverlay(null)}
-          onCycleTab={() => setActiveOverlay(null)}
+          onCycleTab={() => setActiveOverlay('status')}
         />
       )}
       {activeOverlay === 'menu' && pendingMenu && (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -391,30 +391,33 @@ export function App({
   };
 
   // Gate the App-level useInput so it never fires concurrently with an
-  // overlay's own useInput. Modal overlays (menu, confirm, help, text-input)
-  // own the keystream; viewer overlays (status, sources) leave it to App so
-  // Esc can close them and Shift-Tab can keep cycling.
-  const appInputActive =
-    activeOverlay === null || activeOverlay === 'status' || activeOverlay === 'sources';
+  // overlay's own useInput. Every overlay — modal (menu, confirm, help,
+  // text-input) AND viewer (status, sources) — owns its own keystream now;
+  // the viewers handle Esc/Shift-Tab/scroll inside <ScrollableOverlay> and
+  // forward close/cycle back via callbacks. App's useInput only runs when no
+  // overlay is open: Shift-Tab opens the first viewer tab, Esc interrupts a
+  // busy turn.
+  const appInputActive = activeOverlay === null;
+  // A Shift-Tab viewer tab takes over the screen: while one is open the live
+  // chrome (spinner, plan panel, toast, prompt, hint/status bars) is hidden so
+  // the viewer reads as a replacement for the thread, not an addition below it.
+  // <Thread> itself stays mounted (unmounting it reprints <Static> scrollback).
+  const viewerActive = activeOverlay === 'status' || activeOverlay === 'sources';
 
   useInput(
     (_input, key) => {
-      // Shift-Tab cycles viewer tabs only while idle.
+      // Shift-Tab opens the first viewer tab (Agent Status) while idle; the
+      // viewer itself cycles to Sources and back to the thread.
       if (key.shift && key.tab) {
         if (busy) return;
-        setActiveOverlay((curr) => {
-          if (curr === null) return 'status';
-          if (curr === 'status') return 'sources';
-          return null;
-        });
+        setActiveOverlay('status');
         return;
       }
       if (key.escape) {
-        debugLog('app:esc', { busy, activeOverlay, hasTurnAbort: !!turnAbortRef.current });
-        if (activeOverlay) {
-          closeOverlay();
-          return;
-        }
+        // This handler only runs when no overlay is open (isActive gate), so
+        // Esc here can only mean "interrupt the in-flight turn". Each overlay
+        // owns its own Esc-to-close via its own useInput.
+        debugLog('app:esc', { busy, hasTurnAbort: !!turnAbortRef.current });
         if (busy) {
           setInterrupted(true);
           turnAbortRef.current?.abort();
@@ -2413,30 +2416,46 @@ export function App({
         interrupted={interrupted}
         streamingToolDetails={config.toolDetails}
       />
-      {busy && (
-        <Box marginTop={1}>
-          <Spinner label="thinking…" />
-        </Box>
+      {!viewerActive && (
+        <>
+          {busy && (
+            <Box marginTop={1}>
+              <Spinner label="thinking…" />
+            </Box>
+          )}
+          <PlanPanel agent={agent} />
+          {toast && <Toast message={toast.message} variant={toast.variant} />}
+          <Prompt
+            disabled={busy || activeOverlay !== null}
+            onSubmit={handleSubmit}
+            onSlashActiveChange={setSlashActive}
+          />
+          <Box justifyContent="space-between">
+            <HintBar
+              busy={busy}
+              overlayActive={activeOverlay !== null}
+              slashActive={slashActive}
+            />
+            <StatusBar agent={agent} />
+          </Box>
+        </>
       )}
-      <PlanPanel agent={agent} />
-      {toast && <Toast message={toast.message} variant={toast.variant} />}
-      <Prompt
-        disabled={busy || activeOverlay !== null}
-        onSubmit={handleSubmit}
-        onSlashActiveChange={setSlashActive}
-      />
-      <Box justifyContent="space-between">
-        <HintBar busy={busy} overlayActive={activeOverlay !== null} slashActive={slashActive} />
-        <StatusBar agent={agent} />
-      </Box>
       {activeOverlay === 'status' && (
         <StatusViewer
           agent={agent}
           config={config}
           sessionAllowedCount={_sessionToolAllowlist.size}
+          onClose={() => setActiveOverlay(null)}
+          onCycleTab={() => setActiveOverlay('sources')}
         />
       )}
-      {activeOverlay === 'sources' && <SourcesViewer agent={agent} />}
+      {activeOverlay === 'sources' && (
+        <SourcesViewer
+          agent={agent}
+          onClose={() => setActiveOverlay(null)}
+          onCycleTab={() => setActiveOverlay(null)}
+        />
+      )}
       {activeOverlay === 'menu' && pendingMenu && (
         <MenuOverlay
           entries={pendingMenu.entries}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -114,6 +114,7 @@ import type {
   ValueResult,
 } from './menu-types.js';
 import { Thread, REWRITE_ICON, type StaticItem } from './Thread.js';
+import { formatAgentError, type ErrorPanelData } from './error-format.js';
 import { Prompt } from './Prompt.js';
 import { Spinner } from './Spinner.js';
 import { StatusBar } from './StatusBar.js';
@@ -2054,6 +2055,7 @@ export function App({
     setBusy(true);
     const turnStartedAt = Date.now();
     let turnCompleted = false;
+    let errorPanel: ErrorPanelData | null = null;
     const controller = new AbortController();
     turnAbortRef.current = controller;
     try {
@@ -2076,22 +2078,20 @@ export function App({
       const isAbort =
         err instanceof Error && (err.name === 'AbortError' || controller.signal.aborted);
       if (!isAbort) {
-        console.error('agent error:', err);
-        // When debug is on, also surface the error in the chat transcript so
-        // hangs / silent failures are visible without having to grep logs.
-        if (isDebugEnabled()) {
-          const message = err instanceof Error ? err.message : String(err);
-          const stack = err instanceof Error && err.stack ? err.stack : undefined;
-          const cause =
-            err instanceof Error && err.cause instanceof Error ? err.cause.stack : undefined;
-          debugLog('error:turn', { message, stack, cause });
-          const body = [`⚠ Agent error: ${message}`, stack, cause && `Caused by:\n${cause}`]
-            .filter(Boolean)
-            .join('\n\n');
-          // The finally-block commit freezes this into the transcript along
-          // with anything else added this turn — no separate bump needed.
-          agent.getHistory().push({ role: 'assistant', content: body });
+        const debug = isDebugEnabled();
+        if (debug) {
+          debugLog('error:turn', {
+            message: err instanceof Error ? err.message : String(err),
+            stack: err instanceof Error ? err.stack : undefined,
+            cause: err instanceof Error && err.cause instanceof Error ? err.cause.stack : undefined,
+          });
         }
+        // Surface every failed turn as a styled <ErrorPanel> in the transcript
+        // (committed after this turn's output, in the finally block). The full
+        // stack/cause only rides along under debug. This is a UI-only notice —
+        // deliberately NOT pushed into agent history, so the model's context
+        // isn't polluted with its own error text.
+        errorPanel = formatAgentError(err, debug);
       }
     } finally {
       persistAgentState({ agent, historyStore, provenanceHistoryStore });
@@ -2106,6 +2106,14 @@ export function App({
       const endedAt = Date.now();
       const timing = turnCompleted ? { endedAt, durationMs: endedAt - turnStartedAt } : undefined;
       commitNewHistory({ timing });
+      // Append the error panel after the turn's committed output so it reads
+      // as the turn's outcome (in the same batch as the commit above).
+      if (errorPanel) {
+        setStaticItems((prev) => [
+          ...prev,
+          { key: String(itemKeyRef.current++), toolDetails: config.toolDetails, error: errorPanel! },
+        ]);
+      }
     }
   }
 

--- a/src/ui/ErrorPanel.tsx
+++ b/src/ui/ErrorPanel.tsx
@@ -1,0 +1,46 @@
+import { Box, Text } from 'ink';
+import { getThemeColors } from '../theme.js';
+import type { ErrorPanelData } from './error-format.js';
+
+/**
+ * A bordered, error-styled transcript item for a failed turn. Replaces the old
+ * raw `⚠ Agent error: <stack…>` assistant message: a rounded error-colored
+ * frame with a friendly title + category tag, the unwrapped provider message,
+ * a recovery hint, and (debug only) the dim stack/cause beneath.
+ */
+export function ErrorPanel({ data }: { data: ErrorPanelData }) {
+  const colors = getThemeColors();
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      borderStyle="round"
+      borderColor={colors.error}
+      paddingX={1}
+    >
+      <Box>
+        <Text color={colors.error} bold>
+          ⚠ {data.title}
+        </Text>
+        <Text dimColor> · {data.category}</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text>{data.message}</Text>
+      </Box>
+      {data.hint && (
+        <Box marginTop={1}>
+          <Text color={colors.warning}>→ {data.hint}</Text>
+        </Box>
+      )}
+      {data.details && (
+        <Box flexDirection="column" marginTop={1}>
+          {data.details.split('\n').map((line, i) => (
+            <Text key={i} dimColor>
+              {line.length === 0 ? ' ' : line}
+            </Text>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import { getThemeColors } from '../theme.js';
-import { formatTokenCount, type SpinnerStats } from '../output.js';
+import { formatTokenCount, finiteOr0, type SpinnerStats } from '../output.js';
 import { getContextWindow, COMPRESSION_THRESHOLD } from '../context.js';
 import type { Agent } from '../agent.js';
 
@@ -58,9 +58,10 @@ export function StatusBar({ agent }: StatusBarProps) {
 
   const up = stats ? formatTokenCount(stats.turnPromptTokens) : '0';
   const down = stats ? formatTokenCount(stats.turnCompletionTokens) : '0';
+  const latestPromptTokens = stats ? finiteOr0(stats.latestPromptTokens) : 0;
   const contextWindow = stats ? getContextWindow(stats.model, stats.contextWindowOverride) : 1;
   const thresholdTokens = contextWindow * COMPRESSION_THRESHOLD;
-  const usedFrac = stats ? Math.min(1, Math.max(0, stats.latestPromptTokens / thresholdTokens)) : 0;
+  const usedFrac = stats ? Math.min(1, Math.max(0, latestPromptTokens / thresholdTokens)) : 0;
   const freePct = (1 - usedFrac) * 100;
 
   // Quantize the fill to half-dot resolution: a dot whose fractional fill

--- a/src/ui/Thread.tsx
+++ b/src/ui/Thread.tsx
@@ -16,6 +16,8 @@ type RedactedReasoningPart = { type: 'redacted-reasoning'; data: string };
 import { getThemeColors } from '../theme.js';
 import { truncate } from '../text.js';
 import { renderMarkdown } from './markdown.js';
+import { ErrorPanel } from './ErrorPanel.js';
+import type { ErrorPanelData } from './error-format.js';
 import type { MessageStore, StreamEvent } from './message-store.js';
 
 /**
@@ -30,10 +32,17 @@ import type { MessageStore, StreamEvent } from './message-store.js';
 export interface StaticItem {
   /** Stable, monotonic id (never the history index — that shifts on /compact). */
   key: string;
-  message: CoreMessage;
+  /** The finalized message. Omitted for synthetic items like {@link error}. */
+  message?: CoreMessage;
   rewriteOriginal?: string;
   timing?: { endedAt: number; durationMs: number };
   toolDetails: boolean;
+  /**
+   * When set, this item is a failed-turn notice rendered as `<ErrorPanel>`
+   * instead of a message. Lives in the UI transcript only — never pushed into
+   * the agent's LLM history.
+   */
+  error?: ErrorPanelData;
 }
 
 interface ThreadProps {
@@ -99,12 +108,16 @@ export function Thread({
       <Static items={staticItems}>
         {(item) => (
           <Box key={item.key} width={itemWidth} flexDirection="column" paddingX={2}>
-            <MessageBlock
-              message={item.message}
-              rewriteOriginal={item.rewriteOriginal}
-              timing={item.timing}
-              toolDetails={item.toolDetails}
-            />
+            {item.error ? (
+              <ErrorPanel data={item.error} />
+            ) : item.message ? (
+              <MessageBlock
+                message={item.message}
+                rewriteOriginal={item.rewriteOriginal}
+                timing={item.timing}
+                toolDetails={item.toolDetails}
+              />
+            ) : null}
           </Box>
         )}
       </Static>

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -315,7 +315,7 @@ describe('<App> Shift-Tab viewer tabs (#211)', () => {
     expect(frame).toContain('▸ Agent Status'); // active
     expect(frame).toContain('Sources'); // other tab listed
     expect(frame).not.toContain('▸ Sources'); // but not active
-    expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).toContain('esc close');
     expect(frame).not.toContain('commands');
 
     // Shift-Tab again → Sources tab active.

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -23,7 +23,7 @@ import { createElement } from 'react';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { ENTER, tick } from './_keys.js';
+import { ENTER, ESC, SHIFT_TAB, tick } from './_keys.js';
 
 // ── Module mocks (all hoisted by vitest) ────────────────────────────────
 
@@ -288,6 +288,61 @@ describe('<App> exit commands', () => {
     await tick();
     await submit(stdin, '/quit');
     expect(onExit).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});
+
+describe('<App> Shift-Tab viewer tabs (#211)', () => {
+  beforeEach(() => {
+    process.env.BERNARD_HOME = TMP_HOME;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Shift-Tab replaces the thread chrome with the Status viewer, then cycles to Sources and back', async () => {
+    const { stdin, lastFrame, unmount } = renderApp();
+    await tick();
+    // Idle: prompt chrome (HintBar) visible, no viewer.
+    expect(lastFrame()).toContain('commands');
+    expect(lastFrame()).not.toContain('Agent Status');
+
+    // Shift-Tab → Agent Status takes over; the HintBar chrome is hidden.
+    stdin.write(SHIFT_TAB);
+    await tick();
+    let frame = lastFrame() ?? '';
+    expect(frame).toContain('Agent Status');
+    expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).not.toContain('commands');
+
+    // Shift-Tab again → Sources tab (viewer owns the keystream now).
+    stdin.write(SHIFT_TAB);
+    await tick();
+    frame = lastFrame() ?? '';
+    expect(frame).toContain('Sources');
+    expect(frame).not.toContain('Agent Status');
+
+    // Shift-Tab once more → back to the thread with the prompt chrome restored.
+    stdin.write(SHIFT_TAB);
+    await tick();
+    frame = lastFrame() ?? '';
+    expect(frame).toContain('commands');
+    expect(frame).not.toContain('Agent Status');
+    expect(frame).not.toContain('Esc to close · Shift-Tab to switch tabs');
+    unmount();
+  });
+
+  it('Esc closes the viewer and restores the thread chrome', async () => {
+    const { stdin, lastFrame, unmount } = renderApp();
+    await tick();
+    stdin.write(SHIFT_TAB);
+    await tick();
+    expect(lastFrame()).toContain('Agent Status');
+    stdin.write(ESC);
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('Agent Status');
+    expect(frame).toContain('commands');
     unmount();
   });
 });

--- a/src/ui/__tests__/App.test.tsx
+++ b/src/ui/__tests__/App.test.tsx
@@ -300,35 +300,38 @@ describe('<App> Shift-Tab viewer tabs (#211)', () => {
     vi.clearAllMocks();
   });
 
-  it('Shift-Tab replaces the thread chrome with the Status viewer, then cycles to Sources and back', async () => {
+  it('Shift-Tab opens the Status tab, then cycles (and wraps) through the tab menu', async () => {
     const { stdin, lastFrame, unmount } = renderApp();
     await tick();
-    // Idle: prompt chrome (HintBar) visible, no viewer.
+    // Idle: prompt chrome (HintBar) visible, no viewer/tab menu.
     expect(lastFrame()).toContain('commands');
     expect(lastFrame()).not.toContain('Agent Status');
 
-    // Shift-Tab → Agent Status takes over; the HintBar chrome is hidden.
+    // Shift-Tab → Agent Status takes over; both tabs show in the bottom menu,
+    // Status marked active. The HintBar chrome is hidden.
     stdin.write(SHIFT_TAB);
     await tick();
     let frame = lastFrame() ?? '';
-    expect(frame).toContain('Agent Status');
+    expect(frame).toContain('▸ Agent Status'); // active
+    expect(frame).toContain('Sources'); // other tab listed
+    expect(frame).not.toContain('▸ Sources'); // but not active
     expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
     expect(frame).not.toContain('commands');
 
-    // Shift-Tab again → Sources tab (viewer owns the keystream now).
+    // Shift-Tab again → Sources tab active.
     stdin.write(SHIFT_TAB);
     await tick();
     frame = lastFrame() ?? '';
-    expect(frame).toContain('Sources');
-    expect(frame).not.toContain('Agent Status');
+    expect(frame).toContain('▸ Sources');
+    expect(frame).not.toContain('▸ Agent Status');
 
-    // Shift-Tab once more → back to the thread with the prompt chrome restored.
+    // Shift-Tab once more → wraps back to Status (does not close).
     stdin.write(SHIFT_TAB);
     await tick();
     frame = lastFrame() ?? '';
-    expect(frame).toContain('commands');
-    expect(frame).not.toContain('Agent Status');
-    expect(frame).not.toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).toContain('▸ Agent Status');
+    expect(frame).not.toContain('▸ Sources');
+    expect(frame).not.toContain('commands');
     unmount();
   });
 
@@ -337,7 +340,7 @@ describe('<App> Shift-Tab viewer tabs (#211)', () => {
     await tick();
     stdin.write(SHIFT_TAB);
     await tick();
-    expect(lastFrame()).toContain('Agent Status');
+    expect(lastFrame()).toContain('▸ Agent Status');
     stdin.write(ESC);
     await tick();
     const frame = lastFrame() ?? '';

--- a/src/ui/__tests__/ErrorPanel.test.tsx
+++ b/src/ui/__tests__/ErrorPanel.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { createElement } from 'react';
+import { ErrorPanel } from '../ErrorPanel.js';
+import type { ErrorPanelData } from '../error-format.js';
+
+const DATA: ErrorPanelData = {
+  title: 'Rate limit / quota',
+  category: 'rate_limit',
+  message: 'You exceeded your current quota.',
+  hint: 'Rate-limited — wait or switch lineup with /lineups.',
+};
+
+describe('<ErrorPanel>', () => {
+  it('renders the title, category tag, message and hint in a bordered frame', () => {
+    const { lastFrame } = render(createElement(ErrorPanel, { data: DATA }));
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('⚠ Rate limit / quota');
+    expect(frame).toContain('· rate_limit');
+    expect(frame).toContain('You exceeded your current quota.');
+    expect(frame).toContain('→ Rate-limited — wait or switch lineup with /lineups.');
+    expect(frame).toMatch(/[╭╮╰╯]/); // rounded border drawn
+  });
+
+  it('omits the details block when there are none', () => {
+    const { lastFrame } = render(createElement(ErrorPanel, { data: DATA }));
+    expect(lastFrame()).not.toContain('Caused by:');
+  });
+
+  it('renders the dim details block when present', () => {
+    const { lastFrame } = render(
+      createElement(ErrorPanel, {
+        data: { ...DATA, details: 'Error: boom\nCaused by:\ninner' },
+      }),
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Error: boom');
+    expect(frame).toContain('Caused by:');
+  });
+});

--- a/src/ui/__tests__/ScrollableOverlay.test.tsx
+++ b/src/ui/__tests__/ScrollableOverlay.test.tsx
@@ -6,8 +6,14 @@ import { ESC, ARROW_DOWN, ARROW_UP, SHIFT_TAB, PAGE_DOWN, tick } from './_keys.j
 import { ScrollableOverlay, type OverlayLine } from '../overlays/ScrollableOverlay.js';
 
 // ink-testing-library's stdout reports columns:100 and no `rows` getter, so
-// ScrollableOverlay falls back to rows:24 → viewport = 24 - 4 chrome = 20.
+// ScrollableOverlay falls back to rows:24. With 2 tabs the chrome below the
+// viewport is tabs(2) + gap(1) + footer(1) = 4 → viewport = 24 - 4 = 20.
 const VIEWPORT = 20;
+
+const TABS = [
+  { id: 'alpha', label: 'Alpha' },
+  { id: 'beta', label: 'Beta' },
+];
 
 function makeLines(n: number): OverlayLine[] {
   return Array.from({ length: n }, (_, i) => {
@@ -21,7 +27,8 @@ function renderOverlay(lines: OverlayLine[]) {
   const onCycleTab = vi.fn();
   const utils = render(
     createElement(ScrollableOverlay, {
-      title: 'Test Panel',
+      tabs: TABS,
+      activeTab: 'alpha',
       lines,
       onClose,
       onCycleTab,
@@ -31,10 +38,12 @@ function renderOverlay(lines: OverlayLine[]) {
 }
 
 describe('<ScrollableOverlay>', () => {
-  it('renders the title and only the first viewport of rows', () => {
+  it('renders the bottom tab menu (active marked, others muted) and only the first viewport of rows', () => {
     const { lastFrame } = renderOverlay(makeLines(30));
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('Test Panel');
+    expect(frame).toContain('▸ Alpha'); // active tab marked
+    expect(frame).toContain('Beta'); // other tab present
+    expect(frame).not.toContain('▸ Beta'); // but not marked active
     expect(frame).toContain('entry-00');
     expect(frame).toContain(`entry-${VIEWPORT - 1}`); // entry-19, last visible
     expect(frame).not.toContain(`entry-${VIEWPORT}`); // entry-20, first hidden

--- a/src/ui/__tests__/ScrollableOverlay.test.tsx
+++ b/src/ui/__tests__/ScrollableOverlay.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { createElement } from 'react';
+import { Text } from 'ink';
+import { ESC, ARROW_DOWN, ARROW_UP, SHIFT_TAB, PAGE_DOWN, tick } from './_keys.js';
+import { ScrollableOverlay, type OverlayLine } from '../overlays/ScrollableOverlay.js';
+
+// ink-testing-library's stdout reports columns:100 and no `rows` getter, so
+// ScrollableOverlay falls back to rows:24 → viewport = 24 - 4 chrome = 20.
+const VIEWPORT = 20;
+
+function makeLines(n: number): OverlayLine[] {
+  return Array.from({ length: n }, (_, i) => {
+    const id = `entry-${String(i).padStart(2, '0')}`;
+    return { key: id, node: createElement(Text, null, id) };
+  });
+}
+
+function renderOverlay(lines: OverlayLine[]) {
+  const onClose = vi.fn();
+  const onCycleTab = vi.fn();
+  const utils = render(
+    createElement(ScrollableOverlay, {
+      title: 'Test Panel',
+      lines,
+      onClose,
+      onCycleTab,
+    }),
+  );
+  return { ...utils, onClose, onCycleTab };
+}
+
+describe('<ScrollableOverlay>', () => {
+  it('renders the title and only the first viewport of rows', () => {
+    const { lastFrame } = renderOverlay(makeLines(30));
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Test Panel');
+    expect(frame).toContain('entry-00');
+    expect(frame).toContain(`entry-${VIEWPORT - 1}`); // entry-19, last visible
+    expect(frame).not.toContain(`entry-${VIEWPORT}`); // entry-20, first hidden
+    expect(frame).not.toContain('entry-29');
+  });
+
+  it('shows a position indicator only when content overflows', () => {
+    expect(renderOverlay(makeLines(30)).lastFrame()).toContain('rows 1–20 of 30');
+    // A short list that fits shows the legend without the indicator.
+    const frame = renderOverlay(makeLines(3)).lastFrame() ?? '';
+    expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).not.toContain('rows ');
+  });
+
+  it('scrolls down with the down arrow and clamps at the end', async () => {
+    const { stdin, lastFrame } = renderOverlay(makeLines(30));
+    await tick(); // let useInput subscribe before writing
+    stdin.write(ARROW_DOWN);
+    await tick();
+    let frame = lastFrame() ?? '';
+    // Window shifted by one: entry-00 gone, entry-20 now visible.
+    expect(frame).not.toContain('entry-00');
+    expect(frame).toContain('entry-20');
+    // Page down jumps a viewport and clamps at the last page (maxOffset = 10).
+    stdin.write(PAGE_DOWN);
+    await tick();
+    stdin.write(PAGE_DOWN);
+    await tick();
+    frame = lastFrame() ?? '';
+    expect(frame).toContain('entry-29');
+    expect(frame).toContain('rows 11–30 of 30');
+  });
+
+  it('jumps to top/bottom with g/G', async () => {
+    const { stdin, lastFrame } = renderOverlay(makeLines(30));
+    await tick();
+    stdin.write('G');
+    await tick();
+    expect(lastFrame()).toContain('entry-29');
+    stdin.write('g');
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('entry-00');
+    expect(frame).not.toContain('entry-29');
+  });
+
+  it('does not scroll above the top', async () => {
+    const { stdin, lastFrame } = renderOverlay(makeLines(30));
+    await tick();
+    stdin.write(ARROW_UP);
+    await tick();
+    expect(lastFrame()).toContain('rows 1–20 of 30');
+  });
+
+  it('forwards Esc to onClose and Shift-Tab to onCycleTab', async () => {
+    const { stdin, onClose, onCycleTab } = renderOverlay(makeLines(5));
+    await tick();
+    stdin.write(SHIFT_TAB);
+    await tick();
+    expect(onCycleTab).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    stdin.write(ESC);
+    await tick();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/__tests__/ScrollableOverlay.test.tsx
+++ b/src/ui/__tests__/ScrollableOverlay.test.tsx
@@ -6,9 +6,10 @@ import { ESC, ARROW_DOWN, ARROW_UP, SHIFT_TAB, PAGE_DOWN, tick } from './_keys.j
 import { ScrollableOverlay, type OverlayLine } from '../overlays/ScrollableOverlay.js';
 
 // ink-testing-library's stdout reports columns:100 and no `rows` getter, so
-// ScrollableOverlay falls back to rows:24. With 2 tabs the chrome below the
-// viewport is tabs(2) + gap(1) + footer(1) = 4 → viewport = 24 - 4 = 20.
-const VIEWPORT = 20;
+// ScrollableOverlay falls back to rows:24. frameHeight = rows-1 = 23; with 2
+// tabs the chrome below the viewport is tabs(2) + gap(1) + footer(1) = 4 →
+// viewport = 23 - 4 = 19.
+const VIEWPORT = 19;
 
 const TABS = [
   { id: 'alpha', label: 'Alpha' },
@@ -45,13 +46,13 @@ describe('<ScrollableOverlay>', () => {
     expect(frame).toContain('Beta'); // other tab present
     expect(frame).not.toContain('▸ Beta'); // but not marked active
     expect(frame).toContain('entry-00');
-    expect(frame).toContain(`entry-${VIEWPORT - 1}`); // entry-19, last visible
-    expect(frame).not.toContain(`entry-${VIEWPORT}`); // entry-20, first hidden
+    expect(frame).toContain(`entry-${VIEWPORT - 1}`); // entry-18, last visible
+    expect(frame).not.toContain(`entry-${VIEWPORT}`); // entry-19, first hidden
     expect(frame).not.toContain('entry-29');
   });
 
   it('shows a position indicator only when content overflows', () => {
-    expect(renderOverlay(makeLines(30)).lastFrame()).toContain('rows 1–20 of 30');
+    expect(renderOverlay(makeLines(30)).lastFrame()).toContain(`rows 1–${VIEWPORT} of 30`);
     // A short list that fits shows the legend without the indicator.
     const frame = renderOverlay(makeLines(3)).lastFrame() ?? '';
     expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
@@ -64,17 +65,17 @@ describe('<ScrollableOverlay>', () => {
     stdin.write(ARROW_DOWN);
     await tick();
     let frame = lastFrame() ?? '';
-    // Window shifted by one: entry-00 gone, entry-20 now visible.
+    // Window shifted by one: entry-00 gone, entry-19 (first previously-hidden) now visible.
     expect(frame).not.toContain('entry-00');
-    expect(frame).toContain('entry-20');
-    // Page down jumps a viewport and clamps at the last page (maxOffset = 10).
+    expect(frame).toContain(`entry-${VIEWPORT}`);
+    // Page down jumps a viewport and clamps at the last page (maxOffset = 30-19 = 11).
     stdin.write(PAGE_DOWN);
     await tick();
     stdin.write(PAGE_DOWN);
     await tick();
     frame = lastFrame() ?? '';
     expect(frame).toContain('entry-29');
-    expect(frame).toContain('rows 11–30 of 30');
+    expect(frame).toContain('rows 12–30 of 30');
   });
 
   it('jumps to top/bottom with g/G', async () => {
@@ -95,7 +96,7 @@ describe('<ScrollableOverlay>', () => {
     await tick();
     stdin.write(ARROW_UP);
     await tick();
-    expect(lastFrame()).toContain('rows 1–20 of 30');
+    expect(lastFrame()).toContain(`rows 1–${VIEWPORT} of 30`);
   });
 
   it('forwards Esc to onClose and Shift-Tab to onCycleTab', async () => {

--- a/src/ui/__tests__/ScrollableOverlay.test.tsx
+++ b/src/ui/__tests__/ScrollableOverlay.test.tsx
@@ -7,9 +7,9 @@ import { ScrollableOverlay, type OverlayLine } from '../overlays/ScrollableOverl
 
 // ink-testing-library's stdout reports columns:100 and no `rows` getter, so
 // ScrollableOverlay falls back to rows:24. frameHeight = rows-1 = 23; with 2
-// tabs the chrome below the viewport is tabs(2) + gap(1) + footer(1) = 4 →
-// viewport = 23 - 4 = 19.
-const VIEWPORT = 19;
+// tabs the chrome below the viewport is scroll-line(1) + 2 borders + key-hints
+// + tabs(2) = 6 → viewport = 23 - 6 = 17.
+const VIEWPORT = 17;
 
 const TABS = [
   { id: 'alpha', label: 'Alpha' },
@@ -46,8 +46,8 @@ describe('<ScrollableOverlay>', () => {
     expect(frame).toContain('Beta'); // other tab present
     expect(frame).not.toContain('▸ Beta'); // but not marked active
     expect(frame).toContain('entry-00');
-    expect(frame).toContain(`entry-${VIEWPORT - 1}`); // entry-18, last visible
-    expect(frame).not.toContain(`entry-${VIEWPORT}`); // entry-19, first hidden
+    expect(frame).toContain(`entry-${VIEWPORT - 1}`); // entry-16, last visible
+    expect(frame).not.toContain(`entry-${VIEWPORT}`); // entry-17, first hidden
     expect(frame).not.toContain('entry-29');
   });
 
@@ -55,7 +55,7 @@ describe('<ScrollableOverlay>', () => {
     expect(renderOverlay(makeLines(30)).lastFrame()).toContain(`rows 1–${VIEWPORT} of 30`);
     // A short list that fits shows the legend without the indicator.
     const frame = renderOverlay(makeLines(3)).lastFrame() ?? '';
-    expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).toContain('esc close');
     expect(frame).not.toContain('rows ');
   });
 
@@ -68,14 +68,14 @@ describe('<ScrollableOverlay>', () => {
     // Window shifted by one: entry-00 gone, entry-19 (first previously-hidden) now visible.
     expect(frame).not.toContain('entry-00');
     expect(frame).toContain(`entry-${VIEWPORT}`);
-    // Page down jumps a viewport and clamps at the last page (maxOffset = 30-19 = 11).
+    // Page down jumps a viewport and clamps at the last page (maxOffset = 30-17 = 13).
     stdin.write(PAGE_DOWN);
     await tick();
     stdin.write(PAGE_DOWN);
     await tick();
     frame = lastFrame() ?? '';
     expect(frame).toContain('entry-29');
-    expect(frame).toContain('rows 12–30 of 30');
+    expect(frame).toContain('rows 14–30 of 30');
   });
 
   it('jumps to top/bottom with g/G', async () => {

--- a/src/ui/__tests__/SourcesViewer.test.tsx
+++ b/src/ui/__tests__/SourcesViewer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
-import { tick } from './_keys.js';
+import { ENTER, ARROW_DOWN, tick } from './_keys.js';
 import { SourcesViewer } from '../overlays/SourcesViewer.js';
 import type { Agent } from '../../agent.js';
 import type { TurnProvenance } from '../../provenance.js';
@@ -10,7 +10,7 @@ function makeAgent(turns: TurnProvenance[]): Agent {
   return { getTurnProvenance: () => turns } as unknown as Agent;
 }
 
-const PREVIEW = 'a'.repeat(300); // exercises the 160-char preview truncate in buildLines
+const PREVIEW = 'a'.repeat(300); // exercises preview truncation in an expanded source
 
 const REGRESSION_TURNS: TurnProvenance[] = [
   // Issue #211 round-1 case: citations only on intermediate steps; final
@@ -58,89 +58,101 @@ const REGRESSION_TURNS: TurnProvenance[] = [
   },
 ];
 
-describe('<SourcesViewer>', () => {
+describe('<SourcesViewer> accordion', () => {
   it('renders empty state when no turns have provenance', () => {
     const { lastFrame } = render(createElement(SourcesViewer, { agent: makeAgent([]) }));
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('Sources');
     expect(frame).toContain('No citations recorded yet.');
-    expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).toContain('esc close');
   });
 
-  it('renders every turn with its sources and user input', () => {
+  it('lists every turn collapsed by default — headers with source counts, no source rows', () => {
     const { lastFrame } = render(
       createElement(SourcesViewer, { agent: makeAgent(REGRESSION_TURNS) }),
     );
     const frame = lastFrame() ?? '';
-    // Turn headers use 1-based numbering.
-    expect(frame).toContain('Turn 1:');
-    expect(frame).toContain('tell me about Rust');
-    expect(frame).toContain('Turn 2:');
-    expect(frame).toContain('follow-up question');
-    expect(frame).toContain('[^S1]');
-    expect(frame).toContain('[^S2]');
-    expect(frame).toContain('(web)');
-    expect(frame).toContain('(rag)');
-    expect(frame).toContain('(tool-result)');
+    expect(frame).toContain('Turn 1 · tell me about Rust');
+    expect(frame).toContain('Turn 2 · follow-up question');
+    expect(frame).toContain('(2 sources)');
+    expect(frame).toContain('(1 source)');
+    // Collapsed → no source rows rendered yet.
+    expect(frame).not.toContain('[^S1]');
+    expect(frame).not.toContain('rust-lang.org');
   });
 
-  it('renders the empty-sources hint when a turn registered nothing', () => {
+  it('expands the focused turn on Enter, revealing its sources', async () => {
+    const { stdin, lastFrame } = render(
+      createElement(SourcesViewer, { agent: makeAgent(REGRESSION_TURNS) }),
+    );
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('▾ Turn 1'); // expanded marker
+    expect(frame).toContain('[^S1]');
+    expect(frame).toContain('rust-lang.org'); // S1 (cited)
+    expect(frame).toContain('rust-fact-1'); // S2 (uncited) — both render
+    // Turn 2 stays collapsed.
+    expect(frame).not.toContain('shell:cargo --version');
+  });
+
+  it('moves the cursor with the down arrow and expands the newly-focused turn', async () => {
+    const { stdin, lastFrame } = render(
+      createElement(SourcesViewer, { agent: makeAgent(REGRESSION_TURNS) }),
+    );
+    await tick();
+    stdin.write(ARROW_DOWN); // focus Turn 2
+    await tick();
+    stdin.write(ENTER); // expand Turn 2
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('▾ Turn 2');
+    expect(frame).toContain('shell:cargo --version');
+    // Turn 1 stays collapsed.
+    expect(frame).not.toContain('rust-lang.org');
+  });
+
+  it('renders the empty-sources hint when an expanded turn registered nothing', async () => {
     const turns: TurnProvenance[] = [
-      {
-        turnIndex: 0,
-        userInput: 'hi',
-        sources: [],
-        citedIds: [],
-        timestamp: 0,
-      },
+      { turnIndex: 0, userInput: 'hi', sources: [], citedIds: [], timestamp: 0 },
     ];
-    const { lastFrame } = render(createElement(SourcesViewer, { agent: makeAgent(turns) }));
+    const { stdin, lastFrame } = render(createElement(SourcesViewer, { agent: makeAgent(turns) }));
+    await tick();
+    stdin.write(ENTER);
+    await tick();
     expect(lastFrame()).toContain('(no sources registered)');
   });
 
-  it('truncates long rawRef and contentPreview', () => {
-    const { lastFrame } = render(
+  it('truncates a long rawRef and contentPreview in an expanded source', async () => {
+    const { stdin, lastFrame } = render(
       createElement(SourcesViewer, { agent: makeAgent(REGRESSION_TURNS) }),
     );
+    await tick();
+    stdin.write(ENTER);
+    await tick();
     const frame = lastFrame() ?? '';
     expect(frame).toContain('…');
-    // The full 300-char preview must NOT appear verbatim.
-    expect(frame).not.toContain(PREVIEW);
+    expect(frame).not.toContain(PREVIEW); // full 300-char preview never shown verbatim
   });
 
-  it('windows a long history and scrolls to reveal later turns', async () => {
-    // 10 turns × (header + 1 source) + separators ≈ 29 lines > the 20-row
-    // viewport (rows:24 fallback − 4 chrome), so the last turns start hidden.
-    const turns: TurnProvenance[] = Array.from({ length: 10 }, (_, i) => ({
+  it('windows a long collapsed history and scrolls to reveal later turns', async () => {
+    // 25 collapsed headers > the 17-row viewport, so the last turns start hidden.
+    const turns: TurnProvenance[] = Array.from({ length: 25 }, (_, i) => ({
       turnIndex: i,
       userInput: `req-${i}`,
       sources: [{ id: 'S1', kind: 'web', label: `src-${i}`, timestamp: 0 }],
       citedIds: ['S1'],
       timestamp: 0,
     }));
-    const { stdin, lastFrame } = render(
-      createElement(SourcesViewer, { agent: makeAgent(turns) }),
-    );
+    const { stdin, lastFrame } = render(createElement(SourcesViewer, { agent: makeAgent(turns) }));
     let frame = lastFrame() ?? '';
-    expect(frame).toContain('Turn 1:');
-    expect(frame).not.toContain('Turn 10:');
-    // Jump to the bottom — the last turn becomes visible.
+    expect(frame).toContain('Turn 1 ·');
+    expect(frame).not.toContain('Turn 25 ·');
+    // Jump the cursor to the last turn — it scrolls into view.
     await tick();
     stdin.write('G');
     await tick();
     frame = lastFrame() ?? '';
-    expect(frame).toContain('Turn 10:');
-  });
-
-  it('renders all turns even when the latest turn cited nothing (regression #211)', () => {
-    const { lastFrame } = render(
-      createElement(SourcesViewer, { agent: makeAgent(REGRESSION_TURNS) }),
-    );
-    const frame = lastFrame() ?? '';
-    // Both turns visible.
-    expect(frame.indexOf('Turn 1:')).toBeLessThan(frame.indexOf('Turn 2:'));
-    // Turn 1's S1 (cited) and S2 (uncited) both render.
-    expect(frame).toContain('rust-lang.org');
-    expect(frame).toContain('rust-fact-1');
+    expect(frame).toContain('Turn 25 ·');
   });
 });

--- a/src/ui/__tests__/SourcesViewer.test.tsx
+++ b/src/ui/__tests__/SourcesViewer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
+import { tick } from './_keys.js';
 import { SourcesViewer } from '../overlays/SourcesViewer.js';
 import type { Agent } from '../../agent.js';
 import type { TurnProvenance } from '../../provenance.js';
@@ -9,7 +10,7 @@ function makeAgent(turns: TurnProvenance[]): Agent {
   return { getTurnProvenance: () => turns } as unknown as Agent;
 }
 
-const PREVIEW = 'a'.repeat(300); // exercises the 160-char truncate at SourceRow
+const PREVIEW = 'a'.repeat(300); // exercises the 160-char preview truncate in buildLines
 
 const REGRESSION_TURNS: TurnProvenance[] = [
   // Issue #211 round-1 case: citations only on intermediate steps; final
@@ -105,6 +106,30 @@ describe('<SourcesViewer>', () => {
     expect(frame).toContain('…');
     // The full 300-char preview must NOT appear verbatim.
     expect(frame).not.toContain(PREVIEW);
+  });
+
+  it('windows a long history and scrolls to reveal later turns', async () => {
+    // 10 turns × (header + 1 source) + separators ≈ 29 lines > the 20-row
+    // viewport (rows:24 fallback − 4 chrome), so the last turns start hidden.
+    const turns: TurnProvenance[] = Array.from({ length: 10 }, (_, i) => ({
+      turnIndex: i,
+      userInput: `req-${i}`,
+      sources: [{ id: 'S1', kind: 'web', label: `src-${i}`, timestamp: 0 }],
+      citedIds: ['S1'],
+      timestamp: 0,
+    }));
+    const { stdin, lastFrame } = render(
+      createElement(SourcesViewer, { agent: makeAgent(turns) }),
+    );
+    let frame = lastFrame() ?? '';
+    expect(frame).toContain('Turn 1:');
+    expect(frame).not.toContain('Turn 10:');
+    // Jump to the bottom — the last turn becomes visible.
+    await tick();
+    stdin.write('G');
+    await tick();
+    frame = lastFrame() ?? '';
+    expect(frame).toContain('Turn 10:');
   });
 
   it('renders all turns even when the latest turn cited nothing (regression #211)', () => {

--- a/src/ui/__tests__/StatusBar.test.tsx
+++ b/src/ui/__tests__/StatusBar.test.tsx
@@ -84,6 +84,27 @@ describe('<StatusBar> token readout labels (#234)', () => {
   });
 });
 
+describe('<StatusBar> non-finite token stats', () => {
+  it('renders 0 (never "NaNk") and an all-empty gauge when token fields are NaN', () => {
+    const agent = {
+      spinnerStats: {
+        startTime: 0,
+        turnPromptTokens: NaN,
+        turnCompletionTokens: NaN,
+        latestPromptTokens: NaN,
+        model: 'test-model',
+        contextWindowOverride: 1000,
+      },
+      currentStrategy: null,
+    } as unknown as Agent;
+    const frame = stripAnsi(render(createElement(StatusBar, { agent })).lastFrame() ?? '');
+    expect(frame).not.toContain('NaN');
+    expect(frame).toMatch(/turn\s+0↑\s+0↓/);
+    expect(frame).toContain('ctx 0');
+    expect(gauge(frame)).toBe('○○○○○○○○○○'); // gauge still drawn, fully empty
+  });
+});
+
 describe('<StatusBar> idle-tick guard (#232)', () => {
   it('still refreshes the readout when spinnerStats changes between polls', async () => {
     // The poll only forces a re-render when a rendered value actually moved

--- a/src/ui/__tests__/StatusViewer.test.tsx
+++ b/src/ui/__tests__/StatusViewer.test.tsx
@@ -70,7 +70,7 @@ describe('<StatusViewer>', () => {
     expect(frame).toContain('concise');
     expect(frame).toContain('citations: required');
     expect(frame).toContain('evidence: required');
-    expect(frame).toContain('Esc to close · Shift-Tab to switch tabs');
+    expect(frame).toContain('esc close');
   });
 
   it('renders "(none)" for absent values', () => {

--- a/src/ui/__tests__/Thread.test.tsx
+++ b/src/ui/__tests__/Thread.test.tsx
@@ -42,6 +42,25 @@ describe('<Thread>', () => {
     expect(lastFrame() ?? '').toContain('you interrupted');
   });
 
+  it('renders an error StaticItem as an ErrorPanel instead of a message', () => {
+    const staticItems: StaticItem[] = [
+      {
+        key: 'e0',
+        toolDetails: false,
+        error: {
+          title: 'Rate limit / quota',
+          category: 'rate_limit',
+          message: 'You exceeded your current quota.',
+          hint: 'wait or switch lineup',
+        },
+      },
+    ];
+    const frame = stripAnsi(render(createElement(Thread, { staticItems })).lastFrame() ?? '');
+    expect(frame).toContain('⚠ Rate limit / quota');
+    expect(frame).toContain('You exceeded your current quota.');
+    expect(frame).toMatch(/[╭╮╰╯]/);
+  });
+
   it('renders an assistant message with the chevron label', () => {
     const history: CoreMessage[] = [{ role: 'assistant', content: 'hi there' }];
     const { lastFrame } = render(createElement(Thread, { staticItems: items(history) }));

--- a/src/ui/__tests__/_keys.ts
+++ b/src/ui/__tests__/_keys.ts
@@ -24,4 +24,9 @@ export const BACKSPACE = '';
 
 export const SPACE = ' ';
 
+/** Shift+Tab (CSI Z) — Ink decodes this to `{ tab: true, shift: true }`. */
+export const SHIFT_TAB = '\x1b[Z';
+export const PAGE_UP = '\x1b[5~';
+export const PAGE_DOWN = '\x1b[6~';
+
 export const tick = (ms = 10): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/ui/__tests__/error-format.test.ts
+++ b/src/ui/__tests__/error-format.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { formatAgentError } from '../error-format.js';
+
+const QUOTA_JSON =
+  '{"type":"error","error":{"type":"insufficient_quota","code":"insufficient_quota","message":"You exceeded your current quota, please check your plan and billing details.","param":null},"sequence_number":2}';
+
+describe('formatAgentError', () => {
+  it('unwraps the Agent error wrapper and the provider JSON to the human message', () => {
+    const err = new Error(`Agent error: ${QUOTA_JSON}`);
+    const data = formatAgentError(err, false);
+    expect(data.message).toBe(
+      'You exceeded your current quota, please check your plan and billing details.',
+    );
+    expect(data.message).not.toContain('{'); // no raw JSON leaks through
+  });
+
+  it('strips repeated "Agent error:" prefixes', () => {
+    const err = new Error('Agent error: Agent error: something broke');
+    expect(formatAgentError(err, false).message).toBe('something broke');
+  });
+
+  it('classifies a quota error as rate_limit with a friendly title + hint', () => {
+    const data = formatAgentError(new Error(`Agent error: ${QUOTA_JSON}`), false);
+    expect(data.category).toBe('rate_limit');
+    expect(data.title).toBe('Rate limit / quota');
+    expect(data.hint).toMatch(/lineup/i);
+  });
+
+  it('omits details unless requested, and includes stack + cause when debug is on', () => {
+    const cause = new Error('inner boom');
+    const err = new Error('Agent error: outer', { cause });
+    expect(formatAgentError(err, false).details).toBeUndefined();
+    const withDetails = formatAgentError(err, true).details ?? '';
+    expect(withDetails).toContain('Error: Agent error: outer');
+    expect(withDetails).toContain('Caused by:');
+    expect(withDetails).toContain('inner boom');
+  });
+
+  it('passes a plain non-JSON message through unchanged', () => {
+    expect(formatAgentError(new Error('network unreachable'), false).message).toBe(
+      'network unreachable',
+    );
+  });
+});

--- a/src/ui/error-format.ts
+++ b/src/ui/error-format.ts
@@ -1,0 +1,97 @@
+import { classifyError } from '../error-taxonomy.js';
+
+/** Data backing the `<ErrorPanel>` transcript item. */
+export interface ErrorPanelData {
+  /** Friendly headline derived from the error category. */
+  title: string;
+  /** The taxonomy category (shown as a dim tag). */
+  category: string;
+  /** Human-readable primary message (provider JSON unwrapped when present). */
+  message: string;
+  /** One-line recovery hint from the failure taxonomy. */
+  hint?: string;
+  /** Stack + cause, rendered dim. Populated only when debug is on. */
+  details?: string;
+}
+
+const TITLES: Record<string, string> = {
+  rate_limit: 'Rate limit / quota',
+  auth: 'Authentication failed',
+  permission: 'Permission denied',
+  timeout: 'Timed out',
+  not_found: 'Not found',
+  transient: 'Upstream error',
+  invalid_args: 'Invalid request',
+  exec_failed: 'Command failed',
+  pool_exhausted: 'Pool saturated',
+  parse_failed: 'Parse error',
+  denied: 'Blocked',
+  cancelled: 'Cancelled',
+  unknown: 'Agent error',
+};
+
+/**
+ * Turns a thrown agent error into the structured data the error panel renders.
+ * Strips Bernard's `Agent error:` wrapper(s), unwraps a provider JSON envelope
+ * to its human message, classifies via the failure taxonomy for a friendly
+ * title + recovery hint, and (only when `includeDetails`) collects the stack
+ * and cause for the dim detail block.
+ */
+export function formatAgentError(err: unknown, includeDetails: boolean): ErrorPanelData {
+  const raw = err instanceof Error ? err.message : String(err);
+  const message = cleanMessage(raw);
+  const cls = classifyError({ message });
+  return {
+    title: TITLES[cls.category] ?? 'Agent error',
+    category: cls.category,
+    message,
+    hint: cls.playbook.user,
+    details: includeDetails ? collectDetails(err) : undefined,
+  };
+}
+
+function cleanMessage(raw: string): string {
+  let m = raw.trim();
+  // Bernard wraps thrown errors as `Agent error: …`, sometimes twice.
+  while (/^Agent error:\s*/i.test(m)) m = m.replace(/^Agent error:\s*/i, '').trim();
+  return extractJsonMessage(m) ?? m;
+}
+
+/** Pull `.error.message` / `.message` out of a JSON envelope embedded in the string. */
+function extractJsonMessage(s: string): string | null {
+  const start = s.indexOf('{');
+  if (start === -1) return null;
+  const candidate = s.slice(start);
+  const tryParse = (text: string): string | null => {
+    try {
+      return pickMessage(JSON.parse(text));
+    } catch {
+      return null;
+    }
+  };
+  // First try the whole tail, then trim any prose after the final brace.
+  const whole = tryParse(candidate);
+  if (whole) return whole;
+  const end = candidate.lastIndexOf('}');
+  return end > 0 ? tryParse(candidate.slice(0, end + 1)) : null;
+}
+
+function pickMessage(obj: unknown): string | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+  const inner = o.error;
+  if (inner && typeof inner === 'object') {
+    const im = (inner as Record<string, unknown>).message;
+    if (typeof im === 'string') return im;
+  }
+  return typeof o.message === 'string' ? o.message : null;
+}
+
+function collectDetails(err: unknown): string | undefined {
+  const parts: string[] = [];
+  if (err instanceof Error && err.stack) parts.push(err.stack);
+  if (err instanceof Error && err.cause instanceof Error && err.cause.stack) {
+    parts.push('Caused by:\n' + err.cause.stack);
+  }
+  return parts.length ? parts.join('\n\n') : undefined;
+}

--- a/src/ui/overlays/ScrollableOverlay.tsx
+++ b/src/ui/overlays/ScrollableOverlay.tsx
@@ -59,7 +59,13 @@ export function ScrollableOverlay({
   const colors = getThemeColors();
   const { stdout } = useStdout();
   const rows = stdout?.rows ?? 24;
-  const viewport = Math.max(1, rows - tabs.length - FOOTER_AND_GAP_ROWS);
+  // Never occupy the LAST terminal row. A dynamic (non-Static) Ink frame that
+  // fills the full height can't be erased cleanly — the final newline scrolls
+  // the terminal and desyncs Ink's cursor math, so the next render (e.g. after
+  // Esc closes the overlay) leaves stale rows on screen until something forces
+  // a repaint. Capping at rows-1 keeps the erase correct.
+  const frameHeight = Math.max(1, rows - 1);
+  const viewport = Math.max(1, frameHeight - tabs.length - FOOTER_AND_GAP_ROWS);
   const maxOffset = Math.max(0, lines.length - viewport);
 
   const [offset, setOffset] = useState(0);
@@ -92,7 +98,7 @@ export function ScrollableOverlay({
   const visible = lines.slice(clamped, clamped + viewport);
 
   return (
-    <Box flexDirection="column" height={rows}>
+    <Box flexDirection="column" height={frameHeight}>
       {visible.map((line) => (
         <Box key={line.key}>{line.node}</Box>
       ))}

--- a/src/ui/overlays/ScrollableOverlay.tsx
+++ b/src/ui/overlays/ScrollableOverlay.tsx
@@ -8,9 +8,17 @@ export interface OverlayLine {
   node: ReactNode;
 }
 
+/** A selectable viewer tab rendered in the bottom tab menu. */
+export interface OverlayTab {
+  id: string;
+  label: string;
+}
+
 interface ScrollableOverlayProps {
-  /** Bold accent heading shown at the top of the panel. */
-  title: string;
+  /** All viewer tabs, rendered as a vertical menu pinned to the bottom. */
+  tabs: readonly OverlayTab[];
+  /** `id` of the tab this panel is — highlighted in the menu; the rest are muted. */
+  activeTab: string;
   /**
    * Flat list of visual rows. Each entry must render to exactly one terminal
    * line — the windowing math counts entries, not wrapped height, so a node
@@ -24,10 +32,9 @@ interface ScrollableOverlayProps {
   onCycleTab?: () => void;
 }
 
-// Rows reserved for the panel's own chrome: title + spacer + a one-row gap
-// before the footer (held open by the flexGrow filler) + footer. The remaining
-// terminal height is the scroll viewport.
-const CHROME_ROWS = 4;
+// Rows reserved below the scroll viewport: one menu row per tab, a one-row gap
+// above the menu (held open by the flexGrow filler), and the footer hint.
+const FOOTER_AND_GAP_ROWS = 2;
 
 /**
  * Full-screen scrollable panel shared by the Shift-Tab viewer tabs
@@ -43,7 +50,8 @@ const CHROME_ROWS = 4;
  * reprint scrollback — see `src/ui/Thread.tsx`).
  */
 export function ScrollableOverlay({
-  title,
+  tabs,
+  activeTab,
   lines,
   onClose = () => {},
   onCycleTab = () => {},
@@ -51,7 +59,7 @@ export function ScrollableOverlay({
   const colors = getThemeColors();
   const { stdout } = useStdout();
   const rows = stdout?.rows ?? 24;
-  const viewport = Math.max(1, rows - CHROME_ROWS);
+  const viewport = Math.max(1, rows - tabs.length - FOOTER_AND_GAP_ROWS);
   const maxOffset = Math.max(0, lines.length - viewport);
 
   const [offset, setOffset] = useState(0);
@@ -85,15 +93,41 @@ export function ScrollableOverlay({
 
   return (
     <Box flexDirection="column" height={rows}>
-      <Text color={colors.accent} bold>
-        {title}
-      </Text>
-      <Text> </Text>
       {visible.map((line) => (
         <Box key={line.key}>{line.node}</Box>
       ))}
       <Box flexGrow={1} />
+      <TabMenu tabs={tabs} activeTab={activeTab} accent={colors.accent} />
       <Text dimColor>{footerHint(clamped, viewport, lines.length)}</Text>
+    </Box>
+  );
+}
+
+/**
+ * Vertical tab menu pinned to the bottom. The active tab is highlighted (accent
+ * + bold, `▸` marker); the rest are muted. Marker + label share one `<Text>` so
+ * the active row reads as a single contiguous `▸ <label>` string.
+ */
+function TabMenu({
+  tabs,
+  activeTab,
+  accent,
+}: {
+  tabs: readonly OverlayTab[];
+  activeTab: string;
+  accent: string;
+}) {
+  return (
+    <Box flexDirection="column">
+      {tabs.map((tab) => {
+        const active = tab.id === activeTab;
+        return (
+          <Text key={tab.id} color={active ? accent : undefined} bold={active} dimColor={!active}>
+            {active ? '▸ ' : '  '}
+            {tab.label}
+          </Text>
+        );
+      })}
     </Box>
   );
 }

--- a/src/ui/overlays/ScrollableOverlay.tsx
+++ b/src/ui/overlays/ScrollableOverlay.tsx
@@ -1,0 +1,112 @@
+import { useState, type ReactNode } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import { getThemeColors } from '../../theme.js';
+
+/** One pre-rendered visual row. `node` MUST occupy exactly one terminal line. */
+export interface OverlayLine {
+  key: string;
+  node: ReactNode;
+}
+
+interface ScrollableOverlayProps {
+  /** Bold accent heading shown at the top of the panel. */
+  title: string;
+  /**
+   * Flat list of visual rows. Each entry must render to exactly one terminal
+   * line — the windowing math counts entries, not wrapped height, so a node
+   * that wraps to two lines would desync the scroll position. Callers
+   * width-clamp their text (via `truncate`) to keep this invariant.
+   */
+  lines: OverlayLine[];
+  /** Close the panel (Esc). Defaults to a no-op for standalone rendering/tests. */
+  onClose?: () => void;
+  /** Advance to the next Shift-Tab tab (Shift-Tab). Defaults to a no-op. */
+  onCycleTab?: () => void;
+}
+
+// Rows reserved for the panel's own chrome: title + spacer + a one-row gap
+// before the footer (held open by the flexGrow filler) + footer. The remaining
+// terminal height is the scroll viewport.
+const CHROME_ROWS = 4;
+
+/**
+ * Full-screen scrollable panel shared by the Shift-Tab viewer tabs
+ * (`StatusViewer`, `SourcesViewer`). Owns its own keystream while mounted —
+ * `<App>` deactivates its top-level `useInput` for viewer overlays (like it
+ * already does for modal overlays), so Esc / Shift-Tab are handled here and
+ * forwarded back via `onClose` / `onCycleTab`.
+ *
+ * The outer Box is pinned to the full terminal height so the live frame fills
+ * the screen and pushes prior `<Static>` scrollback up — the panel reads as a
+ * replacement for the thread, not an addition below it. Closing it collapses
+ * the frame back to the prompt without remounting `<Thread>` (which would
+ * reprint scrollback — see `src/ui/Thread.tsx`).
+ */
+export function ScrollableOverlay({
+  title,
+  lines,
+  onClose = () => {},
+  onCycleTab = () => {},
+}: ScrollableOverlayProps) {
+  const colors = getThemeColors();
+  const { stdout } = useStdout();
+  const rows = stdout?.rows ?? 24;
+  const viewport = Math.max(1, rows - CHROME_ROWS);
+  const maxOffset = Math.max(0, lines.length - viewport);
+
+  const [offset, setOffset] = useState(0);
+  // The true window start: clamp on every render so a terminal resize (smaller
+  // viewport) or a shorter tab can't strand the window past the end. Movement
+  // is computed from `clamped`, not the raw state, so a stale-high `offset`
+  // can never linger.
+  const clamped = Math.min(offset, maxOffset);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onClose();
+    } else if (key.shift && key.tab) {
+      onCycleTab();
+    } else if (key.downArrow || input === 'j') {
+      setOffset(Math.min(maxOffset, clamped + 1));
+    } else if (key.upArrow || input === 'k') {
+      setOffset(Math.max(0, clamped - 1));
+    } else if (key.pageDown) {
+      setOffset(Math.min(maxOffset, clamped + viewport));
+    } else if (key.pageUp) {
+      setOffset(Math.max(0, clamped - viewport));
+    } else if (input === 'g') {
+      setOffset(0);
+    } else if (input === 'G') {
+      setOffset(maxOffset);
+    }
+  });
+
+  const visible = lines.slice(clamped, clamped + viewport);
+
+  return (
+    <Box flexDirection="column" height={rows}>
+      <Text color={colors.accent} bold>
+        {title}
+      </Text>
+      <Text> </Text>
+      {visible.map((line) => (
+        <Box key={line.key}>{line.node}</Box>
+      ))}
+      <Box flexGrow={1} />
+      <Text dimColor>{footerHint(clamped, viewport, lines.length)}</Text>
+    </Box>
+  );
+}
+
+/**
+ * Footer: a `rows X–Y of N` position indicator (only when the content actually
+ * overflows) plus the key legend. 1-based, inclusive range over the visible
+ * window.
+ */
+function footerHint(offset: number, viewport: number, total: number): string {
+  const base = 'Esc to close · Shift-Tab to switch tabs';
+  if (total <= viewport) return base;
+  const first = total === 0 ? 0 : offset + 1;
+  const last = Math.min(total, offset + viewport);
+  return `rows ${first}–${last} of ${total} · ↑/↓ scroll · ${base}`;
+}

--- a/src/ui/overlays/ScrollableOverlay.tsx
+++ b/src/ui/overlays/ScrollableOverlay.tsx
@@ -1,23 +1,16 @@
-import { useState, type ReactNode } from 'react';
-import { Box, Text, useInput, useStdout } from 'ink';
-import { getThemeColors } from '../../theme.js';
+import { useState } from 'react';
+import { Box, useInput, useStdout } from 'ink';
+import {
+  ViewerShell,
+  viewerViewport,
+  type OverlayLine,
+  type OverlayTab,
+} from './ViewerShell.js';
 
-/** One pre-rendered visual row. `node` MUST occupy exactly one terminal line. */
-export interface OverlayLine {
-  key: string;
-  node: ReactNode;
-}
-
-/** A selectable viewer tab rendered in the bottom tab menu. */
-export interface OverlayTab {
-  id: string;
-  label: string;
-}
+export type { OverlayLine, OverlayTab } from './ViewerShell.js';
 
 interface ScrollableOverlayProps {
-  /** All viewer tabs, rendered as a vertical menu pinned to the bottom. */
   tabs: readonly OverlayTab[];
-  /** `id` of the tab this panel is — highlighted in the menu; the rest are muted. */
   activeTab: string;
   /**
    * Flat list of visual rows. Each entry must render to exactly one terminal
@@ -26,61 +19,34 @@ interface ScrollableOverlayProps {
    * width-clamp their text (via `truncate`) to keep this invariant.
    */
   lines: OverlayLine[];
-  /** Close the panel (Esc). Defaults to a no-op for standalone rendering/tests. */
   onClose?: () => void;
-  /** Advance to the next Shift-Tab tab (Shift-Tab). Defaults to a no-op. */
   onCycleTab?: () => void;
 }
 
-// Rows reserved below the scroll viewport: one menu row per tab, a one-row gap
-// above the menu (held open by the flexGrow filler), and the footer hint.
-const FOOTER_AND_GAP_ROWS = 2;
-
 /**
- * Full-screen scrollable panel shared by the Shift-Tab viewer tabs
- * (`StatusViewer`, `SourcesViewer`). Owns its own keystream while mounted —
- * `<App>` deactivates its top-level `useInput` for viewer overlays (like it
- * already does for modal overlays), so Esc / Shift-Tab are handled here and
- * forwarded back via `onClose` / `onCycleTab`.
- *
- * The outer Box is pinned to the full terminal height so the live frame fills
- * the screen and pushes prior `<Static>` scrollback up — the panel reads as a
- * replacement for the thread, not an addition below it. Closing it collapses
- * the frame back to the prompt without remounting `<Thread>` (which would
- * reprint scrollback — see `src/ui/Thread.tsx`).
+ * A plain vertically-scrollable list rendered inside the shared `ViewerShell`
+ * (used by `StatusViewer`). Owns only the scroll keystream — `↑/↓`/`j`/`k`,
+ * `PgUp`/`PgDn`, `g`/`G`; Esc and Shift-Tab belong to the shell.
  */
 export function ScrollableOverlay({
   tabs,
   activeTab,
   lines,
-  onClose = () => {},
-  onCycleTab = () => {},
+  onClose,
+  onCycleTab,
 }: ScrollableOverlayProps) {
-  const colors = getThemeColors();
   const { stdout } = useStdout();
   const rows = stdout?.rows ?? 24;
-  // Never occupy the LAST terminal row. A dynamic (non-Static) Ink frame that
-  // fills the full height can't be erased cleanly — the final newline scrolls
-  // the terminal and desyncs Ink's cursor math, so the next render (e.g. after
-  // Esc closes the overlay) leaves stale rows on screen until something forces
-  // a repaint. Capping at rows-1 keeps the erase correct.
-  const frameHeight = Math.max(1, rows - 1);
-  const viewport = Math.max(1, frameHeight - tabs.length - FOOTER_AND_GAP_ROWS);
+  const viewport = viewerViewport(rows, tabs.length);
   const maxOffset = Math.max(0, lines.length - viewport);
 
   const [offset, setOffset] = useState(0);
-  // The true window start: clamp on every render so a terminal resize (smaller
-  // viewport) or a shorter tab can't strand the window past the end. Movement
-  // is computed from `clamped`, not the raw state, so a stale-high `offset`
-  // can never linger.
+  // Clamp on every render so a resize (smaller viewport) can't strand the
+  // window past the end; movement is computed from `clamped`, never stale state.
   const clamped = Math.min(offset, maxOffset);
 
   useInput((input, key) => {
-    if (key.escape) {
-      onClose();
-    } else if (key.shift && key.tab) {
-      onCycleTab();
-    } else if (key.downArrow || input === 'j') {
+    if (key.downArrow || input === 'j') {
       setOffset(Math.min(maxOffset, clamped + 1));
     } else if (key.upArrow || input === 'k') {
       setOffset(Math.max(0, clamped - 1));
@@ -96,57 +62,23 @@ export function ScrollableOverlay({
   });
 
   const visible = lines.slice(clamped, clamped + viewport);
+  const position =
+    lines.length > viewport
+      ? { first: clamped + 1, last: Math.min(lines.length, clamped + viewport), total: lines.length }
+      : null;
 
   return (
-    <Box flexDirection="column" height={frameHeight}>
+    <ViewerShell
+      tabs={tabs}
+      activeTab={activeTab}
+      position={position}
+      keyHints="↑/↓ scroll · ⇧⇥ switch tab · esc close"
+      onClose={onClose}
+      onCycleTab={onCycleTab}
+    >
       {visible.map((line) => (
         <Box key={line.key}>{line.node}</Box>
       ))}
-      <Box flexGrow={1} />
-      <TabMenu tabs={tabs} activeTab={activeTab} accent={colors.accent} />
-      <Text dimColor>{footerHint(clamped, viewport, lines.length)}</Text>
-    </Box>
+    </ViewerShell>
   );
-}
-
-/**
- * Vertical tab menu pinned to the bottom. The active tab is highlighted (accent
- * + bold, `▸` marker); the rest are muted. Marker + label share one `<Text>` so
- * the active row reads as a single contiguous `▸ <label>` string.
- */
-function TabMenu({
-  tabs,
-  activeTab,
-  accent,
-}: {
-  tabs: readonly OverlayTab[];
-  activeTab: string;
-  accent: string;
-}) {
-  return (
-    <Box flexDirection="column">
-      {tabs.map((tab) => {
-        const active = tab.id === activeTab;
-        return (
-          <Text key={tab.id} color={active ? accent : undefined} bold={active} dimColor={!active}>
-            {active ? '▸ ' : '  '}
-            {tab.label}
-          </Text>
-        );
-      })}
-    </Box>
-  );
-}
-
-/**
- * Footer: a `rows X–Y of N` position indicator (only when the content actually
- * overflows) plus the key legend. 1-based, inclusive range over the visible
- * window.
- */
-function footerHint(offset: number, viewport: number, total: number): string {
-  const base = 'Esc to close · Shift-Tab to switch tabs';
-  if (total <= viewport) return base;
-  const first = total === 0 ? 0 : offset + 1;
-  const last = Math.min(total, offset + viewport);
-  return `rows ${first}–${last} of ${total} · ↑/↓ scroll · ${base}`;
 }

--- a/src/ui/overlays/SourcesViewer.tsx
+++ b/src/ui/overlays/SourcesViewer.tsx
@@ -1,93 +1,127 @@
-import { Box, Text } from 'ink';
+import { useMemo } from 'react';
+import { Box, Text, useStdout } from 'ink';
 import type { Agent } from '../../agent.js';
 import type { TurnProvenance, SourceItem } from '../../provenance.js';
-import { getThemeColors } from '../../theme.js';
+import { getThemeColors, type ThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
+import { ScrollableOverlay, type OverlayLine } from './ScrollableOverlay.js';
 
 interface SourcesViewerProps {
   agent: Agent;
+  /** Close the panel (Esc). Defaults to a no-op for standalone rendering/tests. */
+  onClose?: () => void;
+  /** Advance to the next Shift-Tab tab. Defaults to a no-op. */
+  onCycleTab?: () => void;
 }
 
 /**
- * Full-screen per-turn citation list. Consumes `agent.getTurnProvenance()`
- * (wired in Phase A — see `src/provenance.ts:38` for the shape).
+ * Scrollable per-turn citation history (issue #211). Consumes
+ * `agent.getTurnProvenance()` — the cumulative array of every turn that
+ * registered sources — and flattens it into one visual row per line so the
+ * shared `ScrollableOverlay` can window it to the terminal height.
  *
- * Accent rule matches the legacy renderer at `src/repl.ts:874`: a source is
- * "cited" when `citedIds.includes(source.id)`. Cited entries render in the
- * theme accent color; uncited entries render dim.
- *
- * Empty state covers two cases (fresh session, and a session where no turn
- * produced citations). Both render the same hint so the user knows the panel
- * is working as designed and not stuck.
+ * Accent rule matches the legacy renderer: a source is "cited" when
+ * `citedIds.includes(source.id)`. Cited entries render in the theme accent
+ * color; uncited entries render dim. Empty state covers both a fresh session
+ * and a session where no turn produced citations.
  */
-export function SourcesViewer({ agent }: SourcesViewerProps) {
+export function SourcesViewer({ agent, onClose, onCycleTab }: SourcesViewerProps) {
   const colors = getThemeColors();
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
   const turns = agent.getTurnProvenance();
+  // The history is immutable while the viewer owns the keystream (the agent is
+  // idle), so rebuild the flat line list only when the turn count or width
+  // changes — not on every scroll keystroke.
+  const lines = useMemo(() => buildLines(turns, colors, cols), [turns.length, colors, cols]);
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Text color={colors.accent} bold>
-        Sources
-      </Text>
-      <Text> </Text>
-      {turns.length === 0 ? (
-        <Text dimColor>No citations recorded yet.</Text>
-      ) : (
-        turns.map((turn) => <TurnBlock key={turn.turnIndex} turn={turn} />)
-      )}
-      <Text> </Text>
-      <Text dimColor>Esc to close · Shift-Tab to switch tabs</Text>
-    </Box>
+    <ScrollableOverlay title="Sources" lines={lines} onClose={onClose} onCycleTab={onCycleTab} />
   );
 }
 
-function TurnBlock({ turn }: { turn: TurnProvenance }) {
-  const colors = getThemeColors();
-  const citedSet = new Set(turn.citedIds);
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      <Box>
-        <Text color={colors.muted}>Turn {turn.turnIndex + 1}:</Text>
-        <Text> {truncate(turn.userInput, 80)}</Text>
-      </Box>
-      {turn.sources.length === 0 ? (
-        <Box marginLeft={2}>
-          <Text dimColor>(no sources registered)</Text>
+/**
+ * Flattens the turn list into single-line rows. Every text value is truncated
+ * to fit the terminal width so no row wraps — wrapping would desync the
+ * overlay's count-based scroll window.
+ */
+function buildLines(turns: TurnProvenance[], colors: ThemeColors, cols: number): OverlayLine[] {
+  if (turns.length === 0) {
+    return [{ key: 'empty', node: <Text dimColor>No citations recorded yet.</Text> }];
+  }
+  const w = Math.max(20, cols - 4);
+  const lines: OverlayLine[] = [];
+  turns.forEach((turn, ti) => {
+    if (ti > 0) lines.push({ key: `sep-${ti}`, node: <Text> </Text> });
+    lines.push({
+      key: `turn-${ti}`,
+      node: (
+        <Box>
+          <Text color={colors.muted}>Turn {turn.turnIndex + 1}:</Text>
+          <Text> {truncate(turn.userInput, Math.min(80, w - 10))}</Text>
         </Box>
-      ) : (
-        turn.sources.map((src) => (
-          <SourceRow key={src.id} source={src} cited={citedSet.has(src.id)} />
-        ))
-      )}
-    </Box>
-  );
+      ),
+    });
+    if (turn.sources.length === 0) {
+      lines.push({
+        key: `turn-${ti}-empty`,
+        node: (
+          <Box marginLeft={2}>
+            <Text dimColor>(no sources registered)</Text>
+          </Box>
+        ),
+      });
+      return;
+    }
+    const citedSet = new Set(turn.citedIds);
+    turn.sources.forEach((src, si) => {
+      pushSourceLines(lines, `turn-${ti}-src-${si}`, src, citedSet.has(src.id), colors, w);
+    });
+  });
+  return lines;
 }
 
-function SourceRow({ source, cited }: { source: SourceItem; cited: boolean }) {
-  const colors = getThemeColors();
-  // Mirrors the legacy renderer at `src/repl.ts:874-885`: cited entries get
-  // the accent label + un-dimmed body; uncited entries use plain dimColor
-  // (no extra color override, which can over-darken on some themes).
-  const showRawRef = source.rawRef && source.rawRef !== source.label;
-  const showPreview = !!source.contentPreview;
-  return (
-    <Box flexDirection="column" marginLeft={2}>
-      <Box>
+function pushSourceLines(
+  lines: OverlayLine[],
+  keyBase: string,
+  source: SourceItem,
+  cited: boolean,
+  colors: ThemeColors,
+  w: number,
+): void {
+  // Mirrors the legacy SourceRow: cited entries get the accent marker +
+  // un-dimmed label; uncited entries render plain dim.
+  lines.push({
+    key: keyBase,
+    node: (
+      <Box marginLeft={2}>
         <Text color={cited ? colors.accent : undefined} dimColor={!cited} bold={cited}>
           [^{source.id}]
         </Text>
         <Text dimColor> ({source.kind}) </Text>
-        <Text dimColor={!cited}>{truncate(source.label, 80)}</Text>
+        <Text dimColor={!cited}>{truncate(source.label, Math.min(80, w - 16))}</Text>
       </Box>
-      {showRawRef && (
+    ),
+  });
+  if (source.rawRef && source.rawRef !== source.label) {
+    lines.push({
+      key: `${keyBase}-ref`,
+      node: (
         <Box marginLeft={4}>
-          <Text dimColor>{truncate(source.rawRef, 120)}</Text>
+          <Text dimColor>{truncate(source.rawRef, Math.min(120, w - 6))}</Text>
         </Box>
-      )}
-      {showPreview && (
+      ),
+    });
+  }
+  if (source.contentPreview) {
+    lines.push({
+      key: `${keyBase}-preview`,
+      node: (
         <Box marginLeft={4}>
-          <Text dimColor>{truncate(source.contentPreview.replace(/\s+/g, ' '), 160)}</Text>
+          <Text dimColor>
+            {truncate(source.contentPreview.replace(/\s+/g, ' '), Math.min(160, w - 6))}
+          </Text>
         </Box>
-      )}
-    </Box>
-  );
+      ),
+    });
+  }
 }

--- a/src/ui/overlays/SourcesViewer.tsx
+++ b/src/ui/overlays/SourcesViewer.tsx
@@ -1,90 +1,167 @@
-import { useMemo } from 'react';
-import { Box, Text, useStdout } from 'ink';
+import { useMemo, useState } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
 import type { Agent } from '../../agent.js';
 import type { TurnProvenance, SourceItem } from '../../provenance.js';
 import { getThemeColors, type ThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
-import { ScrollableOverlay, type OverlayLine } from './ScrollableOverlay.js';
+import { ViewerShell, viewerViewport, type OverlayLine } from './ViewerShell.js';
 import { VIEWER_TABS } from './viewer-tabs.js';
 
 interface SourcesViewerProps {
   agent: Agent;
-  /** Close the panel (Esc). Defaults to a no-op for standalone rendering/tests. */
   onClose?: () => void;
-  /** Advance to the next Shift-Tab tab. Defaults to a no-op. */
   onCycleTab?: () => void;
 }
 
 /**
- * Scrollable per-turn citation history (issue #211). Consumes
- * `agent.getTurnProvenance()` — the cumulative array of every turn that
- * registered sources — and flattens it into one visual row per line so the
- * shared `ScrollableOverlay` can window it to the terminal height.
- *
- * Accent rule matches the legacy renderer: a source is "cited" when
- * `citedIds.includes(source.id)`. Cited entries render in the theme accent
- * color; uncited entries render dim. Empty state covers both a fresh session
- * and a session where no turn produced citations.
+ * Accordion citation history (issue #211). Each turn is a collapsible row:
+ * collapsed by default into a one-line header so the whole conversation reads
+ * as a clean, scannable list; the focused turn expands (Enter/Space) to show
+ * its sources. `↑/↓` moves the cursor; the view auto-scrolls to keep the
+ * focused turn visible. Esc / Shift-Tab are owned by the surrounding
+ * `ViewerShell`.
  */
 export function SourcesViewer({ agent, onClose, onCycleTab }: SourcesViewerProps) {
   const colors = getThemeColors();
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
+  const rows = stdout?.rows ?? 24;
+  const viewport = viewerViewport(rows, VIEWER_TABS.length);
   const turns = agent.getTurnProvenance();
-  // The history is immutable while the viewer owns the keystream (the agent is
-  // idle), so rebuild the flat line list only when the turn count or width
-  // changes — not on every scroll keystroke.
-  const lines = useMemo(() => buildLines(turns, colors, cols), [turns.length, colors, cols]);
+
+  const [selected, setSelected] = useState(0);
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
+  const [offset, setOffset] = useState(0);
+
+  const { lines, headerLineByTurn } = useMemo(
+    () => buildAccordion(turns, expanded, selected, colors, cols),
+    [turns.length, expanded, selected, colors, cols],
+  );
+
+  const maxOffset = Math.max(0, lines.length - viewport);
+  const clamped = Math.min(offset, maxOffset);
+
+  // Re-aim the scroll so turn `sel` (under `exp`) stays visible after a move.
+  const scrollTo = (sel: number, exp: Set<number>) => {
+    const meta = buildAccordion(turns, exp, sel, colors, cols);
+    const total = meta.lines.length;
+    const start = meta.headerLineByTurn[sel] ?? 0;
+    const end = meta.headerLineByTurn[sel + 1] ?? total; // exclusive
+    const maxOff = Math.max(0, total - viewport);
+    setOffset((off) => {
+      const o = Math.min(off, maxOff);
+      const fits = start >= o && end - 1 < o + viewport;
+      return fits ? o : Math.min(maxOff, start);
+    });
+  };
+
+  const move = (delta: number) => {
+    if (turns.length === 0) return;
+    const next = Math.max(0, Math.min(turns.length - 1, selected + delta));
+    setSelected(next);
+    scrollTo(next, expanded);
+  };
+
+  const setOpen = (open: boolean) => {
+    if (turns.length === 0) return;
+    const next = new Set(expanded);
+    if (open) next.add(selected);
+    else next.delete(selected);
+    setExpanded(next);
+    scrollTo(selected, next);
+  };
+
+  useInput((input, key) => {
+    if (turns.length === 0) return;
+    if (key.downArrow || input === 'j') move(1);
+    else if (key.upArrow || input === 'k') move(-1);
+    else if (input === 'g') move(-turns.length);
+    else if (input === 'G') move(turns.length);
+    else if (key.rightArrow) setOpen(true);
+    else if (key.leftArrow) setOpen(false);
+    else if (key.return || input === ' ') setOpen(!expanded.has(selected));
+  });
+
+  const visible = lines.slice(clamped, clamped + viewport);
+  const position =
+    lines.length > viewport
+      ? { first: clamped + 1, last: Math.min(lines.length, clamped + viewport), total: lines.length }
+      : null;
+
   return (
-    <ScrollableOverlay
+    <ViewerShell
       tabs={VIEWER_TABS}
       activeTab="sources"
-      lines={lines}
+      position={position}
+      keyHints="↑/↓ move · ↵ expand · ⇧⇥ switch tab · esc close"
       onClose={onClose}
       onCycleTab={onCycleTab}
-    />
+    >
+      {visible.map((line) => (
+        <Box key={line.key}>{line.node}</Box>
+      ))}
+    </ViewerShell>
   );
 }
 
 /**
- * Flattens the turn list into single-line rows. Every text value is truncated
- * to fit the terminal width so no row wraps — wrapping would desync the
- * overlay's count-based scroll window.
+ * Flattens the turns into single-row lines for the accordion. Returns the line
+ * list plus the line index of each turn's header (for scroll math). Only the
+ * turns in `expanded` contribute source rows; `selected` only drives the header
+ * highlight, so line positions depend on `expanded` alone.
  */
-function buildLines(turns: TurnProvenance[], colors: ThemeColors, cols: number): OverlayLine[] {
+function buildAccordion(
+  turns: TurnProvenance[],
+  expanded: Set<number>,
+  selected: number,
+  colors: ThemeColors,
+  cols: number,
+): { lines: OverlayLine[]; headerLineByTurn: number[] } {
   if (turns.length === 0) {
-    return [{ key: 'empty', node: <Text dimColor>No citations recorded yet.</Text> }];
+    return {
+      lines: [{ key: 'empty', node: <Text dimColor>No citations recorded yet.</Text> }],
+      headerLineByTurn: [],
+    };
   }
-  const w = Math.max(20, cols - 4);
   const lines: OverlayLine[] = [];
-  turns.forEach((turn, ti) => {
-    if (ti > 0) lines.push({ key: `sep-${ti}`, node: <Text> </Text> });
+  const headerLineByTurn: number[] = [];
+  turns.forEach((turn, i) => {
+    const isOpen = expanded.has(i);
+    const isSel = i === selected;
+    headerLineByTurn[i] = lines.length;
+    const count = `${turn.sources.length} source${turn.sources.length === 1 ? '' : 's'}`;
     lines.push({
-      key: `turn-${ti}`,
+      key: `turn-${i}`,
       node: (
-        <Box>
-          <Text color={colors.muted}>Turn {turn.turnIndex + 1}:</Text>
-          <Text> {truncate(turn.userInput, Math.min(80, w - 10))}</Text>
-        </Box>
+        <Text
+          color={isSel ? colors.accent : undefined}
+          bold={isSel}
+          dimColor={!isSel}
+          wrap="truncate-end"
+        >
+          {isOpen ? '▾' : '▸'} Turn {turn.turnIndex + 1} · {turn.userInput} ({count})
+        </Text>
       ),
     });
+    if (!isOpen) return;
     if (turn.sources.length === 0) {
       lines.push({
-        key: `turn-${ti}-empty`,
+        key: `turn-${i}-empty`,
         node: (
-          <Box marginLeft={2}>
+          <Box marginLeft={5}>
             <Text dimColor>(no sources registered)</Text>
           </Box>
         ),
       });
-      return;
+    } else {
+      const citedSet = new Set(turn.citedIds);
+      turn.sources.forEach((src, si) => {
+        pushSourceLines(lines, `turn-${i}-src-${si}`, src, citedSet.has(src.id), colors, cols);
+      });
     }
-    const citedSet = new Set(turn.citedIds);
-    turn.sources.forEach((src, si) => {
-      pushSourceLines(lines, `turn-${ti}-src-${si}`, src, citedSet.has(src.id), colors, w);
-    });
+    lines.push({ key: `turn-${i}-gap`, node: <Text> </Text> });
   });
-  return lines;
+  return { lines, headerLineByTurn };
 }
 
 function pushSourceLines(
@@ -93,19 +170,20 @@ function pushSourceLines(
   source: SourceItem,
   cited: boolean,
   colors: ThemeColors,
-  w: number,
+  cols: number,
 ): void {
-  // Mirrors the legacy SourceRow: cited entries get the accent marker +
-  // un-dimmed label; uncited entries render plain dim.
+  const labelMax = Math.max(10, cols - 24);
   lines.push({
     key: keyBase,
     node: (
-      <Box marginLeft={2}>
+      <Box marginLeft={5}>
         <Text color={cited ? colors.accent : undefined} dimColor={!cited} bold={cited}>
           [^{source.id}]
         </Text>
-        <Text dimColor> ({source.kind}) </Text>
-        <Text dimColor={!cited}>{truncate(source.label, Math.min(80, w - 16))}</Text>
+        <Text dimColor> {source.kind.padEnd(5)} </Text>
+        <Text dimColor={!cited} wrap="truncate-end">
+          {truncate(source.label, labelMax)}
+        </Text>
       </Box>
     ),
   });
@@ -113,8 +191,10 @@ function pushSourceLines(
     lines.push({
       key: `${keyBase}-ref`,
       node: (
-        <Box marginLeft={4}>
-          <Text dimColor>{truncate(source.rawRef, Math.min(120, w - 6))}</Text>
+        <Box marginLeft={10}>
+          <Text dimColor wrap="truncate-end">
+            ↳ {source.rawRef}
+          </Text>
         </Box>
       ),
     });
@@ -123,9 +203,9 @@ function pushSourceLines(
     lines.push({
       key: `${keyBase}-preview`,
       node: (
-        <Box marginLeft={4}>
-          <Text dimColor>
-            {truncate(source.contentPreview.replace(/\s+/g, ' '), Math.min(160, w - 6))}
+        <Box marginLeft={10}>
+          <Text dimColor wrap="truncate-end">
+            {source.contentPreview.replace(/\s+/g, ' ')}
           </Text>
         </Box>
       ),

--- a/src/ui/overlays/SourcesViewer.tsx
+++ b/src/ui/overlays/SourcesViewer.tsx
@@ -5,6 +5,7 @@ import type { TurnProvenance, SourceItem } from '../../provenance.js';
 import { getThemeColors, type ThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
 import { ScrollableOverlay, type OverlayLine } from './ScrollableOverlay.js';
+import { VIEWER_TABS } from './viewer-tabs.js';
 
 interface SourcesViewerProps {
   agent: Agent;
@@ -35,7 +36,13 @@ export function SourcesViewer({ agent, onClose, onCycleTab }: SourcesViewerProps
   // changes — not on every scroll keystroke.
   const lines = useMemo(() => buildLines(turns, colors, cols), [turns.length, colors, cols]);
   return (
-    <ScrollableOverlay title="Sources" lines={lines} onClose={onClose} onCycleTab={onCycleTab} />
+    <ScrollableOverlay
+      tabs={VIEWER_TABS}
+      activeTab="sources"
+      lines={lines}
+      onClose={onClose}
+      onCycleTab={onCycleTab}
+    />
   );
 }
 

--- a/src/ui/overlays/StatusViewer.tsx
+++ b/src/ui/overlays/StatusViewer.tsx
@@ -6,6 +6,7 @@ import { pickActiveStep, summarizePlan, type AgentStatusInputs } from '../../age
 import { getThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
 import { ScrollableOverlay, type OverlayLine } from './ScrollableOverlay.js';
+import { VIEWER_TABS } from './viewer-tabs.js';
 
 interface StatusViewerProps {
   agent: Agent;
@@ -41,7 +42,8 @@ export function StatusViewer({
   );
   return (
     <ScrollableOverlay
-      title="Agent Status"
+      tabs={VIEWER_TABS}
+      activeTab="status"
       lines={lines}
       onClose={onClose}
       onCycleTab={onCycleTab}

--- a/src/ui/overlays/StatusViewer.tsx
+++ b/src/ui/overlays/StatusViewer.tsx
@@ -68,7 +68,7 @@ function RowNode({ label, value }: { label: string; value: string }) {
   return (
     <Box>
       <Text dimColor>{label.padEnd(LABEL_WIDTH)}</Text>
-      <Text>{value}</Text>
+      <Text wrap="truncate-end">{value}</Text>
     </Box>
   );
 }
@@ -85,7 +85,7 @@ function pushAssumptions(lines: OverlayLine[], assumptions: AgentStatusInputs['a
       node: (
         <Box>
           <Text dimColor>{(idx === 0 ? 'Assumptions' : '').padEnd(LABEL_WIDTH)}</Text>
-          <Text>{text}</Text>
+          <Text wrap="truncate-end">{text}</Text>
         </Box>
       ),
     });
@@ -110,7 +110,7 @@ function pushPlanStep(
       node: (
         <Box>
           <Text dimColor>{''.padEnd(LABEL_WIDTH)}</Text>
-          <Text dimColor>verify: {truncate(verification, 120)}</Text>
+          <Text dimColor wrap="truncate-end">verify: {truncate(verification, 120)}</Text>
         </Box>
       ),
     });
@@ -153,8 +153,10 @@ function pushVerification(
         <Text color={tagColor} bold>
           {entry.verdict.toUpperCase()}
         </Text>
-        <Text> — {truncate(entry.reason, 120)}</Text>
-        {entry.source && <Text dimColor> ({truncate(entry.source, 60)})</Text>}
+        <Text wrap="truncate-end"> — {truncate(entry.reason, 120)}</Text>
+        {entry.source && (
+          <Text dimColor wrap="truncate-end"> ({truncate(entry.source, 60)})</Text>
+        )}
       </Box>
     ),
   });

--- a/src/ui/overlays/StatusViewer.tsx
+++ b/src/ui/overlays/StatusViewer.tsx
@@ -1,54 +1,70 @@
+import { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import type { Agent } from '../../agent.js';
 import type { BernardConfig } from '../../config.js';
 import { pickActiveStep, summarizePlan, type AgentStatusInputs } from '../../agent-status.js';
 import { getThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
+import { ScrollableOverlay, type OverlayLine } from './ScrollableOverlay.js';
 
 interface StatusViewerProps {
   agent: Agent;
   config: BernardConfig;
   sessionAllowedCount: number;
+  /** Close the panel (Esc). Defaults to a no-op for standalone rendering/tests. */
+  onClose?: () => void;
+  /** Advance to the next Shift-Tab tab. Defaults to a no-op. */
+  onCycleTab?: () => void;
 }
 
 const LABEL_WIDTH = 15;
 const MAX_VALUE_CHARS = 200;
 
 /**
- * Full-screen Agent Status panel. Replaces the legacy `buildAgentStatusPanel`
- * + `setPinnedRegion('viewer', …)` flow from `src/repl.ts`. Renders the same
- * `AgentStatusInputs` shape that `src/agent-status.ts:15` defines, but as Ink
- * components — no ANSI assembly, no pinned region.
- *
- * **Closes #211 round-2 bug 1 by construction**: there is no pinned-region
- * concept in Ink. The panel is just a JSX subtree that fills the viewport
- * above the thread; closing it (Esc) unmounts the subtree and Ink's render
- * diff leaves the thread + prompt in place.
+ * Scrollable Agent Status panel. Flattens the `AgentStatusInputs` shape into
+ * one visual row per line and renders through the shared `ScrollableOverlay`,
+ * so it shares the full-screen "replaces the thread" treatment and the
+ * Esc / Shift-Tab keystream with `SourcesViewer` (issue #211).
  */
-export function StatusViewer({ agent, config, sessionAllowedCount }: StatusViewerProps) {
-  const colors = getThemeColors();
-  const inputs = collectStatusInputs(agent, config, sessionAllowedCount);
-
+export function StatusViewer({
+  agent,
+  config,
+  sessionAllowedCount,
+  onClose,
+  onCycleTab,
+}: StatusViewerProps) {
+  // Status fields are stable while the viewer owns the keystream (the agent is
+  // idle), so collect + flatten once rather than on every scroll keystroke.
+  const lines = useMemo(
+    () => buildLines(collectStatusInputs(agent, config, sessionAllowedCount)),
+    [agent, config, sessionAllowedCount],
+  );
   return (
-    <Box flexDirection="column" marginTop={1}>
-      <Text color={colors.accent} bold>
-        Agent Status
-      </Text>
-      <Text> </Text>
-      <Row label="Goal" value={inputs.goal ? truncate(inputs.goal, MAX_VALUE_CHARS) : '(none)'} />
-      <Row label="Permissions" value={permissionsValue(inputs.permissions)} />
-      <Row label="Strategy" value={inputs.constraints?.strategyId ?? '(none)'} />
-      <Row label="Response shape" value={responseShapeValue(inputs.constraints)} />
-      <AssumptionsRows assumptions={inputs.assumptions} />
-      <PlanStepRow planStep={inputs.planStep} planSummary={inputs.planSummary} />
-      <VerificationRow entry={inputs.lastVerification} />
-      <Text> </Text>
-      <Text dimColor>Esc to close · Shift-Tab to switch tabs</Text>
-    </Box>
+    <ScrollableOverlay
+      title="Agent Status"
+      lines={lines}
+      onClose={onClose}
+      onCycleTab={onCycleTab}
+    />
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function buildLines(inputs: AgentStatusInputs): OverlayLine[] {
+  const lines: OverlayLine[] = [];
+  const row = (key: string, label: string, value: string) =>
+    lines.push({ key, node: <RowNode label={label} value={value} /> });
+
+  row('goal', 'Goal', inputs.goal ? truncate(inputs.goal, MAX_VALUE_CHARS) : '(none)');
+  row('permissions', 'Permissions', permissionsValue(inputs.permissions));
+  row('strategy', 'Strategy', inputs.constraints?.strategyId ?? '(none)');
+  row('response', 'Response shape', responseShapeValue(inputs.constraints));
+  pushAssumptions(lines, inputs.assumptions);
+  pushPlanStep(lines, inputs.planStep, inputs.planSummary);
+  pushVerification(lines, inputs.lastVerification);
+  return lines;
+}
+
+function RowNode({ label, value }: { label: string; value: string }) {
   return (
     <Box>
       <Text dimColor>{label.padEnd(LABEL_WIDTH)}</Text>
@@ -57,73 +73,91 @@ function Row({ label, value }: { label: string; value: string }) {
   );
 }
 
-function AssumptionsRows({ assumptions }: { assumptions: AgentStatusInputs['assumptions'] }) {
-  if (assumptions.length === 0) return <Row label="Assumptions" value="(none)" />;
-  return (
-    <Box flexDirection="column">
-      {assumptions.map((a, idx) => {
-        const text = `"${a.phrase}" → ${truncate(a.resolvedTo, 80)} (${a.sourceKey})`;
-        return (
-          <Box key={idx}>
-            <Text dimColor>{(idx === 0 ? 'Assumptions' : '').padEnd(LABEL_WIDTH)}</Text>
-            <Text>{text}</Text>
-          </Box>
-        );
-      })}
-    </Box>
-  );
+function pushAssumptions(lines: OverlayLine[], assumptions: AgentStatusInputs['assumptions']): void {
+  if (assumptions.length === 0) {
+    lines.push({ key: 'assumptions', node: <RowNode label="Assumptions" value="(none)" /> });
+    return;
+  }
+  assumptions.forEach((a, idx) => {
+    const text = `"${a.phrase}" → ${truncate(a.resolvedTo, 80)} (${a.sourceKey})`;
+    lines.push({
+      key: `assumption-${idx}`,
+      node: (
+        <Box>
+          <Text dimColor>{(idx === 0 ? 'Assumptions' : '').padEnd(LABEL_WIDTH)}</Text>
+          <Text>{text}</Text>
+        </Box>
+      ),
+    });
+  });
 }
 
-function PlanStepRow({
-  planStep,
-  planSummary,
-}: {
-  planStep: AgentStatusInputs['planStep'];
-  planSummary: AgentStatusInputs['planSummary'];
-}) {
-  if (!planStep) return <Row label="Plan step" value="(none)" />;
+function pushPlanStep(
+  lines: OverlayLine[],
+  planStep: AgentStatusInputs['planStep'],
+  planSummary: AgentStatusInputs['planSummary'],
+): void {
+  if (!planStep) {
+    lines.push({ key: 'plan-step-none', node: <RowNode label="Plan step" value="(none)" /> });
+    return;
+  }
   const { id, status, description, verification } = planStep;
   const header = `[${status}] ${id} of ${planSummary.total} — ${truncate(description, 120)}`;
-  return (
-    <Box flexDirection="column">
-      <Row label="Plan step" value={header} />
-      {verification && (
+  lines.push({ key: 'plan-step', node: <RowNode label="Plan step" value={header} /> });
+  if (verification) {
+    lines.push({
+      key: 'plan-step-verify',
+      node: (
         <Box>
           <Text dimColor>{''.padEnd(LABEL_WIDTH)}</Text>
           <Text dimColor>verify: {truncate(verification, 120)}</Text>
         </Box>
-      )}
-      {planSummary.done > 0 && planSummary.done < planSummary.total && (
+      ),
+    });
+  }
+  if (planSummary.done > 0 && planSummary.done < planSummary.total) {
+    lines.push({
+      key: 'plan-step-progress',
+      node: (
         <Box>
           <Text dimColor>{''.padEnd(LABEL_WIDTH)}</Text>
           <Text dimColor>
             ({planSummary.done}/{planSummary.total} done)
           </Text>
         </Box>
-      )}
-    </Box>
-  );
+      ),
+    });
+  }
 }
 
-function VerificationRow({ entry }: { entry: AgentStatusInputs['lastVerification'] }) {
+function pushVerification(
+  lines: OverlayLine[],
+  entry: AgentStatusInputs['lastVerification'],
+): void {
+  if (!entry) {
+    lines.push({ key: 'last-verify', node: <RowNode label="Last verify" value="(none)" /> });
+    return;
+  }
   const colors = getThemeColors();
-  if (!entry) return <Row label="Last verify" value="(none)" />;
   const tagColor =
     entry.verdict === 'pass'
       ? colors.success
       : entry.verdict === 'warn'
         ? colors.warning
         : colors.error;
-  return (
-    <Box>
-      <Text dimColor>{'Last verify'.padEnd(LABEL_WIDTH)}</Text>
-      <Text color={tagColor} bold>
-        {entry.verdict.toUpperCase()}
-      </Text>
-      <Text> — {truncate(entry.reason, 120)}</Text>
-      {entry.source && <Text dimColor> ({truncate(entry.source, 60)})</Text>}
-    </Box>
-  );
+  lines.push({
+    key: 'last-verify',
+    node: (
+      <Box>
+        <Text dimColor>{'Last verify'.padEnd(LABEL_WIDTH)}</Text>
+        <Text color={tagColor} bold>
+          {entry.verdict.toUpperCase()}
+        </Text>
+        <Text> — {truncate(entry.reason, 120)}</Text>
+        {entry.source && <Text dimColor> ({truncate(entry.source, 60)})</Text>}
+      </Box>
+    ),
+  });
 }
 
 function permissionsValue(p: AgentStatusInputs['permissions']): string {

--- a/src/ui/overlays/ViewerShell.tsx
+++ b/src/ui/overlays/ViewerShell.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import { getThemeColors } from '../../theme.js';
+
+/** One pre-rendered visual row. `node` MUST occupy exactly one terminal line. */
+export interface OverlayLine {
+  key: string;
+  node: ReactNode;
+}
+
+/** A selectable viewer tab rendered in the bottom tab menu. */
+export interface OverlayTab {
+  id: string;
+  label: string;
+}
+
+// Fixed chrome rows below the scrolling content area, excluding the tab rows
+// themselves: scroll-position line + top border + bottom border + key hints.
+const CHROME_BELOW_CONTENT = 4;
+
+/**
+ * Height of the overlay frame. Always one short of the terminal: a dynamic
+ * (non-Static) Ink frame that fills the last row can't be erased cleanly — the
+ * trailing newline scrolls the terminal and desyncs the cursor math, leaving
+ * stale rows after the overlay closes.
+ */
+export function viewerFrameHeight(rows: number): number {
+  return Math.max(1, rows - 1);
+}
+
+/** How many content rows fit above the bottom chrome (`tabCount` tab rows + fixed chrome). */
+export function viewerViewport(rows: number, tabCount: number): number {
+  return Math.max(1, viewerFrameHeight(rows) - tabCount - CHROME_BELOW_CONTENT);
+}
+
+interface ViewerShellProps {
+  tabs: readonly OverlayTab[];
+  /** `id` of the active tab — highlighted in the menu; the rest are muted. */
+  activeTab: string;
+  /**
+   * Scroll position shown directly above the tab menu (`rows X–Y of N`). `null`
+   * keeps the row reserved (blank) so the layout height stays stable.
+   */
+  position: { first: number; last: number; total: number } | null;
+  /** Dim key legend pinned to the very bottom. */
+  keyHints: string;
+  /** The (already-windowed) content rows. */
+  children: ReactNode;
+  onClose?: () => void;
+  onCycleTab?: () => void;
+}
+
+/**
+ * Shared chrome for the Shift-Tab viewer tabs (`StatusViewer`, `SourcesViewer`).
+ * Renders the content area, then a bottom block — scroll position, a vertical
+ * tab menu fenced by top/bottom border rules, and a key legend. Owns the
+ * Esc / Shift-Tab keystream; the content component layered inside owns its own
+ * navigation keys via a separate `useInput` (Ink dispatches to both).
+ *
+ * The frame is pinned to `viewerFrameHeight(rows)` so it fills the screen and
+ * reads as a replacement for the thread, while `<Thread>` stays mounted
+ * (unmounting it would reprint `<Static>` scrollback — see `src/ui/Thread.tsx`).
+ */
+export function ViewerShell({
+  tabs,
+  activeTab,
+  position,
+  keyHints,
+  children,
+  onClose = () => {},
+  onCycleTab = () => {},
+}: ViewerShellProps) {
+  const colors = getThemeColors();
+  const { stdout } = useStdout();
+  const rows = stdout?.rows ?? 24;
+  const cols = stdout?.columns ?? 80;
+  // App wraps the overlay in paddingX={2}, so the usable width is cols - 4.
+  const rule = '─'.repeat(Math.max(4, cols - 4));
+
+  useInput((_input, key) => {
+    if (key.escape) onClose();
+    else if (key.shift && key.tab) onCycleTab();
+  });
+
+  return (
+    <Box flexDirection="column" height={viewerFrameHeight(rows)}>
+      {children}
+      <Box flexGrow={1} />
+      <Text dimColor>
+        {position ? `rows ${position.first}–${position.last} of ${position.total}` : ' '}
+      </Text>
+      <Text dimColor>{rule}</Text>
+      <Box flexDirection="column">
+        {tabs.map((tab) => {
+          const active = tab.id === activeTab;
+          return (
+            <Text
+              key={tab.id}
+              color={active ? colors.accent : undefined}
+              bold={active}
+              dimColor={!active}
+            >
+              {active ? '▸ ' : '  '}
+              {tab.label}
+            </Text>
+          );
+        })}
+      </Box>
+      <Text dimColor>{rule}</Text>
+      <Text dimColor>{keyHints}</Text>
+    </Box>
+  );
+}

--- a/src/ui/overlays/viewer-tabs.ts
+++ b/src/ui/overlays/viewer-tabs.ts
@@ -1,0 +1,12 @@
+import type { OverlayTab } from './ScrollableOverlay.js';
+
+/**
+ * The Shift-Tab viewer tabs, in cycle order. Single source of truth shared by
+ * `StatusViewer` / `SourcesViewer` (which render the bottom tab menu) and
+ * `App` (which owns the open/cycle transitions). `id` matches the
+ * `activeOverlay` value for that tab.
+ */
+export const VIEWER_TABS: readonly OverlayTab[] = [
+  { id: 'status', label: 'Agent Status' },
+  { id: 'sources', label: 'Sources' },
+];

--- a/src/ui/overlays/viewer-tabs.ts
+++ b/src/ui/overlays/viewer-tabs.ts
@@ -1,4 +1,4 @@
-import type { OverlayTab } from './ScrollableOverlay.js';
+import type { OverlayTab } from './ViewerShell.js';
 
 /**
  * The Shift-Tab viewer tabs, in cycle order. Single source of truth shared by


### PR DESCRIPTION
## What & why

Closes the remaining part of #211. The Shift-Tab viewer tabs (Agent Status / Sources) **stacked below** the thread instead of replacing it, and the full-conversation citation list couldn't scroll past the terminal height.

(The other two parts of #211 — the false "no citations from last turn" message and last-turn-only scope — were already fixed on `bernard-1-0-0`; this PR finishes the "replace the thread" + history requirements.)

## Changes

- **New `ScrollableOverlay`** (`src/ui/overlays/ScrollableOverlay.tsx`) — a shared full-height panel that owns its keystream while open (`↑/↓`, `j/k`, `PgUp/PgDn`, `g/G`, `Esc`→close, `Shift-Tab`→cycle), windows a flat line list to the terminal height, and shows a `rows X–Y of N` indicator only when content overflows.
- **`SourcesViewer` / `StatusViewer`** refactored to emit flat, width-clamped `{key, node}[]` line lists (one terminal row each so the count-based scroll window stays accurate) rendered through `ScrollableOverlay`. `buildLines`/`collectStatusInputs` are memoized so scrolling doesn't rebuild the list each keystroke.
- **`App.tsx`** — while a viewer tab is open, the live chrome (spinner, plan panel, toast, prompt, hint/status bars) is hidden via a `viewerActive` gate so the viewer fills the screen, while `<Thread>` stays mounted (unmounting it reprints Ink `<Static>` scrollback). All overlays now own their own keystream; `appInputActive` is `activeOverlay === null` and Shift-Tab just opens the first tab.

## Tests

- New `ScrollableOverlay.test.tsx` (windowing, scroll keys, clamping, Esc/Shift-Tab forwarding).
- `SourcesViewer` long-history windowing case; shared `SHIFT_TAB`/`PAGE_DOWN` keys moved into `_keys.ts`.
- App-level tests: Shift-Tab swaps Status↔Sources↔thread with chrome hidden/restored.
- `npm run build` clean; full suite **2784 passed (141 files)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)