### PR TITLE
feat(permissions): deterministic scope/breadth rule engine + tree-sitter shell AST (#261)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,9 @@
         "node-notifier": "^10.0.1",
         "react": "^18.3.1",
         "remend": "^1.3.0",
+        "tree-sitter-wasms": "^0.1.13",
         "turndown": "^7.2.2",
+        "web-tree-sitter": "^0.25.10",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -5375,6 +5377,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tree-sitter-wasms": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
+      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "tree-sitter-wasms": "^0.1.11"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -6133,6 +6144,20 @@
           "optional": true
         },
         "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "node-notifier": "^10.0.1",
     "react": "^18.3.1",
     "remend": "^1.3.0",
+    "tree-sitter-wasms": "^0.1.13",
     "turndown": "^7.2.2",
+    "web-tree-sitter": "^0.25.10",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,11 @@ import { RESPONSE_STYLE_IDS, type ResponseStyle } from './agent-prompt.js';
 import { normalizeStoredModelMode, type ModelMode } from './model-policy.js';
 import { getCatalogForProvider } from './providers/catalog.js';
 import { BUILTIN_PROVIDERS, type BuiltinProvider } from './providers/types.js';
-import type { ToolPermissions } from './tool-permissions.js';
+import {
+  type PermissionRule,
+  type ToolPermissions,
+  sanitizePermissionRules,
+} from './tool-permissions.js';
 import { FALLBACK_TIERS } from './lineups.js';
 
 /** Resolved runtime configuration for a Bernard session. */
@@ -57,12 +61,12 @@ export interface BernardConfig {
    */
   activeLineupId?: string;
   /**
-   * Profile-persisted tool permission grants (#212), keyed by tool name or
-   * `shell:<primary-command>`. `allow` bypasses the block + confirm gates;
-   * `deny` refuses without prompting. Mutated in place when the user picks
+   * Profile-persisted tool permission rules (#212/#261). An ordered list of
+   * `{effect, tool, specifier?}` rules evaluated deny→ask→allow by the
+   * permission engine (`src/permissions/`). Appended to when the user picks
    * "Always allow … for this profile" at a permission dialog.
    */
-  toolPermissions: ToolPermissions;
+  toolPermissions: PermissionRule[];
   /**
    * "Run Without Permission Checks or Safeguards" (#212). Forces
    * `toolMode: 'write'` + `confirmThreshold: 'never'` at the policy layer.
@@ -329,7 +333,7 @@ export function savePreferences(prefs: {
   maxConcurrentAgents?: number;
   responseStyle?: ResponseStyle;
   activeLineupId?: string;
-  toolPermissions?: ToolPermissions;
+  toolPermissions?: PermissionRule[] | ToolPermissions;
   skipPermissions?: boolean;
 }): void {
   // Patch shape matches ProfileSettings exactly — keys present in `prefs`
@@ -338,6 +342,11 @@ export function savePreferences(prefs: {
   const patch: Record<string, unknown> = {};
   for (const k of Object.keys(prefs)) {
     patch[k] = (prefs as Record<string, unknown>)[k];
+  }
+  // Normalize any tool-permission value (legacy object or v2 rules) to the v2
+  // array shape before it's written to disk (#261).
+  if ('toolPermissions' in patch && patch.toolPermissions !== undefined) {
+    patch.toolPermissions = sanitizePermissionRules(patch.toolPermissions);
   }
   saveActiveSettings(patch as ProfileSettings);
 }
@@ -371,7 +380,7 @@ export function loadPreferences(): {
   maxConcurrentAgents?: number;
   responseStyle?: ResponseStyle;
   activeLineupId?: string;
-  toolPermissions?: ToolPermissions;
+  toolPermissions?: PermissionRule[];
   skipPermissions?: boolean;
 } {
   // Routes through the active profile in profiles.json (#207). Each field is
@@ -420,30 +429,10 @@ export function loadPreferences(): {
       typeof parsed.activeLineupId === 'string' && parsed.activeLineupId.length > 0
         ? parsed.activeLineupId
         : undefined,
-    toolPermissions: sanitizeToolPermissions(parsed.toolPermissions),
+    toolPermissions: sanitizePermissionRules(parsed.toolPermissions),
     skipPermissions:
       typeof parsed.skipPermissions === 'boolean' ? parsed.skipPermissions : undefined,
   };
-}
-
-/**
- * Validates a stored `toolPermissions` blob (#212): must be a plain object;
- * entries whose value isn't exactly `'allow'` or `'deny'` are dropped so a
- * hand-edited profiles.json can't smuggle garbage into the permission gates.
- * Prototype-pollution keys are skipped — no legitimate permission key is
- * named `__proto__`/`constructor`/`prototype`, and assigning them onto a
- * plain object can rewire its prototype.
- */
-const FORBIDDEN_PERMISSION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-function sanitizeToolPermissions(raw: unknown): ToolPermissions | undefined {
-  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
-  const out: ToolPermissions = {};
-  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-    if (FORBIDDEN_PERMISSION_KEYS.has(k)) continue;
-    if (v === 'allow' || v === 'deny') out[k] = v;
-  }
-  return out;
 }
 
 function loadStoredKeys(): Record<string, string> {
@@ -1100,7 +1089,7 @@ export function loadConfig(overrides?: {
     customProviders,
     providerBaseUrl,
     activeLineupId: prefs.activeLineupId,
-    toolPermissions: prefs.toolPermissions ?? {},
+    toolPermissions: prefs.toolPermissions ?? [],
     skipPermissions: prefs.skipPermissions ?? false,
   };
 

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import { loadConfig } from '../config.js';
+import { initShellParser } from '../permissions/shell-ast.js';
 import { assembleContext } from '../framework/context.js';
 import { RAGStore, type RAGSearchResult } from '../rag.js';
 import { debugLog } from '../logger.js';
@@ -43,6 +44,9 @@ export interface RunJobResult {
  */
 export async function runJob(job: CronJob, log: (msg: string) => void): Promise<RunJobResult> {
   registerBuiltinDefinitions();
+  // Load the bash parser so dangerous-command detection / rule matching is
+  // precise in headless runs too (#261). Await so the first shell call sees it.
+  await initShellParser();
   const config = loadConfig();
   const store = new CronStore();
 

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -44,9 +44,10 @@ export interface RunJobResult {
  */
 export async function runJob(job: CronJob, log: (msg: string) => void): Promise<RunJobResult> {
   registerBuiltinDefinitions();
-  // Load the bash parser so dangerous-command detection / rule matching is
-  // precise in headless runs too (#261). Await so the first shell call sees it.
-  await initShellParser();
+  // Warm the bash parser in the background (#261). Cron carries no profile
+  // rules so the parser isn't consulted for matching, and dangerous-command
+  // detection uses regex — so this never needs to block job startup.
+  void initShellParser();
   const config = loadConfig();
   const store = new CronStore();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ import { bootstrapPendingCandidates } from './candidate-bootstrap.js';
 import { runCorrectionAgent } from './correction.js';
 import { debugLog, isDebugEnabled } from './logger.js';
 import { installInstrumentedFetchIfDebug } from './framework/instrumented-fetch.js';
+import { initShellParser } from './permissions/shell-ast.js';
 import { App } from './ui/App.js';
 import { getInkHandlers } from './ui/ink-handlers.js';
 import type {
@@ -222,6 +223,11 @@ async function runInkRepl(args: {
 }): Promise<void> {
   const { config, resume, isFreshInstall, alertBanner } = args;
   let { alertContext } = args;
+
+  // Kick off the tree-sitter bash parser load (#261) in the background so
+  // shell permission rules can match compound commands precisely. Best-effort:
+  // until it's ready, the engine falls back to the conservative regex path.
+  void initShellParser();
 
   const memoryStore = new MemoryStore();
   const routineStore = new RoutineStore();

--- a/src/permissions/breadth.ts
+++ b/src/permissions/breadth.ts
@@ -33,9 +33,10 @@ function within(dir: string): boolean {
   // Only offer a directory-level grant inside cwd or home, and never the root.
   const root = path.parse(dir).root;
   if (dir === root) return false;
-  const cwd = process.cwd();
-  const home = os.homedir();
-  return dir.startsWith(cwd) || dir.startsWith(home);
+  // Separator-aware containment so a sibling like `/home/me/proj2` is not
+  // treated as "within" `/home/me/proj`.
+  const under = (base: string): boolean => dir === base || dir.startsWith(base + path.sep);
+  return under(process.cwd()) || under(os.homedir());
 }
 
 /**

--- a/src/permissions/breadth.ts
+++ b/src/permissions/breadth.ts
@@ -69,16 +69,28 @@ export function breadthOptionsFor(toolName: string, args: unknown): BreadthOptio
     if (!p) return [];
     const abs = path.resolve(p);
     const out: BreadthOption[] = [
-      { label: truncate(abs), specifier: abs, rulePreview: preview(`${toolName} ${truncate(abs)}`) },
+      {
+        label: truncate(abs),
+        specifier: abs,
+        rulePreview: preview(`${toolName} ${truncate(abs)}`),
+      },
     ];
     const dir = path.dirname(abs);
     if (within(dir)) {
       const glob = `${dir}/**`;
-      out.push({ label: glob, specifier: glob, rulePreview: preview(`${toolName} ${truncate(glob)}`) });
+      out.push({
+        label: glob,
+        specifier: glob,
+        rulePreview: preview(`${toolName} ${truncate(glob)}`),
+      });
       const parent = path.dirname(dir);
       if (parent !== dir && within(parent)) {
         const pglob = `${parent}/**`;
-        out.push({ label: pglob, specifier: pglob, rulePreview: preview(`${toolName} ${truncate(pglob)}`) });
+        out.push({
+          label: pglob,
+          specifier: pglob,
+          rulePreview: preview(`${toolName} ${truncate(pglob)}`),
+        });
       }
     }
     return out;

--- a/src/permissions/breadth.ts
+++ b/src/permissions/breadth.ts
@@ -11,7 +11,8 @@
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { primaryShellCommand } from '../tool-permissions.js';
-import { stableArgsString } from './matchers.js';
+import { truncate } from '../text.js';
+import { stableArgsString, FILE_TOOLS, WEB_TOOLS } from './matchers.js';
 
 export interface BreadthOption {
   /** Short label shown in the breadth selector. */
@@ -22,15 +23,10 @@ export interface BreadthOption {
   rulePreview: string;
 }
 
-const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
-const WEB_TOOLS = new Set(['web_read', 'web_search']);
+const LABEL_MAX = 48;
 
 function preview(label: string): string {
   return `Will allow: \`${label}\` for this profile`;
-}
-
-function truncate(s: string, n = 48): string {
-  return s.length > n ? s.slice(0, n - 1) + '…' : s;
 }
 
 function within(dir: string): boolean {
@@ -55,10 +51,11 @@ export function breadthOptionsFor(toolName: string, args: unknown): BreadthOptio
     const primary = cmd ? primaryShellCommand(cmd) : null;
     if (!primary) return []; // complex/empty → no stable grant (legacy parity)
     const anyArgs = `${primary} *`;
+    const shortCmd = truncate(cmd, LABEL_MAX);
     const exact: BreadthOption = {
-      label: truncate(cmd),
+      label: shortCmd,
       specifier: cmd,
-      rulePreview: preview(truncate(cmd)),
+      rulePreview: preview(shortCmd),
     };
     if (cmd === primary || cmd === anyArgs) return [exact]; // bare command: one level
     return [exact, { label: anyArgs, specifier: anyArgs, rulePreview: preview(anyArgs) }];
@@ -68,30 +65,18 @@ export function breadthOptionsFor(toolName: string, args: unknown): BreadthOptio
     const p = typeof a?.path === 'string' ? (a.path as string) : '';
     if (!p) return [];
     const abs = path.resolve(p);
-    const out: BreadthOption[] = [
-      {
-        label: truncate(abs),
-        specifier: abs,
-        rulePreview: preview(`${toolName} ${truncate(abs)}`),
-      },
-    ];
+    // One construction shape for every path level (exact file, dir/**, parent/**).
+    const pathOption = (spec: string): BreadthOption => ({
+      label: truncate(spec, LABEL_MAX),
+      specifier: spec,
+      rulePreview: preview(`${toolName} ${truncate(spec, LABEL_MAX)}`),
+    });
+    const out: BreadthOption[] = [pathOption(abs)];
     const dir = path.dirname(abs);
     if (within(dir)) {
-      const glob = `${dir}/**`;
-      out.push({
-        label: glob,
-        specifier: glob,
-        rulePreview: preview(`${toolName} ${truncate(glob)}`),
-      });
+      out.push(pathOption(`${dir}/**`));
       const parent = path.dirname(dir);
-      if (parent !== dir && within(parent)) {
-        const pglob = `${parent}/**`;
-        out.push({
-          label: pglob,
-          specifier: pglob,
-          rulePreview: preview(`${toolName} ${truncate(pglob)}`),
-        });
-      }
+      if (parent !== dir && within(parent)) out.push(pathOption(`${parent}/**`));
     }
     return out;
   }
@@ -99,10 +84,11 @@ export function breadthOptionsFor(toolName: string, args: unknown): BreadthOptio
   if (WEB_TOOLS.has(toolName)) {
     const u = typeof a?.url === 'string' ? (a.url as string) : '';
     if (!u) return [];
+    const shortUrl = truncate(u, LABEL_MAX);
     const exact: BreadthOption = {
-      label: truncate(u),
+      label: shortUrl,
       specifier: u,
-      rulePreview: preview(`${toolName} ${truncate(u)}`),
+      rulePreview: preview(`${toolName} ${shortUrl}`),
     };
     let host = '';
     try {

--- a/src/permissions/breadth.ts
+++ b/src/permissions/breadth.ts
@@ -1,0 +1,115 @@
+/**
+ * Breadth ladder (#261): given a concrete tool call, produce the ordered list
+ * of scope options the user can pick with ←/→ in the confirm dialog, from
+ * narrowest (this exact call) to broadest (this command/tool with any args).
+ *
+ * Each option's `specifier` is what gets persisted into a `PermissionRule`
+ * (undefined is reserved for hand-written "any invocation" rules; the ladder
+ * never emits an "all shell" / no-specifier level by design).
+ */
+
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { primaryShellCommand } from '../tool-permissions.js';
+import { stableArgsString } from './matchers.js';
+
+export interface BreadthOption {
+  /** Short label shown in the breadth selector. */
+  label: string;
+  /** The rule specifier this option persists. */
+  specifier: string;
+  /** Full "Will allow: … for this profile" preview. */
+  rulePreview: string;
+}
+
+const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
+const WEB_TOOLS = new Set(['web_read', 'web_search']);
+
+function preview(label: string): string {
+  return `Will allow: \`${label}\` for this profile`;
+}
+
+function truncate(s: string, n = 48): string {
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+function within(dir: string): boolean {
+  // Only offer a directory-level grant inside cwd or home, and never the root.
+  const root = path.parse(dir).root;
+  if (dir === root) return false;
+  const cwd = process.cwd();
+  const home = os.homedir();
+  return dir.startsWith(cwd) || dir.startsWith(home);
+}
+
+/**
+ * Returns the breadth ladder for a call, or `[]` when no profile-scope grant
+ * should be offered (complex/unparseable shell, missing args). Callers must
+ * also suppress this for dangerous shell (handled at the augment layer).
+ */
+export function breadthOptionsFor(toolName: string, args: unknown): BreadthOption[] {
+  const a = args as Record<string, unknown> | undefined;
+
+  if (toolName === 'shell') {
+    const cmd = typeof a?.command === 'string' ? (a.command as string).trim() : '';
+    const primary = cmd ? primaryShellCommand(cmd) : null;
+    if (!primary) return []; // complex/empty → no stable grant (legacy parity)
+    const anyArgs = `${primary} *`;
+    const exact: BreadthOption = {
+      label: truncate(cmd),
+      specifier: cmd,
+      rulePreview: preview(truncate(cmd)),
+    };
+    if (cmd === primary || cmd === anyArgs) return [exact]; // bare command: one level
+    return [exact, { label: anyArgs, specifier: anyArgs, rulePreview: preview(anyArgs) }];
+  }
+
+  if (FILE_TOOLS.has(toolName)) {
+    const p = typeof a?.path === 'string' ? (a.path as string) : '';
+    if (!p) return [];
+    const abs = path.resolve(p);
+    const out: BreadthOption[] = [
+      { label: truncate(abs), specifier: abs, rulePreview: preview(`${toolName} ${truncate(abs)}`) },
+    ];
+    const dir = path.dirname(abs);
+    if (within(dir)) {
+      const glob = `${dir}/**`;
+      out.push({ label: glob, specifier: glob, rulePreview: preview(`${toolName} ${truncate(glob)}`) });
+      const parent = path.dirname(dir);
+      if (parent !== dir && within(parent)) {
+        const pglob = `${parent}/**`;
+        out.push({ label: pglob, specifier: pglob, rulePreview: preview(`${toolName} ${truncate(pglob)}`) });
+      }
+    }
+    return out;
+  }
+
+  if (WEB_TOOLS.has(toolName)) {
+    const u = typeof a?.url === 'string' ? (a.url as string) : '';
+    if (!u) return [];
+    const exact: BreadthOption = {
+      label: truncate(u),
+      specifier: u,
+      rulePreview: preview(`${toolName} ${truncate(u)}`),
+    };
+    let host = '';
+    try {
+      host = new URL(u).hostname;
+    } catch {
+      return [exact];
+    }
+    const dom = `domain:${host}`;
+    return [exact, { label: dom, specifier: dom, rulePreview: preview(`${toolName} ${dom}`) }];
+  }
+
+  // MCP and all other tools: exact args → any args.
+  const exactArgs = stableArgsString(args);
+  return [
+    {
+      label: 'these arguments',
+      specifier: exactArgs,
+      rulePreview: preview(`${toolName} (these arguments)`),
+    },
+    { label: 'any arguments', specifier: '*', rulePreview: preview(`${toolName} (any arguments)`) },
+  ];
+}

--- a/src/permissions/engine.test.ts
+++ b/src/permissions/engine.test.ts
@@ -15,7 +15,8 @@ const rule = (
   effect: PermissionRule['effect'],
   tool: string,
   specifier?: string,
-): PermissionRule => (specifier === undefined ? { effect, tool, _v: 2 } : { effect, tool, specifier, _v: 2 });
+): PermissionRule =>
+  specifier === undefined ? { effect, tool, _v: 2 } : { effect, tool, specifier, _v: 2 };
 
 describe('matchShellSpecifier', () => {
   it('bare specifier matches only the bare command', () => {
@@ -84,7 +85,9 @@ describe('matchMCPSpecifier', () => {
 
 describe('resolveGrant', () => {
   it('dangerous shell always asks, even with a matching allow', () => {
-    expect(resolveGrant('shell', { command: 'rm -rf /' }, [rule('allow', 'shell')], true)).toBe('ask');
+    expect(resolveGrant('shell', { command: 'rm -rf /' }, [rule('allow', 'shell')], true)).toBe(
+      'ask',
+    );
     expect(
       resolveGrant('shell', { command: 'rm -rf /' }, [rule('allow', 'shell', 'rm *')], true),
     ).toBe('ask');
@@ -103,9 +106,9 @@ describe('resolveGrant', () => {
     expect(resolveGrant('shell', { command: 'npm i' }, rules, false)).toBe('ask');
   });
   it('no-specifier rule matches any invocation of the tool', () => {
-    expect(resolveGrant('web_read', { url: 'https://x.com' }, [rule('allow', 'web_read')], false)).toBe(
-      'allow',
-    );
+    expect(
+      resolveGrant('web_read', { url: 'https://x.com' }, [rule('allow', 'web_read')], false),
+    ).toBe('allow');
   });
   it('file path grant covers files under the directory glob', () => {
     const root = path.resolve('/proj');

--- a/src/permissions/engine.test.ts
+++ b/src/permissions/engine.test.ts
@@ -148,4 +148,18 @@ describe('breadthOptionsFor', () => {
     const opts = breadthOptionsFor('srv__tool', { a: 1 });
     expect(opts.map((o) => o.specifier)).toEqual(['{"a":1}', '*']);
   });
+  it('web_search (no url arg) falls back to the generic args ladder', () => {
+    const opts = breadthOptionsFor('web_search', { query: 'cats', limit: 5 });
+    expect(opts.map((o) => o.specifier)).toEqual(['{"limit":5,"query":"cats"}', '*']);
+  });
+});
+
+describe('stableArgsString totality', () => {
+  it('fails closed to a fixed string on unstringifiable args', () => {
+    expect(matchMCPSpecifier('null', undefined)).toBe(true);
+    expect(matchMCPSpecifier('null', 10n)).toBe(true);
+  });
+  it('still distinguishes real args', () => {
+    expect(matchMCPSpecifier('null', { a: 1 })).toBe(false);
+  });
 });

--- a/src/permissions/engine.test.ts
+++ b/src/permissions/engine.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { PermissionRule } from '../tool-permissions.js';
+import { resolveGrant } from './engine.js';
+import {
+  matchShellSpecifier,
+  matchPathSpecifier,
+  matchDomainSpecifier,
+  matchMCPSpecifier,
+} from './matchers.js';
+import { breadthOptionsFor } from './breadth.js';
+
+const rule = (
+  effect: PermissionRule['effect'],
+  tool: string,
+  specifier?: string,
+): PermissionRule => (specifier === undefined ? { effect, tool, _v: 2 } : { effect, tool, specifier, _v: 2 });
+
+describe('matchShellSpecifier', () => {
+  it('bare specifier matches only the bare command', () => {
+    expect(matchShellSpecifier('git', 'git')).toBe(true);
+    expect(matchShellSpecifier('git', 'git status')).toBe(false);
+  });
+  it('trailing * matches any args (and the bare command)', () => {
+    expect(matchShellSpecifier('git *', 'git')).toBe(true);
+    expect(matchShellSpecifier('git *', 'git status')).toBe(true);
+    expect(matchShellSpecifier('git *', 'git push origin main')).toBe(true);
+  });
+  it('enforces a word boundary', () => {
+    expect(matchShellSpecifier('git *', 'github-cli')).toBe(false);
+    expect(matchShellSpecifier('git', 'github')).toBe(false);
+  });
+  it('multi-token prefix matches exactly or as a prefix with *', () => {
+    expect(matchShellSpecifier('git status', 'git status')).toBe(true);
+    expect(matchShellSpecifier('git status', 'git status --short')).toBe(false);
+    expect(matchShellSpecifier('git status *', 'git status --short')).toBe(true);
+    expect(matchShellSpecifier('npm *', 'git status')).toBe(false);
+  });
+});
+
+describe('matchPathSpecifier (gitignore globs)', () => {
+  const root = path.resolve('/proj');
+  it('** matches recursively, * does not cross segments', () => {
+    expect(matchPathSpecifier(`${root}/src/**`, `${root}/src/a/b.ts`)).toBe(true);
+    expect(matchPathSpecifier(`${root}/src/**`, `${root}/other/b.ts`)).toBe(false);
+    expect(matchPathSpecifier(`${root}/src/*`, `${root}/src/b.ts`)).toBe(true);
+    expect(matchPathSpecifier(`${root}/src/*`, `${root}/src/a/b.ts`)).toBe(false);
+  });
+  it('exact path matches itself', () => {
+    expect(matchPathSpecifier(`${root}/src/main.ts`, `${root}/src/main.ts`)).toBe(true);
+    expect(matchPathSpecifier(`${root}/src/main.ts`, `${root}/src/other.ts`)).toBe(false);
+  });
+  it('~/ anchor expands to home', () => {
+    const home = os.homedir();
+    expect(matchPathSpecifier('~/docs/**', path.join(home, 'docs/a.txt'))).toBe(true);
+  });
+});
+
+describe('matchDomainSpecifier', () => {
+  it('domain: matches host and subdomains', () => {
+    expect(matchDomainSpecifier('domain:example.com', 'https://example.com/x')).toBe(true);
+    expect(matchDomainSpecifier('domain:example.com', 'https://sub.example.com/x')).toBe(true);
+    expect(matchDomainSpecifier('domain:example.com', 'https://notexample.com/')).toBe(false);
+  });
+  it('exact-URL specifier matches only that URL', () => {
+    expect(matchDomainSpecifier('https://a.com/p', 'https://a.com/p')).toBe(true);
+    expect(matchDomainSpecifier('https://a.com/p', 'https://a.com/q')).toBe(false);
+  });
+  it('malformed URL → false', () => {
+    expect(matchDomainSpecifier('domain:example.com', 'not a url')).toBe(false);
+  });
+});
+
+describe('matchMCPSpecifier', () => {
+  it('* matches any args', () => {
+    expect(matchMCPSpecifier('*', { a: 1 })).toBe(true);
+  });
+  it('exact args match regardless of key order', () => {
+    expect(matchMCPSpecifier('{"a":1,"b":2}', { b: 2, a: 1 })).toBe(true);
+    expect(matchMCPSpecifier('{"a":1,"b":2}', { a: 1, b: 3 })).toBe(false);
+  });
+});
+
+describe('resolveGrant', () => {
+  it('dangerous shell always asks, even with a matching allow', () => {
+    expect(resolveGrant('shell', { command: 'rm -rf /' }, [rule('allow', 'shell')], true)).toBe('ask');
+    expect(
+      resolveGrant('shell', { command: 'rm -rf /' }, [rule('allow', 'shell', 'rm *')], true),
+    ).toBe('ask');
+  });
+  it('deny wins over allow regardless of order', () => {
+    const rules = [rule('allow', 'shell', 'git *'), rule('deny', 'shell', 'git *')];
+    expect(resolveGrant('shell', { command: 'git status' }, rules, false)).toBe('deny');
+  });
+  it('ask wins over allow', () => {
+    const rules = [rule('allow', 'shell', 'git *'), rule('ask', 'shell', 'git *')];
+    expect(resolveGrant('shell', { command: 'git status' }, rules, false)).toBe('ask');
+  });
+  it('a matching allow proceeds; non-match defaults to ask', () => {
+    const rules = [rule('allow', 'shell', 'git *')];
+    expect(resolveGrant('shell', { command: 'git push' }, rules, false)).toBe('allow');
+    expect(resolveGrant('shell', { command: 'npm i' }, rules, false)).toBe('ask');
+  });
+  it('no-specifier rule matches any invocation of the tool', () => {
+    expect(resolveGrant('web_read', { url: 'https://x.com' }, [rule('allow', 'web_read')], false)).toBe(
+      'allow',
+    );
+  });
+  it('file path grant covers files under the directory glob', () => {
+    const root = path.resolve('/proj');
+    const rules = [rule('allow', 'file_write', `${root}/src/**`)];
+    expect(resolveGrant('file_write', { path: `${root}/src/a/b.ts` }, rules, false)).toBe('allow');
+    expect(resolveGrant('file_write', { path: `${root}/other.ts` }, rules, false)).toBe('ask');
+  });
+  it('complex shell (parse-error) is not covered by a command specifier', () => {
+    // Non-dangerous compound — the regex stub yields parse-error so a
+    // `touch *` specifier cannot match (would need real AST splitting).
+    const rules = [rule('allow', 'shell', 'touch *')];
+    expect(resolveGrant('shell', { command: 'touch a && touch b' }, rules, false)).toBe('ask');
+  });
+});
+
+describe('breadthOptionsFor', () => {
+  it('shell: exact → command *', () => {
+    const opts = breadthOptionsFor('shell', { command: 'git status' });
+    expect(opts.map((o) => o.specifier)).toEqual(['git status', 'git *']);
+  });
+  it('shell: bare command yields a single level', () => {
+    const opts = breadthOptionsFor('shell', { command: 'ls' });
+    expect(opts).toHaveLength(1);
+    expect(opts[0].specifier).toBe('ls');
+  });
+  it('shell: complex command → no grant offered', () => {
+    expect(breadthOptionsFor('shell', { command: 'a | b' })).toEqual([]);
+  });
+  it('web: exact url → domain', () => {
+    const opts = breadthOptionsFor('web_read', { url: 'https://docs.example.com/a' });
+    expect(opts.map((o) => o.specifier)).toEqual([
+      'https://docs.example.com/a',
+      'domain:docs.example.com',
+    ]);
+  });
+  it('mcp/other: exact args → any args', () => {
+    const opts = breadthOptionsFor('srv__tool', { a: 1 });
+    expect(opts.map((o) => o.specifier)).toEqual(['{"a":1}', '*']);
+  });
+});

--- a/src/permissions/engine.ts
+++ b/src/permissions/engine.ts
@@ -26,6 +26,13 @@ export type GrantDecision = 'allow' | 'deny' | 'ask';
 const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
 const WEB_TOOLS = new Set(['web_read', 'web_search']);
 
+/** Does a single rule cover a single simple shell command string? */
+function ruleMatchesShell(rule: PermissionRule, command: string): boolean {
+  if (rule.tool !== 'shell') return false;
+  if (rule.specifier === undefined) return true;
+  return matchShellSpecifier(rule.specifier, command);
+}
+
 /** Does a single rule cover this concrete (toolName, args) call? */
 function ruleMatchesCall(rule: PermissionRule, toolName: string, args: unknown): boolean {
   if (rule.tool !== toolName) return false;
@@ -36,12 +43,7 @@ function ruleMatchesCall(rule: PermissionRule, toolName: string, args: unknown):
     if (typeof cmd !== 'string') return false;
     const parsed = parseShellCommand(cmd);
     if (parsed.kind === 'simple') return matchShellSpecifier(rule.specifier, parsed.command);
-    if (parsed.kind === 'compound') {
-      return parsed.subcommands.every(
-        (sc) => sc.kind === 'simple' && matchShellSpecifier(rule.specifier!, sc.command),
-      );
-    }
-    return false; // parse-error: no specifier can safely cover it
+    return false; // compound handled in resolveGrant; parse-error never matches
   }
   if (FILE_TOOLS.has(toolName)) {
     const p = (args as Record<string, unknown> | undefined)?.path;
@@ -80,5 +82,28 @@ export function resolveGrant(
 ): GrantDecision {
   // Invariant: dangerous shell always re-prompts, no rule can override it.
   if (toolName === 'shell' && isDangerousShell) return 'ask';
+
+  // Compound shell: every subcommand must independently resolve to allow, and
+  // any subcommand that denies sinks the whole command (deny-first).
+  if (toolName === 'shell') {
+    const cmd = (args as Record<string, unknown> | undefined)?.command;
+    if (typeof cmd === 'string') {
+      const parsed = parseShellCommand(cmd);
+      if (parsed.kind === 'compound') {
+        let anyAsk = false;
+        for (const sub of parsed.subcommands) {
+          if (sub.kind !== 'simple') {
+            anyAsk = true;
+            continue;
+          }
+          const d = scanRules(rules, (rule) => ruleMatchesShell(rule, sub.command));
+          if (d === 'deny') return 'deny';
+          if (d !== 'allow') anyAsk = true;
+        }
+        return anyAsk ? 'ask' : 'allow';
+      }
+    }
+  }
+
   return scanRules(rules, (rule) => ruleMatchesCall(rule, toolName, args));
 }

--- a/src/permissions/engine.ts
+++ b/src/permissions/engine.ts
@@ -13,38 +13,28 @@
  */
 
 import type { PermissionRule } from '../tool-permissions.js';
-import { parseShellCommand } from './shell-ast.js';
+import { parseShellCommand, type ParsedShell } from './shell-ast.js';
 import {
   matchShellSpecifier,
   matchPathSpecifier,
   matchDomainSpecifier,
   matchMCPSpecifier,
+  FILE_TOOLS,
+  WEB_TOOLS,
 } from './matchers.js';
 
 export type GrantDecision = 'allow' | 'deny' | 'ask';
 
-const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
-const WEB_TOOLS = new Set(['web_read', 'web_search']);
-
-/** Does a single rule cover a single simple shell command string? */
+/** Does a rule cover a single simple shell command string? */
 function ruleMatchesShell(rule: PermissionRule, command: string): boolean {
   if (rule.tool !== 'shell') return false;
-  if (rule.specifier === undefined) return true;
-  return matchShellSpecifier(rule.specifier, command);
+  return rule.specifier === undefined || matchShellSpecifier(rule.specifier, command);
 }
 
-/** Does a single rule cover this concrete (toolName, args) call? */
-function ruleMatchesCall(rule: PermissionRule, toolName: string, args: unknown): boolean {
+/** Does a rule cover a non-shell (toolName, args) call? */
+function ruleMatchesNonShell(rule: PermissionRule, toolName: string, args: unknown): boolean {
   if (rule.tool !== toolName) return false;
   if (rule.specifier === undefined) return true; // matches any invocation of the tool
-
-  if (toolName === 'shell') {
-    const cmd = (args as Record<string, unknown> | undefined)?.command;
-    if (typeof cmd !== 'string') return false;
-    const parsed = parseShellCommand(cmd);
-    if (parsed.kind === 'simple') return matchShellSpecifier(rule.specifier, parsed.command);
-    return false; // compound handled in resolveGrant; parse-error never matches
-  }
   if (FILE_TOOLS.has(toolName)) {
     const p = (args as Record<string, unknown> | undefined)?.path;
     return typeof p === 'string' && matchPathSpecifier(rule.specifier, p);
@@ -74,36 +64,52 @@ function scanRules(
   return 'ask';
 }
 
+/**
+ * Flattens a parsed shell command into its simple-subcommand strings, or `null`
+ * when no specifier can safely cover it (parse-error / unhandled construct). A
+ * simple command is the degenerate 1-element case, so the engine resolves
+ * simple and compound commands through the same path.
+ */
+function shellSubcommands(parsed: ParsedShell): string[] | null {
+  if (parsed.kind === 'simple') return [parsed.command];
+  if (parsed.kind === 'compound') {
+    const out: string[] = [];
+    for (const sub of parsed.subcommands) {
+      if (sub.kind !== 'simple') return null;
+      out.push(sub.command);
+    }
+    return out;
+  }
+  return null; // parse-error
+}
+
 export function resolveGrant(
   toolName: string,
   args: unknown,
   rules: PermissionRule[],
   isDangerousShell: boolean,
 ): GrantDecision {
-  // Invariant: dangerous shell always re-prompts, no rule can override it.
-  if (toolName === 'shell' && isDangerousShell) return 'ask';
-
-  // Compound shell: every subcommand must independently resolve to allow, and
-  // any subcommand that denies sinks the whole command (deny-first).
-  if (toolName === 'shell') {
-    const cmd = (args as Record<string, unknown> | undefined)?.command;
-    if (typeof cmd === 'string') {
-      const parsed = parseShellCommand(cmd);
-      if (parsed.kind === 'compound') {
-        let anyAsk = false;
-        for (const sub of parsed.subcommands) {
-          if (sub.kind !== 'simple') {
-            anyAsk = true;
-            continue;
-          }
-          const d = scanRules(rules, (rule) => ruleMatchesShell(rule, sub.command));
-          if (d === 'deny') return 'deny';
-          if (d !== 'allow') anyAsk = true;
-        }
-        return anyAsk ? 'ask' : 'allow';
-      }
-    }
+  if (toolName !== 'shell') {
+    return scanRules(rules, (rule) => ruleMatchesNonShell(rule, toolName, args));
   }
 
-  return scanRules(rules, (rule) => ruleMatchesCall(rule, toolName, args));
+  // Invariant: dangerous shell always re-prompts, no rule can override it.
+  if (isDangerousShell) return 'ask';
+
+  const cmd = (args as Record<string, unknown> | undefined)?.command;
+  // Parse once. Each subcommand (simple = 1 element) is resolved independently;
+  // the compound is allowed only when every subcommand allows, and any denied
+  // subcommand sinks the whole command (deny-first). Parse-error / non-string
+  // commands can only be covered by a no-specifier `shell` rule.
+  const subs = typeof cmd === 'string' ? shellSubcommands(parseShellCommand(cmd)) : null;
+  if (!subs) {
+    return scanRules(rules, (rule) => rule.tool === 'shell' && rule.specifier === undefined);
+  }
+  let anyAsk = false;
+  for (const sub of subs) {
+    const d = scanRules(rules, (rule) => ruleMatchesShell(rule, sub));
+    if (d === 'deny') return 'deny';
+    if (d !== 'allow') anyAsk = true;
+  }
+  return anyAsk ? 'ask' : 'allow';
 }

--- a/src/permissions/engine.ts
+++ b/src/permissions/engine.ts
@@ -1,0 +1,84 @@
+/**
+ * Deterministic permission rule engine (#261).
+ *
+ * `resolveGrant` evaluates an ordered `PermissionRule[]` against one concrete
+ * tool call and returns `allow | deny | ask`, following the Claude-Code model:
+ *
+ *   1. Dangerous shell ALWAYS re-prompts (`ask`) before any rule is consulted —
+ *      a breadth grant can never silence a genuinely dangerous invocation.
+ *   2. Across all matching rules: any `deny` wins → `deny`; else any `ask`
+ *      wins → `ask`; else any `allow` → `allow`; else (no match) → `ask`.
+ *
+ * Specifier matching is dispatched per tool family (shell / file / web / MCP).
+ */
+
+import type { PermissionRule } from '../tool-permissions.js';
+import { parseShellCommand } from './shell-ast.js';
+import {
+  matchShellSpecifier,
+  matchPathSpecifier,
+  matchDomainSpecifier,
+  matchMCPSpecifier,
+} from './matchers.js';
+
+export type GrantDecision = 'allow' | 'deny' | 'ask';
+
+const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
+const WEB_TOOLS = new Set(['web_read', 'web_search']);
+
+/** Does a single rule cover this concrete (toolName, args) call? */
+function ruleMatchesCall(rule: PermissionRule, toolName: string, args: unknown): boolean {
+  if (rule.tool !== toolName) return false;
+  if (rule.specifier === undefined) return true; // matches any invocation of the tool
+
+  if (toolName === 'shell') {
+    const cmd = (args as Record<string, unknown> | undefined)?.command;
+    if (typeof cmd !== 'string') return false;
+    const parsed = parseShellCommand(cmd);
+    if (parsed.kind === 'simple') return matchShellSpecifier(rule.specifier, parsed.command);
+    if (parsed.kind === 'compound') {
+      return parsed.subcommands.every(
+        (sc) => sc.kind === 'simple' && matchShellSpecifier(rule.specifier!, sc.command),
+      );
+    }
+    return false; // parse-error: no specifier can safely cover it
+  }
+  if (FILE_TOOLS.has(toolName)) {
+    const p = (args as Record<string, unknown> | undefined)?.path;
+    return typeof p === 'string' && matchPathSpecifier(rule.specifier, p);
+  }
+  if (WEB_TOOLS.has(toolName)) {
+    const u = (args as Record<string, unknown> | undefined)?.url;
+    return typeof u === 'string' && matchDomainSpecifier(rule.specifier, u);
+  }
+  return matchMCPSpecifier(rule.specifier, args);
+}
+
+/** Scan rules for a single call; deny > ask > allow > (default) ask. */
+function scanRules(
+  rules: PermissionRule[],
+  matchFn: (rule: PermissionRule) => boolean,
+): GrantDecision {
+  let hasAsk = false;
+  let hasAllow = false;
+  for (const rule of rules) {
+    if (!matchFn(rule)) continue;
+    if (rule.effect === 'deny') return 'deny'; // deny always wins
+    if (rule.effect === 'ask') hasAsk = true;
+    else if (rule.effect === 'allow') hasAllow = true;
+  }
+  if (hasAsk) return 'ask';
+  if (hasAllow) return 'allow';
+  return 'ask';
+}
+
+export function resolveGrant(
+  toolName: string,
+  args: unknown,
+  rules: PermissionRule[],
+  isDangerousShell: boolean,
+): GrantDecision {
+  // Invariant: dangerous shell always re-prompts, no rule can override it.
+  if (toolName === 'shell' && isDangerousShell) return 'ask';
+  return scanRules(rules, (rule) => ruleMatchesCall(rule, toolName, args));
+}

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -1,0 +1,11 @@
+/** Deterministic permission engine (#261) — public surface. */
+export { resolveGrant, type GrantDecision } from './engine.js';
+export {
+  matchShellSpecifier,
+  matchPathSpecifier,
+  matchDomainSpecifier,
+  matchMCPSpecifier,
+  stableArgsString,
+} from './matchers.js';
+export { parseShellCommand, type ParsedShell } from './shell-ast.js';
+export { breadthOptionsFor, type BreadthOption } from './breadth.js';

--- a/src/permissions/matchers.ts
+++ b/src/permissions/matchers.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure specifier matchers for the deterministic permission engine (#261).
+ *
+ * Each matcher answers "does this rule's `specifier` cover this concrete tool
+ * call?" for one family of tools. They are intentionally side-effect-free and
+ * unit-tested in isolation (`matchers.test.ts`). The shell matcher operates on
+ * a single already-split simple command (compound splitting + AST safety live
+ * in `shell-ast.ts`).
+ */
+
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+/** Stable, key-sorted JSON of an args object — used as the exact-args specifier. */
+export function stableArgsString(args: unknown): string {
+  const seen = new WeakSet<object>();
+  const norm = (v: unknown): unknown => {
+    if (v === null || typeof v !== 'object') return v;
+    if (seen.has(v as object)) return null;
+    seen.add(v as object);
+    if (Array.isArray(v)) return v.map(norm);
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+      out[k] = norm((v as Record<string, unknown>)[k]);
+    }
+    return out;
+  };
+  return JSON.stringify(norm(args));
+}
+
+/**
+ * Shell specifier match for a single simple command (`program arg arg …`).
+ *
+ * Grammar (the subset the breadth ladder emits, plus hand-written rules):
+ * - `git`        → matches only the bare command `git` (no args)
+ * - `git *`      → matches `git` and `git <anything>` (trailing `*` = any/zero
+ *                  further tokens), with a word boundary so `git *` ≠ `github`
+ * - `git status` → matches exactly `git status`
+ * - a `*` token in a non-final position matches exactly one token
+ */
+export function matchShellSpecifier(specifier: string, command: string): boolean {
+  const specToks = specifier.trim().split(/\s+/).filter(Boolean);
+  const cmdToks = command.trim().split(/\s+/).filter(Boolean);
+  if (specToks.length === 0) return false;
+
+  const trailingStar = specToks[specToks.length - 1] === '*';
+  const fixed = trailingStar ? specToks.slice(0, -1) : specToks;
+
+  if (trailingStar) {
+    // Prefix match: every fixed token must equal the command token at the same
+    // position; the command may carry zero or more extra trailing tokens.
+    if (cmdToks.length < fixed.length) return false;
+  } else if (cmdToks.length !== fixed.length) {
+    return false;
+  }
+  for (let i = 0; i < fixed.length; i++) {
+    if (fixed[i] === '*') continue; // single-token wildcard
+    if (fixed[i] !== cmdToks[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Converts a gitignore-ish glob to an anchored RegExp. `**​/` = zero or more
+ * directory segments, `**` = anything, `*` = one segment (no slash).
+ */
+function globToRegExp(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        i++;
+        if (glob[i + 1] === '/') {
+          i++;
+          re += '(?:.*/)?';
+        } else {
+          re += '.*';
+        }
+      } else {
+        re += '[^/]*';
+      }
+    } else if ('\\^$.|?+()[]{}'.includes(c)) {
+      re += '\\' + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+/** Resolves a path specifier's anchor into an absolute glob pattern. */
+function resolvePathAnchor(specifier: string): string {
+  if (specifier.startsWith('//')) return specifier.slice(1); // //abs → /abs
+  if (specifier.startsWith('~/')) return path.join(os.homedir(), specifier.slice(2));
+  if (specifier.startsWith('/')) return specifier; // already absolute (ladder emits these)
+  if (specifier.startsWith('./')) return path.join(process.cwd(), specifier.slice(2));
+  return path.join('**', specifier); // unanchored → match at any depth
+}
+
+/**
+ * gitignore-style path match. The breadth ladder emits absolute patterns
+ * (exact file, then `<dir>/**`), which take the fast `/`-anchored path.
+ */
+export function matchPathSpecifier(specifier: string, filePath: string): boolean {
+  if (!filePath || typeof filePath !== 'string') return false;
+  const abs = path.resolve(filePath);
+  return globToRegExp(resolvePathAnchor(specifier)).test(abs);
+}
+
+/**
+ * Web specifier match. A `domain:` specifier matches the host and its
+ * subdomains; anything else is treated as an exact-URL specifier.
+ */
+export function matchDomainSpecifier(specifier: string, url: string): boolean {
+  if (!specifier.startsWith('domain:')) return specifier === url;
+  const domain = specifier.slice('domain:'.length).toLowerCase();
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return host === domain || host.endsWith('.' + domain);
+}
+
+/** MCP/other-tool match: `*` = any args, else exact (stable) args JSON. */
+export function matchMCPSpecifier(specifier: string, args: unknown): boolean {
+  if (specifier === '*') return true;
+  return stableArgsString(args) === specifier;
+}

--- a/src/permissions/matchers.ts
+++ b/src/permissions/matchers.ts
@@ -13,10 +13,18 @@ import * as os from 'node:os';
 
 /** Tools whose breadth/scope is a filesystem path (gitignore-glob matched). */
 export const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
-/** Tools whose breadth/scope is a URL (exact or `domain:` matched). */
-export const WEB_TOOLS = new Set(['web_read', 'web_search']);
+/**
+ * Tools whose breadth/scope is a URL (exact or `domain:` matched). Only
+ * `web_read` takes a `url`; `web_search` (`{query, limit}`) is intentionally
+ * excluded so it falls back to the generic exact-args/any-args ladder.
+ */
+export const WEB_TOOLS = new Set(['web_read']);
 
-/** Stable, key-sorted JSON of an args object — used as the exact-args specifier. */
+/**
+ * Stable, key-sorted JSON of an args object — used as the exact-args specifier.
+ * Total: always returns a string, failing closed to `'null'` on unstringifiable
+ * input (BigInt, `undefined`) so a rule can never silently widen to "any args".
+ */
 export function stableArgsString(args: unknown): string {
   const seen = new WeakSet<object>();
   const norm = (v: unknown): unknown => {
@@ -30,7 +38,11 @@ export function stableArgsString(args: unknown): string {
     }
     return out;
   };
-  return JSON.stringify(norm(args));
+  try {
+    return JSON.stringify(norm(args)) ?? 'null';
+  } catch {
+    return 'null';
+  }
 }
 
 /**

--- a/src/permissions/matchers.ts
+++ b/src/permissions/matchers.ts
@@ -11,6 +11,11 @@
 import * as path from 'node:path';
 import * as os from 'node:os';
 
+/** Tools whose breadth/scope is a filesystem path (gitignore-glob matched). */
+export const FILE_TOOLS = new Set(['file_read_lines', 'file_edit_lines', 'file_write']);
+/** Tools whose breadth/scope is a URL (exact or `domain:` matched). */
+export const WEB_TOOLS = new Set(['web_read', 'web_search']);
+
 /** Stable, key-sorted JSON of an args object — used as the exact-args specifier. */
 export function stableArgsString(args: unknown): string {
   const seen = new WeakSet<object>();

--- a/src/permissions/shell-ast.test.ts
+++ b/src/permissions/shell-ast.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initShellParser, isShellParserReady, parseShellCommand } from './shell-ast.js';
+import { resolveGrant } from './engine.js';
+import type { PermissionRule } from '../tool-permissions.js';
+
+const rule = (
+  effect: PermissionRule['effect'],
+  tool: string,
+  specifier?: string,
+): PermissionRule =>
+  specifier === undefined ? { effect, tool, _v: 2 } : { effect, tool, specifier, _v: 2 };
+
+describe('shell-ast (tree-sitter)', () => {
+  beforeAll(async () => {
+    await initShellParser();
+  });
+
+  it('loads the parser', () => {
+    expect(isShellParserReady()).toBe(true);
+  });
+
+  it('parses a simple command', () => {
+    expect(parseShellCommand('git status')).toEqual({
+      kind: 'simple',
+      program: 'git',
+      command: 'git status',
+    });
+  });
+
+  it('splits compound commands into independent subcommands', () => {
+    const parsed = parseShellCommand('git status && npm test');
+    expect(parsed.kind).toBe('compound');
+    if (parsed.kind === 'compound') {
+      expect(parsed.subcommands.map((s) => (s.kind === 'simple' ? s.command : '?'))).toEqual([
+        'git status',
+        'npm test',
+      ]);
+    }
+  });
+
+  it('splits ; and | the same way', () => {
+    expect(parseShellCommand('git status; ls -la').kind).toBe('compound');
+    expect(parseShellCommand('cat f | grep x').kind).toBe('compound');
+  });
+
+  it('fails closed on exec wrappers', () => {
+    expect(parseShellCommand('bash -c "rm -rf /"')).toEqual({ kind: 'parse-error' });
+    expect(parseShellCommand('sudo rm -rf /')).toEqual({ kind: 'parse-error' });
+    expect(parseShellCommand('xargs -n1 rm')).toEqual({ kind: 'parse-error' });
+  });
+
+  it('fails closed on substitution, redirects, and variable assignment', () => {
+    expect(parseShellCommand('echo $(whoami)')).toEqual({ kind: 'parse-error' });
+    expect(parseShellCommand('cat foo > /etc/passwd')).toEqual({ kind: 'parse-error' });
+    expect(parseShellCommand('FOO=bar git status')).toEqual({ kind: 'parse-error' });
+    expect(parseShellCommand('echo $HOME')).toEqual({ kind: 'parse-error' });
+  });
+
+  it('fails closed on find -exec', () => {
+    expect(parseShellCommand('find . -name x -exec rm {} ;')).toEqual({ kind: 'parse-error' });
+    // plain find is fine
+    expect(parseShellCommand('find . -name x')).toEqual({
+      kind: 'simple',
+      program: 'find',
+      command: 'find . -name x',
+    });
+  });
+});
+
+describe('resolveGrant with AST compound (#261)', () => {
+  beforeAll(async () => {
+    await initShellParser();
+  });
+
+  it('allows a compound only when every subcommand is granted', () => {
+    const rules = [rule('allow', 'shell', 'git *'), rule('allow', 'shell', 'ls *')];
+    expect(resolveGrant('shell', { command: 'git status && ls -la' }, rules, false)).toBe('allow');
+  });
+
+  it('asks when any subcommand is ungranted', () => {
+    const rules = [rule('allow', 'shell', 'git *')];
+    expect(resolveGrant('shell', { command: 'git status && npm install' }, rules, false)).toBe(
+      'ask',
+    );
+  });
+
+  it('denies the whole compound if any subcommand is denied', () => {
+    const rules = [
+      rule('allow', 'shell', 'git *'),
+      rule('allow', 'shell', 'rm *'),
+      rule('deny', 'shell', 'rm *'),
+    ];
+    // rm isn't dangerous here (no -rf /), so the deny rule is what sinks it.
+    expect(resolveGrant('shell', { command: 'git status && rm foo' }, rules, false)).toBe('deny');
+  });
+
+  it('dangerous floor still wins over a fully-granted compound', () => {
+    const rules = [rule('allow', 'shell', 'git *'), rule('allow', 'shell', 'rm *')];
+    expect(resolveGrant('shell', { command: 'git status && rm -rf /' }, rules, true)).toBe('ask');
+  });
+});

--- a/src/permissions/shell-ast.ts
+++ b/src/permissions/shell-ast.ts
@@ -1,0 +1,29 @@
+/**
+ * Shell command parsing for the permission engine (#261).
+ *
+ * Phase 1B ships a deliberately conservative REGEX STUB: a command is either a
+ * single simple invocation (no shell metacharacters) or `parse-error`. Anything
+ * with pipes / separators / redirects / subshells / `$` expansion / newlines
+ * (`COMPLEX_RE`) is `parse-error`, which the engine treats as "no specifier can
+ * safely cover this" — matching the legacy behavior where complex commands got
+ * a null permission key and always prompted.
+ *
+ * Phase 5 replaces this with a real tree-sitter-bash AST: compound-command
+ * splitting (each subcommand checked independently), fail-closed on unhandled
+ * node types, and exec-wrapper blocking.
+ */
+
+import { primaryShellCommand } from '../tool-permissions.js';
+
+export type ParsedShell =
+  | { kind: 'simple'; program: string; command: string }
+  | { kind: 'compound'; subcommands: ParsedShell[] }
+  | { kind: 'parse-error' };
+
+export function parseShellCommand(command: string): ParsedShell {
+  const trimmed = command.trim();
+  if (!trimmed) return { kind: 'parse-error' };
+  const primary = primaryShellCommand(trimmed); // null on COMPLEX_RE or VAR= prefix
+  if (!primary) return { kind: 'parse-error' };
+  return { kind: 'simple', program: primary, command: trimmed };
+}

--- a/src/permissions/shell-ast.ts
+++ b/src/permissions/shell-ast.ts
@@ -1,18 +1,24 @@
 /**
  * Shell command parsing for the permission engine (#261).
  *
- * Phase 1B ships a deliberately conservative REGEX STUB: a command is either a
- * single simple invocation (no shell metacharacters) or `parse-error`. Anything
- * with pipes / separators / redirects / subshells / `$` expansion / newlines
- * (`COMPLEX_RE`) is `parse-error`, which the engine treats as "no specifier can
- * safely cover this" — matching the legacy behavior where complex commands got
- * a null permission key and always prompted.
+ * Uses tree-sitter-bash (via `web-tree-sitter`, WASM — no native build) to
+ * parse a command into an AST, then:
+ *   - splits compound commands (`&&`/`||`/`;`/`|`/newline) into independent
+ *     simple subcommands, each checked separately by the engine;
+ *   - **fails closed** (→ `parse-error`, which the engine treats as "no
+ *     specifier covers this", i.e. prompt) on any unhandled construct:
+ *     subshells, command/process substitution, variable expansion, redirects,
+ *     control flow, here-docs, leading variable assignments;
+ *   - **never auto-approves exec wrappers** (`bash -c`, `eval`, `xargs`,
+ *     `sudo`, `find -exec`, …) — they always route to `parse-error` → prompt.
  *
- * Phase 5 replaces this with a real tree-sitter-bash AST: compound-command
- * splitting (each subcommand checked independently), fail-closed on unhandled
- * node types, and exec-wrapper blocking.
+ * The parser loads asynchronously (`initShellParser`). Until it's ready — or if
+ * loading fails — `parseShellCommand` falls back to a conservative regex split
+ * (`primaryShellCommand`/`COMPLEX_RE`), so the module is always safe to call
+ * synchronously and degrades to "prompt on anything non-trivial".
  */
 
+import { createRequire } from 'node:module';
 import { primaryShellCommand } from '../tool-permissions.js';
 
 export type ParsedShell =
@@ -20,10 +26,151 @@ export type ParsedShell =
   | { kind: 'compound'; subcommands: ParsedShell[] }
   | { kind: 'parse-error' };
 
+/** Exec wrappers that can run arbitrary inner commands — never auto-approve. */
+const EXEC_WRAPPERS = new Set([
+  'bash',
+  'sh',
+  'zsh',
+  'fish',
+  'ksh',
+  'dash',
+  'eval',
+  'exec',
+  'xargs',
+  'watch',
+  'setsid',
+  'sudo',
+  'su',
+  'env',
+]);
+
+/** Inner AST nodes that make a command's effect non-static → fail closed. */
+const UNSAFE_INNER = new Set([
+  'command_substitution',
+  'process_substitution',
+  'variable_assignment',
+  'expansion',
+  'simple_expansion',
+  'arithmetic_expansion',
+]);
+
+/** Structural nodes the walker understands; anything else fails closed. */
+const HANDLED_STRUCTURE = new Set(['program', 'list', 'pipeline', 'command']);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let parser: any = null;
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Best-effort async load of the tree-sitter bash parser. Safe to call multiple
+ * times; resolves once. Failures are swallowed (the regex fallback covers us).
+ */
+export async function initShellParser(): Promise<void> {
+  if (parser) return;
+  initPromise ??= (async () => {
+    const { Parser, Language } = await import('web-tree-sitter');
+    await Parser.init();
+    const require = createRequire(import.meta.url);
+    const wasmPath = require.resolve('tree-sitter-wasms/out/tree-sitter-bash.wasm');
+    const lang = await Language.load(wasmPath);
+    const p = new Parser();
+    p.setLanguage(lang);
+    parser = p;
+  })().catch(() => {
+    parser = null;
+    initPromise = null;
+  });
+  return initPromise ?? Promise.resolve();
+}
+
+/** True once the AST parser has loaded (else `parseShellCommand` uses regex). */
+export function isShellParserReady(): boolean {
+  return parser !== null;
+}
+
 export function parseShellCommand(command: string): ParsedShell {
   const trimmed = command.trim();
   if (!trimmed) return { kind: 'parse-error' };
-  const primary = primaryShellCommand(trimmed); // null on COMPLEX_RE or VAR= prefix
+  if (parser) {
+    try {
+      return parseWithAst(trimmed);
+    } catch {
+      // fall through to the conservative regex path
+    }
+  }
+  return parseWithRegex(trimmed);
+}
+
+function parseWithRegex(trimmed: string): ParsedShell {
+  const primary = primaryShellCommand(trimmed); // null on COMPLEX_RE / VAR= prefix
   if (!primary) return { kind: 'parse-error' };
   return { kind: 'simple', program: primary, command: trimmed };
+}
+
+interface Accum {
+  simples: Array<{ program: string; command: string }>;
+  unsafe: boolean;
+}
+
+function parseWithAst(command: string): ParsedShell {
+  const tree = parser.parse(command);
+  const root = tree.rootNode;
+  if (root.hasError) return { kind: 'parse-error' };
+  const acc: Accum = { simples: [], unsafe: false };
+  walk(root, acc);
+  if (acc.unsafe || acc.simples.length === 0) return { kind: 'parse-error' };
+  if (acc.simples.length === 1) {
+    return { kind: 'simple', program: acc.simples[0].program, command: acc.simples[0].command };
+  }
+  return {
+    kind: 'compound',
+    subcommands: acc.simples.map((s) => ({
+      kind: 'simple' as const,
+      program: s.program,
+      command: s.command,
+    })),
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function walk(node: any, acc: Accum): void {
+  if (acc.unsafe) return;
+  const type = node.type as string;
+
+  if (type === 'command') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const children: any[] = node.namedChildren;
+    for (const c of children) {
+      if (UNSAFE_INNER.has(c.type)) {
+        acc.unsafe = true;
+        return;
+      }
+    }
+    const nameNode = children.find((c) => c.type === 'command_name');
+    if (!nameNode) {
+      acc.unsafe = true;
+      return;
+    }
+    const program = String(nameNode.text).trim();
+    if (EXEC_WRAPPERS.has(program)) {
+      acc.unsafe = true;
+      return;
+    }
+    if (program === 'find' && /(^|\s)-(exec|execdir|delete|ok)\b/.test(node.text)) {
+      acc.unsafe = true;
+      return;
+    }
+    acc.simples.push({ program, command: String(node.text).trim() });
+    return;
+  }
+
+  if (HANDLED_STRUCTURE.has(type)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const c of node.namedChildren as any[]) walk(c, acc);
+    return;
+  }
+
+  // Any other *named* construct (subshell, redirect, control flow, here-doc,
+  // function def, …) is unhandled → fail closed.
+  acc.unsafe = true;
 }

--- a/src/policy/test-helpers.ts
+++ b/src/policy/test-helpers.ts
@@ -40,7 +40,7 @@ export function makePolicyInput(overrides?: {
     maxConcurrentAgents: 4,
     responseStyle: 'default',
     customProviders: {},
-    toolPermissions: {},
+    toolPermissions: [],
     skipPermissions: false,
   };
   return {

--- a/src/profiles.test.ts
+++ b/src/profiles.test.ts
@@ -70,7 +70,10 @@ describe('profiles store', () => {
     vi.resetModules();
     const config = await import('./config.js');
     const prefs = config.loadPreferences();
-    expect(prefs.toolPermissions).toEqual({ 'shell:ls': 'allow' });
+    // Legacy v1 blob is migrated to v2 rules on read (#261); garbage dropped.
+    expect(prefs.toolPermissions).toEqual([
+      { effect: 'allow', tool: 'shell', specifier: 'ls *', _v: 2 },
+    ]);
   });
 
   it('loadPreferences drops prototype-pollution keys from toolPermissions (#212)', async () => {
@@ -103,8 +106,10 @@ describe('profiles store', () => {
     vi.resetModules();
     const config = await import('./config.js');
     const prefs = config.loadPreferences();
-    expect(prefs.toolPermissions).toEqual({ 'shell:ls': 'allow' });
-    expect(Object.getPrototypeOf(prefs.toolPermissions)).toBe(Object.prototype);
+    // Forbidden keys are dropped during migration; only the real grant survives.
+    expect(prefs.toolPermissions).toEqual([
+      { effect: 'allow', tool: 'shell', specifier: 'ls *', _v: 2 },
+    ]);
   });
 
   it('loadPreferences normalizes a legacy modelMode="off" on disk to "optimize-performance"', async () => {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -25,7 +25,7 @@ import * as path from 'node:path';
 import { PREFS_PATH, PROFILES_PATH, PROFILES_MIGRATED_MARKER } from './paths.js';
 import { atomicWriteFileSync } from './fs-utils.js';
 import type { ResponseStyle } from './agent-prompt.js';
-import type { ToolPermissions } from './tool-permissions.js';
+import type { ToolPermissions, ToolPermissionRules } from './tool-permissions.js';
 
 /** Slug pattern + length cap used for profile ids. */
 const ID_PATTERN = /^[a-z][a-z0-9_-]*$/;
@@ -77,9 +77,11 @@ export interface ProfileSettings {
    * (`web_read`) or `shell:<primary-command>` (`shell:ls`); see
    * `permissionKeyFor` in `src/tool-permissions.ts`. `allow` bypasses both
    * the read-only block gate and the risk confirm gate; `deny` refuses the
-   * call without prompting.
+   * call without prompting. On disk this may be a legacy v1 object or the v2
+   * `PermissionRule[]` (#261); both are migrated on read by
+   * `sanitizePermissionRules`.
    */
-  toolPermissions?: ToolPermissions;
+  toolPermissions?: ToolPermissions | ToolPermissionRules;
   /**
    * "Run Without Permission Checks or Safeguards" (#212). When true the
    * policy engine forces `toolMode: 'write'` + `confirmThreshold: 'never'`

--- a/src/tool-permissions.test.ts
+++ b/src/tool-permissions.test.ts
@@ -4,6 +4,9 @@ import {
   permissionKeyFor,
   permissionKeyLabel,
   primaryShellCommand,
+  migrateToolPermissions,
+  sanitizePermissionRules,
+  ruleLabel,
 } from './tool-permissions.js';
 
 describe('primaryShellCommand', () => {
@@ -111,5 +114,48 @@ describe('permissionKeyLabel', () => {
   it('strips the shell: prefix and passes other keys through', () => {
     expect(permissionKeyLabel('shell:ls')).toBe('ls');
     expect(permissionKeyLabel('web_read')).toBe('web_read');
+  });
+});
+
+describe('migrateToolPermissions (#261)', () => {
+  it('returns [] for null/undefined', () => {
+    expect(migrateToolPermissions(undefined)).toEqual([]);
+    expect(migrateToolPermissions(null)).toEqual([]);
+  });
+
+  it('migrates a legacy v1 object, preserving "any args" semantics for shell', () => {
+    const rules = migrateToolPermissions({ 'shell:ls': 'allow', web_read: 'deny' });
+    expect(rules).toEqual([
+      { effect: 'allow', tool: 'shell', specifier: 'ls *', _v: 2 },
+      { effect: 'deny', tool: 'web_read', _v: 2 },
+    ]);
+  });
+
+  it('passes a v2 array through, dropping malformed entries', () => {
+    const rules = migrateToolPermissions([
+      { effect: 'allow', tool: 'shell', specifier: 'git *', _v: 2 },
+      { effect: 'bogus', tool: 'x', _v: 2 } as never,
+      { effect: 'deny', tool: '', _v: 2 } as never,
+    ]);
+    expect(rules).toEqual([{ effect: 'allow', tool: 'shell', specifier: 'git *', _v: 2 }]);
+  });
+
+  it('drops prototype-pollution keys from a legacy blob', () => {
+    const rules = migrateToolPermissions({ __proto__: 'allow', ls: 'allow' } as never);
+    expect(rules.every((r) => r.tool !== '__proto__')).toBe(true);
+  });
+
+  it('sanitizePermissionRules accepts both shapes and junk', () => {
+    expect(sanitizePermissionRules('garbage')).toEqual([]);
+    expect(sanitizePermissionRules({ web_read: 'allow' })).toEqual([
+      { effect: 'allow', tool: 'web_read', _v: 2 },
+    ]);
+  });
+});
+
+describe('ruleLabel (#261)', () => {
+  it('renders tool + specifier, or "(any args)" when absent', () => {
+    expect(ruleLabel({ effect: 'allow', tool: 'shell', specifier: 'git *', _v: 2 })).toBe('shell git *');
+    expect(ruleLabel({ effect: 'deny', tool: 'web_read', _v: 2 })).toBe('web_read (any args)');
   });
 });

--- a/src/tool-permissions.test.ts
+++ b/src/tool-permissions.test.ts
@@ -140,6 +140,15 @@ describe('migrateToolPermissions (#261)', () => {
     expect(rules).toEqual([{ effect: 'allow', tool: 'shell', specifier: 'git *', _v: 2 }]);
   });
 
+  it('drops rules with empty/whitespace specifiers (never-matching, misleading)', () => {
+    const rules = migrateToolPermissions([
+      { effect: 'allow', tool: 'shell', specifier: '', _v: 2 } as never,
+      { effect: 'allow', tool: 'shell', specifier: '   ', _v: 2 } as never,
+      { effect: 'allow', tool: 'shell', specifier: 'git *', _v: 2 },
+    ]);
+    expect(rules).toEqual([{ effect: 'allow', tool: 'shell', specifier: 'git *', _v: 2 }]);
+  });
+
   it('drops prototype-pollution keys from a legacy blob', () => {
     const rules = migrateToolPermissions({ __proto__: 'allow', ls: 'allow' } as never);
     expect(rules.every((r) => r.tool !== '__proto__')).toBe(true);

--- a/src/tool-permissions.ts
+++ b/src/tool-permissions.ts
@@ -25,8 +25,111 @@
 
 export type ToolPermissionValue = 'allow' | 'deny';
 
-/** Permission key → grant. Persisted per-profile (`ProfileSettings.toolPermissions`). */
+/** Permission key → grant. Legacy v1 shape (still read from disk + migrated). */
 export type ToolPermissions = Record<string, ToolPermissionValue>;
+
+/**
+ * Permission-rule effects (#261). `allow`/`deny` mirror the legacy grant
+ * values; `ask` forces a prompt even when a broader allow would otherwise
+ * match (used for the dangerous-command floor and explicit user "ask" rules).
+ */
+export type ToolPermissionEffect = 'allow' | 'deny' | 'ask';
+
+/**
+ * A single profile-scoped permission rule (#261) — the deterministic,
+ * Claude-Code-style grant unit that carries both axes: which tool (and how
+ * broadly, via `specifier`) and what effect.
+ */
+export interface PermissionRule {
+  effect: ToolPermissionEffect;
+  /** Tool name: `shell`, `web_read`, `server__tool`, etc. */
+  tool: string;
+  /**
+   * Scope/breadth pattern. **Absent** = matches ANY invocation of the tool.
+   * - `shell`: a glob like `git` (exact, no args) or `git *` (any args)
+   * - `file_*`: a gitignore-style path pattern (`*` = one segment, `**` = recursive)
+   * - `web_*`: `domain:example.com` or an exact URL
+   * - MCP / other: `*` (any args) or an exact-args JSON string
+   */
+  specifier?: string;
+  /** Schema-version discriminant so migration can tell v2 rules from a v1 blob. */
+  _v: 2;
+}
+
+/** Ordered rule list. Persisted per-profile (`ProfileSettings.toolPermissions`). */
+export type ToolPermissionRules = PermissionRule[];
+
+/**
+ * Prototype-pollution keys: no legitimate tool name is named `__proto__` /
+ * `constructor` / `prototype`, and assigning them onto a plain object can
+ * rewire its prototype.
+ */
+export const FORBIDDEN_PERMISSION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isValidRule(r: unknown): r is PermissionRule {
+  if (!r || typeof r !== 'object') return false;
+  const rule = r as Record<string, unknown>;
+  if (rule.effect !== 'allow' && rule.effect !== 'deny' && rule.effect !== 'ask') return false;
+  if (typeof rule.tool !== 'string' || rule.tool.length === 0) return false;
+  if (FORBIDDEN_PERMISSION_KEYS.has(rule.tool)) return false;
+  if (rule.specifier !== undefined && typeof rule.specifier !== 'string') return false;
+  return true;
+}
+
+function normalizeRule(r: PermissionRule): PermissionRule {
+  // Drop any extra fields a hand-edited file may carry; re-stamp `_v`.
+  return r.specifier === undefined
+    ? { effect: r.effect, tool: r.tool, _v: 2 }
+    : { effect: r.effect, tool: r.tool, specifier: r.specifier, _v: 2 };
+}
+
+/**
+ * Converts a legacy v1 key (`shell:ls` or a bare tool name) into a v2 rule.
+ * `shell:<primary>` becomes `{ tool: 'shell', specifier: '<primary> *' }` to
+ * preserve the legacy "any args to that command" semantics (the v1 key matched
+ * regardless of the command's arguments).
+ */
+function ruleFromLegacyKey(key: string, effect: ToolPermissionValue): PermissionRule {
+  if (key.startsWith('shell:')) {
+    const primary = key.slice('shell:'.length);
+    return { effect, tool: 'shell', specifier: `${primary} *`, _v: 2 };
+  }
+  return { effect, tool: key, _v: 2 };
+}
+
+/**
+ * Lazily migrates a stored `toolPermissions` value (v1 object or v2 array)
+ * into a `PermissionRule[]`. Non-destructive — callers persist the v2 form on
+ * the next save, so a v1 file remains readable for rollback until then.
+ */
+export function migrateToolPermissions(
+  raw: ToolPermissions | ToolPermissionRules | undefined | null,
+): PermissionRule[] {
+  if (raw == null) return [];
+  if (Array.isArray(raw)) return raw.filter(isValidRule).map(normalizeRule);
+  if (typeof raw !== 'object') return [];
+  const out: PermissionRule[] = [];
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (FORBIDDEN_PERMISSION_KEYS.has(key)) continue;
+    if (value !== 'allow' && value !== 'deny') continue;
+    out.push(ruleFromLegacyKey(key, value));
+  }
+  return out;
+}
+
+/**
+ * Validates + migrates an untrusted stored value into a `PermissionRule[]`.
+ * Accepts both the legacy v1 object and the v2 array shape; drops malformed
+ * entries so a hand-edited profiles.json can't smuggle garbage into the gates.
+ */
+export function sanitizePermissionRules(raw: unknown): PermissionRule[] {
+  return migrateToolPermissions(raw as ToolPermissions | ToolPermissionRules | undefined);
+}
+
+/** Human label for a rule in `/tool-permissions` and dialogs. */
+export function ruleLabel(rule: PermissionRule): string {
+  return rule.specifier ? `${rule.tool} ${rule.specifier}` : `${rule.tool} (any args)`;
+}
 
 /**
  * Characters that make a command line "complex": pipes, separators,

--- a/src/tool-permissions.ts
+++ b/src/tool-permissions.ts
@@ -105,7 +105,7 @@ function ruleFromLegacyKey(key: string, effect: ToolPermissionValue): Permission
 export function migrateToolPermissions(
   raw: ToolPermissions | ToolPermissionRules | undefined | null,
 ): PermissionRule[] {
-  if (raw == null) return [];
+  if (raw === null || raw === undefined) return [];
   if (Array.isArray(raw)) return raw.filter(isValidRule).map(normalizeRule);
   if (typeof raw !== 'object') return [];
   const out: PermissionRule[] = [];

--- a/src/tool-permissions.ts
+++ b/src/tool-permissions.ts
@@ -72,7 +72,11 @@ function isValidRule(r: unknown): r is PermissionRule {
   if (rule.effect !== 'allow' && rule.effect !== 'deny' && rule.effect !== 'ask') return false;
   if (typeof rule.tool !== 'string' || rule.tool.length === 0) return false;
   if (FORBIDDEN_PERMISSION_KEYS.has(rule.tool)) return false;
-  if (rule.specifier !== undefined && typeof rule.specifier !== 'string') return false;
+  if (rule.specifier !== undefined) {
+    // Reject empty/whitespace specifiers: they never match yet would render as
+    // "(any args)", a misleading persisted rule. Drop them during sanitization.
+    if (typeof rule.specifier !== 'string' || rule.specifier.trim() === '') return false;
+  }
   return true;
 }
 
@@ -128,7 +132,10 @@ export function sanitizePermissionRules(raw: unknown): PermissionRule[] {
 
 /** Human label for a rule in `/tool-permissions` and dialogs. */
 export function ruleLabel(rule: PermissionRule): string {
-  return rule.specifier ? `${rule.tool} ${rule.specifier}` : `${rule.tool} (any args)`;
+  // Explicit undefined check: only a truly absent specifier is "(any args)".
+  return rule.specifier !== undefined
+    ? `${rule.tool} ${rule.specifier}`
+    : `${rule.tool} (any args)`;
 }
 
 /**

--- a/src/tools/augment.test.ts
+++ b/src/tools/augment.test.ts
@@ -1157,7 +1157,7 @@ describe('augmentTools', () => {
           profileStore: store,
           confirmThreshold: 'high',
           confirmAction,
-          getToolPermissions: () => ({ t: 'allow' }),
+          getToolPermissions: () => [{ effect: 'allow', tool: 't', _v: 2 }],
         },
       );
       await augmented.t.execute({}, {});
@@ -1174,13 +1174,13 @@ describe('augmentTools', () => {
           profileStore: store,
           confirmThreshold: 'high',
           confirmAction,
-          getToolPermissions: () => ({ 'shell:touch': 'allow' }),
+          getToolPermissions: () => [{ effect: 'allow', tool: 'shell', specifier: 'touch *', _v: 2 }],
         },
       );
       await augmented.shell.execute({ command: 'touch x' }, {});
       expect(confirmAction).not.toHaveBeenCalled();
       expect(execute).toHaveBeenCalledTimes(1);
-      // Different primary command → no grant → prompts (and is denied here).
+      // Different (dangerous) command → grant doesn't match / dangerous floor → prompts.
       await augmented.shell.execute({ command: 'rm -rf ./x' }, {});
       expect(confirmAction).toHaveBeenCalledTimes(1);
       expect(execute).toHaveBeenCalledTimes(1);
@@ -1195,7 +1195,10 @@ describe('augmentTools', () => {
           profileStore: store,
           confirmThreshold: 'high',
           confirmAction,
-          getToolPermissions: () => ({ 'shell:touch': 'allow', shell: 'allow' }),
+          getToolPermissions: () => [
+            { effect: 'allow', tool: 'shell', specifier: 'touch *', _v: 2 },
+            { effect: 'allow', tool: 'shell', _v: 2 },
+          ],
         },
       );
       await augmented.shell.execute({ command: 'touch x; rm -rf /' }, {});
@@ -1218,7 +1221,7 @@ describe('augmentTools', () => {
           profileStore: store,
           confirmThreshold: 'high',
           confirmAction,
-          getToolPermissions: () => ({ t: 'deny' }),
+          getToolPermissions: () => [{ effect: 'deny', tool: 't', _v: 2 }],
         },
       );
       const r = await augmented.t.execute({}, {});
@@ -1236,7 +1239,7 @@ describe('augmentTools', () => {
           profileStore: store,
           toolMode: 'read-only',
           blockAction,
-          getToolPermissions: () => ({ t: 'allow' }),
+          getToolPermissions: () => [{ effect: 'allow', tool: 't', _v: 2 }],
         },
       );
       await augmented.t.execute({}, {});
@@ -1253,7 +1256,7 @@ describe('augmentTools', () => {
           profileStore: store,
           toolMode: 'read-only',
           blockAction,
-          getToolPermissions: () => ({ t: 'deny' }),
+          getToolPermissions: () => [{ effect: 'deny', tool: 't', _v: 2 }],
         },
       );
       const r = await augmented.t.execute({}, {});

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -11,8 +11,10 @@ import { CACHE_MISS, getCachedResult, setCachedResult } from '../framework/tools
 import { redactArgs, REDACTED } from '../framework/tools/redact.js';
 import type { ProvenanceStore } from '../provenance.js';
 import type { ToolMeta } from '../framework/tools/types.js';
-import { isDangerous } from './shell.js';
+import { isDangerous, isSafelisted } from './shell.js';
 import { permissionKeyFor } from '../tool-permissions.js';
+import { resolveGrant } from '../permissions/engine.js';
+import { breadthOptionsFor, type BreadthOption } from '../permissions/breadth.js';
 
 /**
  * The wrapper shim prepends `[failure: <category>] <playbook.model>` to
@@ -359,21 +361,43 @@ export function augmentTools(
   const augmented: Record<string, any> = {};
 
   /**
-   * Profile-persisted grant lookup (#212), shared by both gates: `allow`
-   * skips the gate's prompt, `deny` refuses without prompting, `prompt`
-   * falls through to the gate's dialog. Checked after the session
+   * Is this shell call a dangerous, non-safelisted command? Such calls always
+   * re-prompt and are never offered a profile-scope grant (#261).
+   */
+  const isDangerousShellCall = (toolName: string, args: unknown): boolean => {
+    if (toolName !== 'shell') return false;
+    const cmd = (args as Record<string, unknown> | undefined)?.command;
+    return typeof cmd === 'string' && isDangerous(cmd) && !isSafelisted(cmd);
+  };
+
+  /**
+   * Profile-persisted grant resolution (#212/#261), shared by both gates.
+   * Evaluates the active profile's `PermissionRule[]` through the deterministic
+   * engine: `allow` skips the gate's prompt, `deny` refuses without prompting,
+   * `ask` falls through to the gate's dialog. Checked after the session
    * allowlist, before prompting.
    */
   const resolveProfileGrant = (
     toolName: string,
-    permissionKey: string | null,
+    args: unknown,
     gate: 'block' | 'confirm',
-  ): 'allow' | 'deny' | 'prompt' => {
-    const grant = permissionKey ? opts.getToolPermissions?.()?.[permissionKey] : undefined;
-    if (grant === 'deny') {
-      debugLog(`augment:${toolName}:${gate}:profile-deny`, { permissionKey });
-    }
-    return grant ?? 'prompt';
+  ): 'allow' | 'deny' | 'ask' => {
+    const rules = opts.getToolPermissions?.() ?? [];
+    if (rules.length === 0) return 'ask';
+    const decision = resolveGrant(toolName, args, rules, isDangerousShellCall(toolName, args));
+    if (decision === 'deny') debugLog(`augment:${toolName}:${gate}:profile-deny`, {});
+    return decision;
+  };
+
+  /**
+   * Breadth ladder for the confirm/block dialog (#261), or `undefined` when no
+   * profile-scope grant should be offered (dangerous shell, complex/unparseable
+   * commands, missing args) so the dialog omits the "for this profile" row.
+   */
+  const computeBreadthOptions = (toolName: string, args: unknown): BreadthOption[] | undefined => {
+    if (isDangerousShellCall(toolName, args)) return undefined;
+    const ladder = breadthOptionsFor(toolName, args);
+    return ladder.length ? ladder : undefined;
   };
 
   /**
@@ -396,7 +420,7 @@ export function augmentTools(
     if (!shouldBlockInReadOnly(meta, args)) return true;
     if (sessionToolAllowlist.has(toolName)) return true;
     const permissionKey = permissionKeyFor(toolName, args);
-    const grant = resolveProfileGrant(toolName, permissionKey, 'block');
+    const grant = resolveProfileGrant(toolName, args, 'block');
     if (grant === 'allow') return true;
     if (grant === 'deny') return false;
     if (!blockAction) {
@@ -408,6 +432,7 @@ export function augmentTools(
       args,
       reason: buildConfirmReason(toolName, args),
       permissionKey,
+      breadthOptions: computeBreadthOptions(toolName, args),
     };
     const signal = (execOptions as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
     let outcome: BlockOutcome;
@@ -444,7 +469,7 @@ export function augmentTools(
     const risk = riskFromMeta(meta, args);
     if (!shouldConfirm(risk, confirmThreshold)) return true;
     const permissionKey = permissionKeyFor(toolName, args);
-    const grant = resolveProfileGrant(toolName, permissionKey, 'confirm');
+    const grant = resolveProfileGrant(toolName, args, 'confirm');
     if (grant === 'allow') return true;
     if (grant === 'deny') return false;
     const input: ConfirmActionInput = {
@@ -453,6 +478,7 @@ export function augmentTools(
       risk,
       reason: buildConfirmReason(toolName, args),
       permissionKey,
+      breadthOptions: computeBreadthOptions(toolName, args),
     };
     const signal = (execOptions as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
     try {

--- a/src/tools/augment.ts
+++ b/src/tools/augment.ts
@@ -381,10 +381,11 @@ export function augmentTools(
     toolName: string,
     args: unknown,
     gate: 'block' | 'confirm',
+    isDangerousShell: boolean,
   ): 'allow' | 'deny' | 'ask' => {
     const rules = opts.getToolPermissions?.() ?? [];
     if (rules.length === 0) return 'ask';
-    const decision = resolveGrant(toolName, args, rules, isDangerousShellCall(toolName, args));
+    const decision = resolveGrant(toolName, args, rules, isDangerousShell);
     if (decision === 'deny') debugLog(`augment:${toolName}:${gate}:profile-deny`, {});
     return decision;
   };
@@ -394,8 +395,12 @@ export function augmentTools(
    * profile-scope grant should be offered (dangerous shell, complex/unparseable
    * commands, missing args) so the dialog omits the "for this profile" row.
    */
-  const computeBreadthOptions = (toolName: string, args: unknown): BreadthOption[] | undefined => {
-    if (isDangerousShellCall(toolName, args)) return undefined;
+  const computeBreadthOptions = (
+    toolName: string,
+    args: unknown,
+    isDangerousShell: boolean,
+  ): BreadthOption[] | undefined => {
+    if (isDangerousShell) return undefined;
     const ladder = breadthOptionsFor(toolName, args);
     return ladder.length ? ladder : undefined;
   };
@@ -419,8 +424,9 @@ export function augmentTools(
     const meta = readToolMeta(toolDef);
     if (!shouldBlockInReadOnly(meta, args)) return true;
     if (sessionToolAllowlist.has(toolName)) return true;
+    const dangerousShell = isDangerousShellCall(toolName, args);
     const permissionKey = permissionKeyFor(toolName, args);
-    const grant = resolveProfileGrant(toolName, args, 'block');
+    const grant = resolveProfileGrant(toolName, args, 'block', dangerousShell);
     if (grant === 'allow') return true;
     if (grant === 'deny') return false;
     if (!blockAction) {
@@ -432,7 +438,7 @@ export function augmentTools(
       args,
       reason: buildConfirmReason(toolName, args),
       permissionKey,
-      breadthOptions: computeBreadthOptions(toolName, args),
+      breadthOptions: computeBreadthOptions(toolName, args, dangerousShell),
     };
     const signal = (execOptions as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
     let outcome: BlockOutcome;
@@ -468,8 +474,9 @@ export function augmentTools(
     const meta = readToolMeta(toolDef);
     const risk = riskFromMeta(meta, args);
     if (!shouldConfirm(risk, confirmThreshold)) return true;
+    const dangerousShell = isDangerousShellCall(toolName, args);
     const permissionKey = permissionKeyFor(toolName, args);
-    const grant = resolveProfileGrant(toolName, args, 'confirm');
+    const grant = resolveProfileGrant(toolName, args, 'confirm', dangerousShell);
     if (grant === 'allow') return true;
     if (grant === 'deny') return false;
     const input: ConfirmActionInput = {
@@ -478,7 +485,7 @@ export function augmentTools(
       risk,
       reason: buildConfirmReason(toolName, args),
       permissionKey,
-      breadthOptions: computeBreadthOptions(toolName, args),
+      breadthOptions: computeBreadthOptions(toolName, args, dangerousShell),
     };
     const signal = (execOptions as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
     try {

--- a/src/tools/shell.test.ts
+++ b/src/tools/shell.test.ts
@@ -206,11 +206,11 @@ describe('createShellTool', () => {
     expect(execSync).not.toHaveBeenCalled();
   });
 
-  it('does NOT call confirmAction even when wired — the unified gate runs in augmentTools (#144)', async () => {
-    // Shell used to call confirmAction itself, but that double-prompted when
-    // augmentTools also gated the same call. Confirmation is now applied
-    // centrally in `runDefinition`; shell's own check only runs the legacy
-    // `confirmDangerous` fallback for callers that don't go through augment.
+  it('does NOT prompt at all when confirmAction is wired — the unified gate owns it (#144/#212)', async () => {
+    // When the unified gate is wired (the REPL), it gates dangerous shell calls
+    // centrally and is profile-/session-/skip-permissions-aware. Shell must NOT
+    // call confirmAction OR confirmDangerous itself — doing so double-prompts
+    // and ignores every "always allow" / skip-permissions decision (#212).
     const confirmAction = vi.fn().mockResolvedValue(true);
     confirmDangerous.mockResolvedValue(true);
     vi.mocked(execSync).mockReturnValue('done');
@@ -221,7 +221,8 @@ describe('createShellTool', () => {
     });
     await shellTool.execute({ command: 'rm -rf /tmp/test' }, {});
     expect(confirmAction).not.toHaveBeenCalled();
-    expect(confirmDangerous).toHaveBeenCalledWith('rm -rf /tmp/test', undefined);
+    expect(confirmDangerous).not.toHaveBeenCalled();
+    expect(execSync).toHaveBeenCalled();
   });
 
   it('falls back to confirmDangerous when confirmAction is not wired (#144)', async () => {

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -123,12 +123,16 @@ export function createShellTool(options: ToolOptions): BernardTool<ShellArgs, Sh
     description: SHELL_DESCRIPTION,
     parameters: SHELL_PARAMETERS,
     execute: async ({ command }, execOptions) => {
-      if (isDangerous(command) && !isSafelisted(command)) {
-        // The unified `confirmAction` gate (#144) is installed centrally in
-        // `runDefinition` (`augmentTools`), so when both confirmAction and
-        // confirmDangerous are wired we'd otherwise prompt twice. Only fall
-        // back to the legacy `confirmDangerous` callback — covers tests and
-        // callers that haven't migrated to the unified gate.
+      // The unified `confirmAction` gate (#144/#212) is installed centrally in
+      // `runDefinition` (`augmentTools`) and is profile-, session-, and
+      // skip-permissions-aware; it already gates dangerous shell calls
+      // (meta.kind: 'dangerous' → high risk). When it's wired (the REPL),
+      // calling `confirmDangerous` here too would prompt a SECOND time and
+      // ignore every "always allow" / "allow for session" / skip-permissions
+      // decision the user already made (#212). So only fall back to the legacy
+      // `confirmDangerous` callback when the unified gate is ABSENT — covers
+      // tests and callers that haven't migrated.
+      if (!options.confirmAction && isDangerous(command) && !isSafelisted(command)) {
         const confirmed = await options.confirmDangerous(command, execOptions?.abortSignal);
         if (!confirmed) {
           return ok({ output: 'Command cancelled by user.', is_error: false });

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,5 +1,6 @@
 import type { RiskLevel } from '../risk.js';
-import type { ToolPermissions } from '../tool-permissions.js';
+import type { PermissionRule } from '../tool-permissions.js';
+import type { BreadthOption } from '../permissions/breadth.js';
 
 /**
  * Input passed to the unified pre-execution confirmation callback (issue #144).
@@ -25,6 +26,12 @@ export interface ConfirmActionInput {
    * "Always allow for this profile" option.
    */
   permissionKey?: string | null;
+  /**
+   * Breadth ladder (#261) for the scope axis: ordered narrow→broad scope
+   * options the user picks with ←/→. Absent/empty ⇒ no profile-scope grant is
+   * offered (complex/dangerous shell), so the dialog omits the profile row.
+   */
+  breadthOptions?: BreadthOption[];
 }
 
 /** A single question for the `askUser` callback. */
@@ -66,6 +73,8 @@ export interface BlockActionInput {
   reason: string;
   /** Profile-grant key for this call (#212) — see {@link ConfirmActionInput.permissionKey}. */
   permissionKey?: string | null;
+  /** Breadth ladder (#261) — see {@link ConfirmActionInput.breadthOptions}. */
+  breadthOptions?: BreadthOption[];
 }
 
 /**
@@ -139,7 +148,7 @@ export interface ToolOptions {
    * snapshot) so mid-session grants and profile switches take effect
    * immediately. Omitted by cron — headless runs never honor profile grants.
    */
-  getToolPermissions?: () => ToolPermissions | undefined;
+  getToolPermissions?: () => PermissionRule[] | undefined;
 }
 
 /** Outcome of a shell tool invocation. */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -70,7 +70,12 @@ import {
   saveActiveSettings,
   type ProfileSettings,
 } from '../profiles.js';
-import { permissionKeyLabel, type ToolPermissionValue } from '../tool-permissions.js';
+import {
+  ruleLabel,
+  type PermissionRule,
+  type ToolPermissionEffect,
+} from '../tool-permissions.js';
+import type { BreadthOption } from '../permissions/breadth.js';
 import { applyProfileToConfig } from '../config.js';
 import { setToolDetailsVisible } from '../output.js';
 import { truncate } from '../text.js';
@@ -234,13 +239,17 @@ interface PendingGrid {
 interface PendingConfirm {
   kind: 'confirm';
   input: ConfirmActionInput;
-  resolve: (allowed: boolean, scope: 'once' | 'session' | 'profile') => void;
+  resolve: (
+    allowed: boolean,
+    scope: 'once' | 'session' | 'profile',
+    breadth: BreadthOption | undefined,
+  ) => void;
 }
 
 interface PendingBlock {
   kind: 'block';
   input: BlockActionInput;
-  resolve: (outcome: BlockOutcome) => void;
+  resolve: (outcome: BlockOutcome, breadth: BreadthOption | undefined) => void;
 }
 
 type PendingDialog = PendingConfirm | PendingBlock;
@@ -403,8 +412,8 @@ export function App({
       setPendingGrid(null);
     }
     if (pendingDialog) {
-      if (pendingDialog.kind === 'confirm') pendingDialog.resolve(false, 'once');
-      else pendingDialog.resolve('deny');
+      if (pendingDialog.kind === 'confirm') pendingDialog.resolve(false, 'once', undefined);
+      else pendingDialog.resolve('deny', undefined);
       setPendingDialog(null);
     }
     if (pendingTextInput) {
@@ -2444,19 +2453,31 @@ export function App({
    * gates read it through `getToolPermissions` on every call) and writes the
    * active profile so the grant survives REPL restarts.
    */
-  function persistToolPermission(key: string, value: ToolPermissionValue): void {
-    config.toolPermissions = { ...config.toolPermissions, [key]: value };
+  /** Build a PermissionRule from a tool + selected breadth option (#261). */
+  function buildRuleFromBreadth(
+    toolName: string,
+    breadth: BreadthOption | undefined,
+    effect: ToolPermissionEffect,
+  ): PermissionRule {
+    return breadth
+      ? { effect, tool: toolName, specifier: breadth.specifier, _v: 2 }
+      : { effect, tool: toolName, _v: 2 };
+  }
+
+  /** Append a rule to the active profile and persist (#261). */
+  function persistPermissionRule(rule: PermissionRule): void {
+    config.toolPermissions = [...config.toolPermissions, rule];
     saveActiveSettings({ toolPermissions: config.toolPermissions });
   }
 
   /**
-   * `/tool-permissions` (#212): inspect/remove the active profile's persisted
-   * grants and toggle the global "Run Without Permission Checks or
-   * Safeguards" escape hatch.
+   * `/tool-permissions` (#212/#261): inspect/remove/flip the active profile's
+   * persisted permission rules and toggle the global "Run Without Permission
+   * Checks or Safeguards" escape hatch.
    */
   async function runToolPermissionsMenu(): Promise<void> {
     const skipOn = config.skipPermissions;
-    const keys = Object.keys(config.toolPermissions).sort();
+    const rules = config.toolPermissions;
     const entries: MenuEntry[] = [
       {
         label: 'Run Without Permission Checks or Safeguards',
@@ -2466,20 +2487,20 @@ export function App({
           : 'Disable the block gate and every confirmation prompt for this profile.',
         value: '__skip__',
       },
-      ...(keys.length > 0
+      ...(rules.length > 0
         ? [
-            { type: 'section' as const, title: 'Profile grants:' },
-            ...keys.map((k) => ({
-              label: k,
-              annotation: config.toolPermissions[k],
-              value: k,
+            { type: 'section' as const, title: 'Profile rules (deny → ask → allow):' },
+            ...rules.map((r, i) => ({
+              label: ruleLabel(r),
+              annotation: r.effect,
+              value: String(i),
             })),
-            { label: 'Reset all grants', value: '__reset__' },
+            { label: 'Reset all rules', value: '__reset__' },
           ]
-        : [{ type: 'section' as const, title: 'No tool grants saved for this profile.' }]),
+        : [{ type: 'section' as const, title: 'No tool rules saved for this profile.' }]),
     ];
     const result = await requestMenu(entries, {
-      title: `Tool permissions — profile grants persist across sessions`,
+      title: `Tool permissions — profile rules persist across sessions`,
     });
     if (result.cancelled) return;
     const value = result.item.value as string;
@@ -2490,35 +2511,37 @@ export function App({
     }
 
     if (value === '__reset__') {
-      config.toolPermissions = {};
-      saveActiveSettings({ toolPermissions: {} });
-      flashToast('All profile tool grants removed.', 'success');
+      config.toolPermissions = [];
+      saveActiveSettings({ toolPermissions: [] });
+      flashToast('All profile tool rules removed.', 'success');
       return;
     }
 
-    // Per-grant submenu.
-    const current = config.toolPermissions[value];
-    if (!current) return;
-    const flipped: ToolPermissionValue = current === 'allow' ? 'deny' : 'allow';
+    // Per-rule submenu.
+    const idx = Number(value);
+    const rule = rules[idx];
+    if (!rule) return;
+    const flipped: ToolPermissionEffect = rule.effect === 'allow' ? 'deny' : 'allow';
     const sub = await requestMenu(
       [
-        { label: 'Remove grant', value: 'remove' },
+        { label: 'Remove rule', value: 'remove' },
         { label: `Switch to ${flipped}`, value: 'switch' },
         { label: 'Cancel', value: 'cancel' },
       ],
-      { title: `${value} — currently ${current}` },
+      { title: `${ruleLabel(rule)} — currently ${rule.effect}` },
     );
     if (sub.cancelled || sub.item.value === 'cancel') return;
     if (sub.item.value === 'remove') {
-      const updated = { ...config.toolPermissions };
-      delete updated[value];
+      const updated = rules.filter((_, i) => i !== idx);
       config.toolPermissions = updated;
       saveActiveSettings({ toolPermissions: updated });
-      flashToast(`Removed grant for "${permissionKeyLabel(value)}".`, 'success');
+      flashToast(`Removed rule "${ruleLabel(rule)}".`, 'success');
       return;
     }
-    persistToolPermission(value, flipped);
-    flashToast(`"${permissionKeyLabel(value)}" switched to ${flipped}.`, 'success');
+    const updated = rules.map((r, i) => (i === idx ? { ...r, effect: flipped } : r));
+    config.toolPermissions = updated;
+    saveActiveSettings({ toolPermissions: updated });
+    flashToast(`"${ruleLabel(rule)}" switched to ${flipped}.`, 'success');
   }
 
   function requestConfirm(input: ConfirmActionInput, signal?: AbortSignal): Promise<boolean> {
@@ -2541,11 +2564,11 @@ export function App({
       setPendingDialog({
         kind: 'confirm',
         input,
-        resolve: (allowed, scope) => {
+        resolve: (allowed, scope, breadth) => {
           signal?.removeEventListener('abort', onAbort);
           if (allowed && scope === 'session') confirmAllowSession.current.set(key, true);
-          if (allowed && scope === 'profile' && input.permissionKey) {
-            persistToolPermission(input.permissionKey, 'allow');
+          if (allowed && scope === 'profile') {
+            persistPermissionRule(buildRuleFromBreadth(input.toolName, breadth, 'allow'));
           }
           finish(allowed);
         },
@@ -2572,10 +2595,10 @@ export function App({
       setPendingDialog({
         kind: 'block',
         input,
-        resolve: (outcome) => {
+        resolve: (outcome, breadth) => {
           signal?.removeEventListener('abort', onAbort);
-          if (outcome === 'allow-tool-for-profile' && input.permissionKey) {
-            persistToolPermission(input.permissionKey, 'allow');
+          if (outcome === 'allow-tool-for-profile') {
+            persistPermissionRule(buildRuleFromBreadth(input.toolName, breadth, 'allow'));
           }
           finish(outcome);
         },
@@ -2761,13 +2784,14 @@ export function App({
           reason={pendingDialog.input.reason}
           risk={pendingDialog.input.risk}
           permissionKey={pendingDialog.input.permissionKey}
-          onResolve={(allowed, scope) => {
-            pendingDialog.resolve(allowed, scope);
+          breadthOptions={pendingDialog.input.breadthOptions}
+          onResolve={(allowed, scope, breadth) => {
+            pendingDialog.resolve(allowed, scope, breadth);
             setPendingDialog(null);
             setActiveOverlay(null);
           }}
           onCancel={() => {
-            pendingDialog.resolve(false, 'once');
+            pendingDialog.resolve(false, 'once', undefined);
             setPendingDialog(null);
             setActiveOverlay(null);
           }}
@@ -2800,13 +2824,14 @@ export function App({
           toolName={pendingDialog.input.toolName}
           reason={pendingDialog.input.reason}
           permissionKey={pendingDialog.input.permissionKey}
-          onResolve={(outcome) => {
-            pendingDialog.resolve(outcome);
+          breadthOptions={pendingDialog.input.breadthOptions}
+          onResolve={(outcome, breadth) => {
+            pendingDialog.resolve(outcome, breadth);
             setPendingDialog(null);
             setActiveOverlay(null);
           }}
           onCancel={() => {
-            pendingDialog.resolve('deny');
+            pendingDialog.resolve('deny', undefined);
             setPendingDialog(null);
             setActiveOverlay(null);
           }}

--- a/src/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/ui/__tests__/ConfirmDialog.test.tsx
@@ -2,7 +2,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
 import { ConfirmDialog } from '../overlays/ConfirmDialog.js';
-import { ESC, ENTER, ARROW_DOWN, CTRL_C, tick } from './_keys.js';
+import type { BreadthOption } from '../../permissions/breadth.js';
+import { ESC, ENTER, ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, CTRL_C, tick } from './_keys.js';
+
+/** A two-step breadth ladder fixture (exact → any args). */
+const BREADTH: BreadthOption[] = [
+  { label: 'touch x', specifier: 'touch x', rulePreview: 'Will allow: `touch x` for this profile' },
+  { label: 'touch *', specifier: 'touch *', rulePreview: 'Will allow: `touch *` for this profile' },
+];
 
 describe('<ConfirmDialog>', () => {
   describe('kind: "confirm"', () => {
@@ -39,7 +46,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(true, 'once');
+      expect(onResolve).toHaveBeenCalledWith(true, 'once', undefined);
     });
 
     it('Down + Enter resolves allow-session', async () => {
@@ -58,7 +65,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(true, 'session');
+      expect(onResolve).toHaveBeenCalledWith(true, 'session', undefined);
     });
 
     it('Down x2 + Enter resolves cancel (deny)', async () => {
@@ -78,7 +85,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(false, 'once');
+      expect(onResolve).toHaveBeenCalledWith(false, 'once', undefined);
     });
 
     it('digit shortcut commits matching choice', async () => {
@@ -95,7 +102,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write('2');
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(true, 'session');
+      expect(onResolve).toHaveBeenCalledWith(true, 'session', undefined);
     });
 
     it('Esc and Ctrl-C call onCancel', async () => {
@@ -163,7 +170,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith('allow-once');
+      expect(onResolve).toHaveBeenCalledWith('allow-once', undefined);
     });
 
     it('Down + Enter commits allow-tool-for-session', async () => {
@@ -182,7 +189,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith('allow-tool-for-session');
+      expect(onResolve).toHaveBeenCalledWith('allow-tool-for-session', undefined);
     });
 
     it('Down x2 + Enter commits deny', async () => {
@@ -202,12 +209,12 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith('deny');
+      expect(onResolve).toHaveBeenCalledWith('deny', undefined);
     });
   });
 
-  describe('profile grants (#212, permissionKey set)', () => {
-    it('confirm kind renders the 4th choice with the command label and shell header tag', () => {
+  describe('profile grants (#212/#261, breadthOptions set)', () => {
+    it('confirm kind renders the profile choice with the command label and shell header tag', () => {
       const { lastFrame } = render(
         createElement(ConfirmDialog, {
           kind: 'confirm',
@@ -215,6 +222,9 @@ describe('<ConfirmDialog>', () => {
           reason: '$ touch x',
           risk: 'high',
           permissionKey: 'shell:touch',
+          breadthOptions: [
+            { label: 'touch', specifier: 'touch *', rulePreview: 'Will allow: `touch` for this profile' },
+          ],
           onResolve: () => {},
           onCancel: () => {},
         }),
@@ -225,14 +235,14 @@ describe('<ConfirmDialog>', () => {
       expect(frame).toContain('4. Cancel');
     });
 
-    it('confirm kind: Down x2 + Enter resolves profile scope', async () => {
+    it('confirm kind: Down x2 + Enter resolves profile scope with the selected breadth', async () => {
       const onResolve = vi.fn();
       const { stdin } = render(
         createElement(ConfirmDialog, {
           kind: 'confirm',
-          toolName: 'web_read',
+          toolName: 'shell',
           reason: 'r',
-          permissionKey: 'web_read',
+          breadthOptions: BREADTH,
           onResolve,
           onCancel: () => {},
         }),
@@ -243,7 +253,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(true, 'profile');
+      expect(onResolve).toHaveBeenCalledWith(true, 'profile', BREADTH[0]);
     });
 
     it('confirm kind: Down x3 + Enter still reaches Cancel', async () => {
@@ -251,9 +261,9 @@ describe('<ConfirmDialog>', () => {
       const { stdin } = render(
         createElement(ConfirmDialog, {
           kind: 'confirm',
-          toolName: 'web_read',
+          toolName: 'shell',
           reason: 'r',
-          permissionKey: 'web_read',
+          breadthOptions: BREADTH,
           onResolve,
           onCancel: () => {},
         }),
@@ -265,7 +275,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(false, 'once');
+      expect(onResolve).toHaveBeenCalledWith(false, 'once', undefined);
     });
 
     it('confirm kind: digit 3 commits the profile choice', async () => {
@@ -273,9 +283,9 @@ describe('<ConfirmDialog>', () => {
       const { stdin } = render(
         createElement(ConfirmDialog, {
           kind: 'confirm',
-          toolName: 'web_read',
+          toolName: 'shell',
           reason: 'r',
-          permissionKey: 'web_read',
+          breadthOptions: BREADTH,
           onResolve,
           onCancel: () => {},
         }),
@@ -283,7 +293,7 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write('3');
       await tick();
-      expect(onResolve).toHaveBeenCalledWith(true, 'profile');
+      expect(onResolve).toHaveBeenCalledWith(true, 'profile', BREADTH[0]);
     });
 
     it('block kind: Down x2 + Enter commits allow-tool-for-profile; Deny moves to 4', async () => {
@@ -294,6 +304,7 @@ describe('<ConfirmDialog>', () => {
           toolName: 'shell',
           reason: '$ touch x',
           permissionKey: 'shell:touch',
+          breadthOptions: BREADTH,
           onResolve,
           onCancel: () => {},
         }),
@@ -305,10 +316,10 @@ describe('<ConfirmDialog>', () => {
       await tick();
       stdin.write(ENTER);
       await tick();
-      expect(onResolve).toHaveBeenCalledWith('allow-tool-for-profile');
+      expect(onResolve).toHaveBeenCalledWith('allow-tool-for-profile', BREADTH[0]);
     });
 
-    it('null permissionKey keeps the historic 3-choice list', () => {
+    it('absent breadthOptions keeps the historic 3-choice list (no profile row)', () => {
       const { lastFrame } = render(
         createElement(ConfirmDialog, {
           kind: 'confirm',
@@ -323,6 +334,93 @@ describe('<ConfirmDialog>', () => {
       const frame = lastFrame() ?? '';
       expect(frame).toContain('3. Cancel');
       expect(frame).not.toContain('for this profile');
+    });
+  });
+
+  describe('breadth axis (#261)', () => {
+    it('→ on the profile row broadens the scope passed to onResolve', async () => {
+      const onResolve = vi.fn();
+      const { stdin } = render(
+        createElement(ConfirmDialog, {
+          kind: 'confirm',
+          toolName: 'shell',
+          reason: 'r',
+          breadthOptions: BREADTH,
+          onResolve,
+          onCancel: () => {},
+        }),
+      );
+      await tick();
+      stdin.write(ARROW_DOWN);
+      stdin.write(ARROW_DOWN); // highlight the profile row
+      stdin.write(ARROW_RIGHT); // breadth 0 -> 1
+      await tick();
+      stdin.write(ENTER);
+      await tick();
+      expect(onResolve).toHaveBeenCalledWith(true, 'profile', BREADTH[1]);
+    });
+
+    it('← clamps at the narrowest breadth (index 0)', async () => {
+      const onResolve = vi.fn();
+      const { stdin } = render(
+        createElement(ConfirmDialog, {
+          kind: 'confirm',
+          toolName: 'shell',
+          reason: 'r',
+          breadthOptions: BREADTH,
+          onResolve,
+          onCancel: () => {},
+        }),
+      );
+      await tick();
+      stdin.write(ARROW_DOWN);
+      stdin.write(ARROW_DOWN);
+      stdin.write(ARROW_LEFT); // already at 0, clamps
+      await tick();
+      stdin.write(ENTER);
+      await tick();
+      expect(onResolve).toHaveBeenCalledWith(true, 'profile', BREADTH[0]);
+    });
+
+    it('shows the resolved rule preview while the profile row is highlighted', async () => {
+      const { stdin, lastFrame } = render(
+        createElement(ConfirmDialog, {
+          kind: 'confirm',
+          toolName: 'shell',
+          reason: 'r',
+          breadthOptions: BREADTH,
+          onResolve: () => {},
+          onCancel: () => {},
+        }),
+      );
+      await tick();
+      stdin.write(ARROW_DOWN);
+      stdin.write(ARROW_DOWN); // highlight profile row
+      await tick();
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Will allow: `touch x` for this profile');
+      expect(frame).toContain('←/→ scope');
+    });
+
+    it('arrows are inert and no profile row renders when breadthOptions is absent', async () => {
+      const onResolve = vi.fn();
+      const { stdin, lastFrame } = render(
+        createElement(ConfirmDialog, {
+          kind: 'confirm',
+          toolName: 'shell',
+          reason: 'r',
+          onResolve,
+          onCancel: () => {},
+        }),
+      );
+      await tick();
+      stdin.write(ARROW_RIGHT);
+      stdin.write(ARROW_LEFT);
+      await tick();
+      expect(lastFrame() ?? '').not.toContain('for this profile');
+      stdin.write(ENTER);
+      await tick();
+      expect(onResolve).toHaveBeenCalledWith(true, 'once', undefined);
     });
   });
 });

--- a/src/ui/overlays/ConfirmDialog.tsx
+++ b/src/ui/overlays/ConfirmDialog.tsx
@@ -4,6 +4,7 @@ import { getThemeColors } from '../../theme.js';
 import type { RiskLevel } from '../../risk.js';
 import type { BlockOutcome } from '../../tools/types.js';
 import { permissionKeyLabel } from '../../tool-permissions.js';
+import type { BreadthOption } from '../../permissions/breadth.js';
 import { MenuRow } from './MenuRow.js';
 
 type ConfirmChoice = 'allow-once' | 'allow-session' | 'allow-profile' | 'cancel';
@@ -14,48 +15,58 @@ interface ConfirmDialogPropsCommon {
   reason: string;
   onCancel: () => void;
   /**
-   * Profile-grant key for this call (#212). When non-null, an
-   * "Always allow … for this profile" choice is appended; `null`/`undefined`
-   * (complex shell commands, legacy callers) keeps the historic 3-choice
-   * list.
+   * Profile-grant key for this call (#212), used only for the command-level
+   * header framing (`shell (touch)`).
    */
   permissionKey?: string | null;
+  /**
+   * Scope/breadth ladder (#261): ordered narrow→broad options the user cycles
+   * with ←/→. When non-empty, the "Always allow … for this profile" choice is
+   * offered (its label reflects the selected breadth). Empty/absent ⇒ no
+   * profile row (dangerous/complex shell).
+   */
+  breadthOptions?: BreadthOption[];
+  /** Initial breadth selection (default 0 = narrowest = today's behavior). */
+  initialBreadthIndex?: number;
 }
 
 interface ConfirmKindProps extends ConfirmDialogPropsCommon {
   kind: 'confirm';
   risk?: RiskLevel;
-  onResolve: (allowed: boolean, scope: 'once' | 'session' | 'profile') => void;
+  onResolve: (
+    allowed: boolean,
+    scope: 'once' | 'session' | 'profile',
+    breadth: BreadthOption | undefined,
+  ) => void;
 }
 
 interface BlockKindProps extends ConfirmDialogPropsCommon {
   kind: 'block';
-  onResolve: (outcome: BlockOutcome) => void;
+  onResolve: (outcome: BlockOutcome, breadth: BreadthOption | undefined) => void;
 }
 
 export type ConfirmDialogProps = ConfirmKindProps | BlockKindProps;
 
 /**
- * Replaces the legacy three-option dialogs from `src/repl.ts`:
- *   - `kind: 'confirm'` mirrors `confirmActionFn` (risk-based, #144):
- *       "Allow once / Allow for session / [Always allow for this profile] / Cancel"
- *   - `kind: 'block'`   mirrors `blockActionFn` (read-only mode, #179):
- *       "Allow once / Enable for this tool, this session / [Always allow for this profile] / Deny"
+ * Risk/read-only confirmation dialog with two orthogonal axes (#144/#179/#261):
+ *   - ↑/↓ = **duration**: Allow once / for session / [for this profile] / Cancel
+ *   - ←/→ = **breadth**:  this exact call → this command/tool with any args
  *
- * The bracketed profile choice (#212) appears only when `permissionKey` is
- * set — the augment layer passes `shell:<primary>` for simple shell commands
- * and the tool name otherwise; complex shell lines carry `null` and keep the
- * historic 3-choice list.
- *
- * Wire-shape (props named after the tool-side callback contracts in
- * `src/tools/types.ts`) is identical to the legacy callbacks so Phase D can
- * drop the readline implementations and route to this component without
- * touching tool code.
+ * The profile choice (and the breadth axis) appear only when `breadthOptions`
+ * is non-empty — the augment layer omits them for dangerous/complex shell, so
+ * a breadth grant can never silence a dangerous invocation. Picking a profile
+ * grant persists a `PermissionRule` built from the selected breadth.
  */
 export function ConfirmDialog(props: ConfirmDialogProps) {
   const colors = getThemeColors();
-  const keyLabel = props.permissionKey ? permissionKeyLabel(props.permissionKey) : null;
-  const profileLabel = keyLabel ? `Always allow \`${keyLabel}\` for this profile` : null;
+  const breadthOptions = props.breadthOptions ?? [];
+  const hasBreadth = breadthOptions.length > 0;
+  const [breadthIdx, setBreadthIdx] = useState(
+    Math.min(Math.max(props.initialBreadthIndex ?? 0, 0), Math.max(breadthOptions.length - 1, 0)),
+  );
+  const breadth = hasBreadth ? breadthOptions[breadthIdx] : undefined;
+  const profileLabel = breadth ? `Always allow \`${breadth.label}\` for this profile` : null;
+
   // Choice/label pairs assembled together so the two can't drift.
   const rows: Array<{ choice: ConfirmChoice | BlockChoice; label: string }> =
     props.kind === 'confirm'
@@ -80,12 +91,13 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
   const commit = (idx: number) => {
     if (props.kind === 'confirm') {
       const choice = choices[idx] as ConfirmChoice;
-      if (choice === 'cancel') props.onResolve(false, 'once');
-      else if (choice === 'allow-profile') props.onResolve(true, 'profile');
-      else props.onResolve(true, choice === 'allow-session' ? 'session' : 'once');
+      if (choice === 'cancel') props.onResolve(false, 'once', undefined);
+      else if (choice === 'allow-profile') props.onResolve(true, 'profile', breadth);
+      else props.onResolve(true, choice === 'allow-session' ? 'session' : 'once', undefined);
     } else {
       const choice = choices[idx] as BlockChoice;
-      props.onResolve(choice);
+      const isProfile = choice === 'allow-tool-for-profile';
+      props.onResolve(choice, isProfile ? breadth : undefined);
     }
   };
 
@@ -110,6 +122,14 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       setHighlight((h) => Math.min(choices.length - 1, h + 1));
       return;
     }
+    if (key.leftArrow) {
+      if (hasBreadth) setBreadthIdx((b) => Math.max(0, b - 1));
+      return;
+    }
+    if (key.rightArrow) {
+      if (hasBreadth) setBreadthIdx((b) => Math.min(breadthOptions.length - 1, b + 1));
+      return;
+    }
     if (/^[1-9]$/.test(input)) {
       const idx = parseInt(input, 10) - 1;
       if (idx < choices.length) commit(idx);
@@ -123,13 +143,20 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
         ? colors.warning
         : colors.accent;
 
+  const keyLabel = props.permissionKey ? permissionKeyLabel(props.permissionKey) : null;
   // Command-level header framing (#212): `shell (touch)` instead of bare
-  // `shell` when the permission key carries a primary command — the label
-  // differs from the raw key exactly when a `shell:` prefix was stripped.
+  // `shell` when the permission key carries a primary command.
   const toolLabel =
     keyLabel && keyLabel !== props.permissionKey
       ? `${props.toolName} (${keyLabel})`
       : props.toolName;
+
+  // The profile row's index (if present) so we can show the breadth selector
+  // only while it's highlighted.
+  const profileRowIdx = choices.findIndex(
+    (c) => c === 'allow-profile' || c === 'allow-tool-for-profile',
+  );
+  const showBreadth = hasBreadth && highlight === profileRowIdx;
 
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -147,8 +174,22 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       {labels.map((label, idx) => (
         <MenuRow key={idx} selected={idx === highlight} label={`${idx + 1}. ${label}`} />
       ))}
+      {showBreadth && breadth ? (
+        <Box marginLeft={2} marginTop={1} flexDirection="column">
+          <Text color={colors.accent}>
+            {breadthOptions.length > 1
+              ? `← scope: ${breadth.label} →  (${breadthIdx + 1}/${breadthOptions.length})`
+              : `scope: ${breadth.label}`}
+          </Text>
+          <Text dimColor>{breadth.rulePreview}</Text>
+        </Box>
+      ) : null}
       <Text> </Text>
-      <Text dimColor>↑/↓ move · Enter select · Esc cancel</Text>
+      <Text dimColor>
+        {hasBreadth
+          ? '↑/↓ choose · ←/→ scope · Enter select · Esc cancel'
+          : '↑/↓ move · Enter select · Esc cancel'}
+      </Text>
     </Box>
   );
 }


### PR DESCRIPTION
Closes #261

Implements the **Scope/breadth axis** from #212's addendum as a deterministic, Claude-Code-style permission system. Also folds in the dangerous-shell double-prompt fix that was a prerequisite.

## Why
#212 shipped only the **Duration** axis (once/session/profile). The **Scope/breadth** axis (how *broadly* a grant applies + the 2D selector) lived only in #212's addendum with no acceptance criteria, so it was never built. Research was decisive that the deterministic, AST-based approach (what Claude Code itself moved to) is the right call over an LLM/wrapper-mediated one — model-mediated authorization measured a 74.6% adversarial breach rate vs 0% for deterministic policy.

## What

**Engine (`src/permissions/`)** — `resolveGrant` evaluates an ordered `PermissionRule[]` **deny → ask → allow**, first match wins. Per-tool-family matchers: shell globs (`git *`), gitignore path patterns (`*` = one segment, `**` = recursive), web `domain:` (subdomain-inclusive), MCP/exact-args.

**Dangerous floor** — `isDangerous(cmd) && !isSafelisted(cmd)` always returns `ask` *before* any rule, and the dialog hides the profile row for it. A breadth grant can never silence a dangerous invocation.

**tree-sitter-bash AST** (`web-tree-sitter`, WASM — no native build) — compound commands split into independent subcommands (each must be granted); fails closed on subshells / substitution / expansion / redirects / control flow / here-docs; never auto-approves exec wrappers (`bash -c`, `eval`, `xargs`, `sudo`, `find -exec`, …). Loads async with a conservative regex fallback, so it's always safe to call synchronously.

**2D dialog** — ↑/↓ duration, ←/→ scope; shows the resolved rule preview ("Will allow: `git *` for this profile"). Default selection = today's behavior, so nothing regresses.

**Storage** — `PermissionRule[]` replaces the flat `Record<string,'allow'|'deny'>`, with lazy non-destructive migration of legacy v1 grants. `/tool-permissions` lists/flips/removes rules.

## Breadth ladder
- shell: exact → `cmd *`
- file_*: exact path → `dir/**` → `parent/**`
- web_*: exact URL → `domain:host`
- MCP/other: exact args → any args

## Phases (each commit lands independently)
- Phase 0 — shell.ts unified-gate fix (dangerous shell no longer double-prompts / ignores skip-permissions)
- Phases 1–4 — data model + engine + gate wiring + 2D UI + `/tool-permissions`
- Phase 5 — tree-sitter AST hardening

## Testing
- `src/permissions/engine.test.ts` (matchers, deny-first, dangerous floor, breadth ladder)
- `src/permissions/shell-ast.test.ts` (AST compound splitting, exec-wrapper/redirect/substitution fail-closed)
- Updated `ConfirmDialog.test.tsx` (2D navigation) + `augment.test.ts` (rule-based gates) + migration tests
- Full suite green: **2897 passing**

## Notes
- Benign-wrapper stripping (`timeout git …` → `git`) is intentionally skipped for now — it over-prompts (safe), not under-prompts. Follow-up.
- Adds runtime deps `web-tree-sitter` + `tree-sitter-wasms` (grammar resolved from node_modules at load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
