### PR TITLE
fix(permissions): /task dispatch honors skipPermissions/confirmMode

### DIFF
--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -503,6 +503,39 @@ describe('buildContextMessage', () => {
   });
 });
 
+describe('resolvePolicyDecisionFor (out-of-turn task dispatch)', () => {
+  let store: MemoryStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.readFileSync).mockReturnValue('');
+    store = new MemoryStore();
+  });
+
+  it('honors skipPermissions → confirmThreshold "never" for a /task dispatch', () => {
+    // Regression: /task and task- routines dispatch outside the processInput
+    // turn loop, so ctx.policyDecision is undefined and the augment gate would
+    // default confirmThreshold to 'high' — re-prompting on dangerous shell
+    // even in unrestricted mode. The Agent must resolve a real decision.
+    const agent = makeAgent(
+      makeConfig({ skipPermissions: true, confirmMode: 'strict', toolMode: 'read-only' }),
+      {},
+      store,
+    );
+    const decision = agent.resolvePolicyDecisionFor('cd repo && gh pr list --json number || true');
+    expect(decision.toolMode?.confirmThreshold).toBe('never');
+    expect(decision.toolMode?.mode).toBe('write');
+  });
+
+  it('reflects confirmMode for a guarded profile (no skipPermissions)', () => {
+    const agent = makeAgent(makeConfig({ confirmMode: 'auto', toolMode: 'write' }), {}, store);
+    const decision = agent.resolvePolicyDecisionFor('rm -rf ./build && make');
+    expect(decision.toolMode?.confirmThreshold).toBe('high');
+  });
+});
+
 describe('prompt-injection regression (issue #172)', () => {
   let store: MemoryStore;
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -45,7 +45,7 @@ import { PlanStore } from './plan-store.js';
 import { type ResolvedEntry } from './reference-resolver.js';
 import type { AgentContext } from './framework/context.js';
 import { DefaultPolicyEngine, isReactEffective } from './policy/index.js';
-import type { PolicyEngine, PolicyResult } from './policy/index.js';
+import type { PolicyDecision, PolicyEngine, PolicyResult } from './policy/index.js';
 import { extractCitationMarkers, type SourceItem, type TurnProvenance } from './provenance.js';
 import type { Step } from './plan-store.js';
 import type { VerificationEntry } from './agent-status.js';
@@ -271,6 +271,25 @@ export class Agent {
    */
   getContext(): AgentContext {
     return this.ctx;
+  }
+
+  /**
+   * Resolves a {@link PolicyDecision} for a dispatch that runs OUTSIDE the
+   * normal `processInput` turn loop (e.g. `/task`, `task-` routines). Between
+   * turns `this.ctx.policyDecision` is `undefined`, so a definition dispatched
+   * directly via `runDefinition` would inherit no decision — and the augment
+   * gate would default `confirmThreshold` to `'high'`, silently ignoring the
+   * user's `skipPermissions` / `confirmMode` / `toolMode` settings. Callers
+   * should spread the returned decision onto the ctx they hand to
+   * `runDefinition` so out-of-turn tasks honor the same per-turn policy a
+   * chat turn would.
+   */
+  resolvePolicyDecisionFor(userInput: string): PolicyDecision {
+    return this.policyEngine.decide({
+      userInput,
+      config: this.config,
+      previousUserInput: extractRecentUserTexts(this.history, 1)[0],
+    }).decision;
   }
 
   /** Returns step limit hit info from last processInput, or null if limit wasn't hit. */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2366,7 +2366,14 @@ export function App({
       const input: TaskInput = context
         ? { task: description, context, slotId: slot.id }
         : { task: description, slotId: slot.id };
-      const { result, formatted } = await runDefinition(ctx, taskDefinition, input);
+      // Tasks dispatch OUTSIDE the normal turn loop, so `ctx.policyDecision` is
+      // undefined here (it's only set during `processInput`). Without it the
+      // augment gate defaults `confirmThreshold` to 'high' and ignores the
+      // user's skipPermissions / confirmMode / toolMode — re-prompting on
+      // dangerous shell even in unrestricted mode. Resolve the same per-turn
+      // decision a chat turn would and thread it onto the task ctx.
+      const taskCtx = { ...ctx, policyDecision: agent.resolvePolicyDecisionFor(description) };
+      const { result, formatted } = await runDefinition(taskCtx, taskDefinition, input);
       if (result.finishReason === 'length') {
         const recommended = Math.ceil((config.maxTokens * 2) / 1024) * 1024;
         flashToast(

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2371,8 +2371,12 @@ export function App({
       // augment gate defaults `confirmThreshold` to 'high' and ignores the
       // user's skipPermissions / confirmMode / toolMode — re-prompting on
       // dangerous shell even in unrestricted mode. Resolve the same per-turn
-      // decision a chat turn would and thread it onto the task ctx.
-      const taskCtx = { ...ctx, policyDecision: agent.resolvePolicyDecisionFor(description) };
+      // decision a chat turn would, feeding the policy engine the exact user
+      // message the model sees (`buildUserMessage` adds the `Task:`/`Context:`
+      // framing) so the decision can't diverge from the real dispatch.
+      const taskMessage = taskDefinition.buildUserMessage(input).content;
+      const policyInput = typeof taskMessage === 'string' ? taskMessage : description;
+      const taskCtx = { ...ctx, policyDecision: agent.resolvePolicyDecisionFor(policyInput) };
       const { result, formatted } = await runDefinition(taskCtx, taskDefinition, input);
       if (result.finishReason === 'length') {
         const recommended = Math.ceil((config.maxTokens * 2) / 1024) * 1024;


### PR DESCRIPTION
## Problem

In **unrestricted** tool mode (`skipPermissions: true`), confirm prompts still appeared for shell commands when triggered via `/task` or `task-` routines — proven by a live `Confirm high: shell` dialog on a compound `gh pr list … || true` command.

## Root cause

Tasks dispatch via `runDefinition` **outside** the `processInput` turn loop, where `ctx.policyDecision` is `undefined`. The augment gate then defaults `confirmThreshold` to `'high'`, re-prompting on dangerous shell even when the active profile has `skipPermissions` (unrestricted) set.

## Fix

- Add `Agent.resolvePolicyDecisionFor(input)` — reuses the Agent's own `policyEngine` (single source of truth) to resolve a per-turn decision for out-of-turn dispatches.
- Thread that decision onto the task ctx in `runTaskInk` so `/task` honors the same policy a chat turn would.

## Tests

Regression coverage in `src/agent.test.ts`:
- `skipPermissions` → `confirmThreshold: 'never'`, `mode: 'write'`
- guarded profile (no skipPermissions) → `confirmThreshold: 'high'`

Typecheck clean, build clean, full agent + policy + augment suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)