### PR TITLE
feat(lineups): role × cost-tier model matrix (#264)

### DIFF
--- a/docs/split-panel-menu-mockups.txt
+++ b/docs/split-panel-menu-mockups.txt
@@ -1,0 +1,183 @@
+================================================================================
+SPLIT-PANEL MENU — RIGHT-PANEL STYLE VARIATIONS
+================================================================================
+
+Decided so far:
+  • LEFT = the existing numbered list, unchanged in spirit: `›`/number markers,
+    section divider before the lineup-level actions. NO per-row description line
+    on highlight (that info now lives in the right panel).
+  • RIGHT = a detail panel for the highlighted row. This is the part we're
+    styling — every variation below keeps the SAME left list and only swaps the
+    right pane.
+
+Sample data: the xAI-only lineup, "Orchestrator" highlighted.
+
+Shared left list (identical in every option):
+
+     1. Orchestrator
+     2. Task executor
+     3. Function caller
+     4. Summarizer
+     5. Classifier / router
+     6. Coder
+    ───────────────────
+     7. Rename lineup
+     8. Save changes
+     9. Save as new lineup
+    10. Delete lineup
+    11. Cancel
+
+
+================================================================================
+STYLE 1 — Aligned labeled lines (plain)
+================================================================================
+Right pane: role title, three tier lines with aligned labels, description below.
+No borders. Simplest possible.
+
+ Lineup: xAI-only — pick a role
+
+  › 1. Orchestrator           Orchestrator
+    2. Task executor
+    3. Function caller        premium   xai / grok-4.3
+    4. Summarizer             mid       xai / grok-4.20-non-reasoning
+    5. Classifier / router    cheap     xai / grok-4.1-fast-reasoning
+    6. Coder
+   ───────────────────        Main interactive agent + cron — long-context
+    7. Rename lineup          planning & tool orchestration.
+    8. Save changes
+    9. Save as new lineup
+   10. Delete lineup
+   11. Cancel
+
+ ↑/↓ move · Enter select · Esc cancel
+
+
+================================================================================
+STYLE 2 — Boxed card
+================================================================================
+Right pane wrapped in a border with the role name as the box title.
+
+  › 1. Orchestrator         ┌─ Orchestrator ──────────────────────────────────┐
+    2. Task executor        │                                                 │
+    3. Function caller      │   premium   xai / grok-4.3                       │
+    4. Summarizer           │   mid       xai / grok-4.20-non-reasoning        │
+    5. Classifier / router  │   cheap     xai / grok-4.1-fast-reasoning        │
+    6. Coder                │                                                 │
+   ───────────────────      │   Main interactive agent + cron — long-context  │
+    7. Rename lineup        │   planning & tool orchestration.                │
+    8. Save changes         │                                                 │
+    9. Save as new lineup   └─────────────────────────────────────────────────┘
+   10. Delete lineup
+   11. Cancel
+
+
+================================================================================
+STYLE 3 — Mini table (header row)
+================================================================================
+Right pane renders the ladder as a TIER / PROVIDER / MODEL table.
+
+  › 1. Orchestrator           Orchestrator
+    2. Task executor          Main interactive agent + cron.
+    3. Function caller
+    4. Summarizer             TIER     PROVIDER   MODEL
+    5. Classifier / router    ───────  ─────────  ─────────────────────────
+    6. Coder                  premium  xai        grok-4.3
+   ───────────────────        mid      xai        grok-4.20-non-reasoning
+    7. Rename lineup          cheap    xai        grok-4.1-fast-reasoning
+    8. Save changes
+    9. Save as new lineup
+   10. Delete lineup
+   11. Cancel
+
+
+================================================================================
+STYLE 4 — Stacked tier blocks (label above value, color-emphasis)
+================================================================================
+Each tier is a two-line block: a dim UPPERCASE label, then the model in the
+accent color. Airier, easier to read one tier at a time.
+
+  › 1. Orchestrator           ORCHESTRATOR
+    2. Task executor
+    3. Function caller        PREMIUM
+    4. Summarizer               xai / grok-4.3
+    5. Classifier / router
+    6. Coder                  MID
+   ───────────────────          xai / grok-4.20-non-reasoning
+    7. Rename lineup
+    8. Save changes           CHEAP
+    9. Save as new lineup       xai / grok-4.1-fast-reasoning
+   10. Delete lineup
+   11. Cancel
+
+
+================================================================================
+STYLE 5 — Provider/model split with separators (spec-sheet)
+================================================================================
+Provider and model on separate aligned columns, with a faint rule under the
+title. Leans "configuration screen."
+
+  › 1. Orchestrator           Orchestrator
+    2. Task executor          ──────────────────────────────────────────
+    3. Function caller         premium    xai  ·  grok-4.3
+    4. Summarizer              mid        xai  ·  grok-4.20-non-reasoning
+    5. Classifier / router     cheap      xai  ·  grok-4.1-fast-reasoning
+    6. Coder                  ──────────────────────────────────────────
+   ───────────────────         used by: main agent + cron daemon
+    7. Rename lineup
+    8. Save changes
+    9. Save as new lineup
+   10. Delete lineup
+   11. Cancel
+
+
+================================================================================
+STYLE 6 — Compact badges (single-line tiers)
+================================================================================
+Tightest vertical footprint: each tier is one line with a colored badge.
+Good when the detail pane must stay short.
+
+  › 1. Orchestrator           Orchestrator — main agent + cron
+
+    2. Task executor          [premium]  xai / grok-4.3
+    3. Function caller        [  mid  ]  xai / grok-4.20-non-reasoning
+    4. Summarizer             [ cheap ]  xai / grok-4.1-fast-reasoning
+    5. Classifier / router
+    6. Coder
+   ───────────────────
+    7. Rename lineup
+    8. Save changes
+    9. Save as new lineup
+   10. Delete lineup
+   11. Cancel
+
+
+================================================================================
+STYLE 7 — Tree / hierarchy
+================================================================================
+Right pane drawn as a tree rooted at the role. Visually ties the three tiers to
+the one role they belong to.
+
+  › 1. Orchestrator           Orchestrator
+    2. Task executor          │ Main interactive agent + cron.
+    3. Function caller        │
+    4. Summarizer             ├─ premium   xai / grok-4.3
+    5. Classifier / router    ├─ mid       xai / grok-4.20-non-reasoning
+    6. Coder                  └─ cheap     xai / grok-4.1-fast-reasoning
+   ───────────────────
+    7. Rename lineup
+    8. Save changes
+    9. Save as new lineup
+   10. Delete lineup
+   11. Cancel
+
+
+================================================================================
+NOTES
+================================================================================
+• Actions (rows 7–11) have no tier ladder; their right pane would show just a
+  one-line explainer (e.g. "Save as new lineup → clone this grid under a new
+  name"), or stay blank — your call.
+• Whatever style we pick, the right pane is a `renderDetail(item)` callback, so
+  the split layout is reusable for any list-with-detail menu and Enter can still
+  hand off to any sub-menu component.
+• Below ~80 cols we fall back to today's single column.

--- a/src/__tests__/lineup-fixtures.ts
+++ b/src/__tests__/lineup-fixtures.ts
@@ -1,0 +1,22 @@
+import { ALL_ROLE_IDS } from '../model-roles.js';
+
+/** Test-only mirrors of the lineup slot shapes (see {@link module:lineups}). */
+export type Slot = { provider: string; model: string };
+export type Ladder = { premium: Slot; mid: Slot; cheap: Slot };
+
+/**
+ * Replicates one cost ladder across all roles — the migration shape a flat
+ * (role-less) lineup expands into. Mirrors the production `replicateAcrossRoles`
+ * helper, kept here so the store and policy suites share one fixture.
+ */
+export function fullRoles(ladder: Ladder): Record<string, Ladder> {
+  const out: Record<string, Ladder> = {};
+  for (const r of ALL_ROLE_IDS) {
+    out[r] = {
+      premium: { ...ladder.premium },
+      mid: { ...ladder.mid },
+      cheap: { ...ladder.cheap },
+    };
+  }
+  return out;
+}

--- a/src/agent-prompt.ts
+++ b/src/agent-prompt.ts
@@ -268,12 +268,17 @@ function formatLineupPromptLine(config: BernardConfig): string {
   try {
     const lineups = loadLineups();
     const lineup = resolveActiveLineup(lineups, config.activeLineupId, config.provider);
+    // Show the orchestrator role's cost ladder — that's the model governing the
+    // main agent (this turn). Other roles (executor, function-caller, …) have
+    // their own ladders, editable per-role via /lineup.
+    const o = lineup.roles.orchestrator;
     return (
-      `\nActive lineup: ${lineup.name} — ` +
-      `premium ${lineup.premium.provider}/${lineup.premium.model}, ` +
-      `mid ${lineup.mid.provider}/${lineup.mid.model}, ` +
-      `cheap ${lineup.cheap.provider}/${lineup.cheap.model}. ` +
-      `The user can edit it with /lineup or switch lineups with /lineups.`
+      `\nActive lineup: ${lineup.name} (orchestrator role) — ` +
+      `premium ${o.premium.provider}/${o.premium.model}, ` +
+      `mid ${o.mid.provider}/${o.mid.model}, ` +
+      `cheap ${o.cheap.provider}/${o.cheap.model}. ` +
+      `Each role has its own premium/mid/cheap binding; the user can edit them ` +
+      `with /lineup or switch lineups with /lineups.`
     );
   } catch {
     return `\nYou are running as provider: ${config.provider}, model: ${config.model}.`;

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -757,6 +757,71 @@ describe('Agent', () => {
     expect(call.messages.length).toBeGreaterThan(2);
   });
 
+  it('continues when the model returns only reasoning and an empty answer', async () => {
+    // Regression: a reasoning model ended a turn with finishReason 'stop' but a
+    // blank `text` — it dumped its answer into the reasoning channel and emitted
+    // nothing. completionTokens>0 proves it generated. The turn should not be
+    // accepted as a (blank) "complete" answer; the loop nudges for the real one.
+    mockGenerateText.mockResolvedValueOnce({
+      text: '',
+      reasoning: 'The dates I added are:',
+      finishReason: 'stop',
+      steps: [],
+      response: {
+        messages: [
+          { role: 'assistant', content: [{ type: 'reasoning', text: 'The dates I added are:' }] },
+        ],
+      },
+      usage: { promptTokens: 100, completionTokens: 80, totalTokens: 180 },
+    });
+    mockGenerateText.mockResolvedValueOnce({
+      text: 'June 1 and June 8.',
+      finishReason: 'stop',
+      steps: [],
+      response: { messages: [{ role: 'assistant', content: 'June 1 and June 8.' }] },
+      usage: { promptTokens: 120, completionTokens: 20, totalTokens: 140 },
+    });
+    const agent = makeAgent(makeConfig(), toolOptions, store);
+    await agent.processInput('what were the dates?');
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    const secondCall = mockGenerateText.mock.calls[1][0];
+    const nudges = secondCall.messages.filter(
+      (m: any) =>
+        m.role === 'user' && typeof m.content === 'string' && m.content.includes('no visible answer'),
+    );
+    expect(nudges.length).toBe(1);
+  });
+
+  it('does not continue when the model returns a normal answer', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: 'Here is the answer.',
+      finishReason: 'stop',
+      steps: [],
+      response: { messages: [{ role: 'assistant', content: 'Here is the answer.' }] },
+      usage: { promptTokens: 100, completionTokens: 40, totalTokens: 140 },
+    });
+    const agent = makeAgent(makeConfig(), toolOptions, store);
+    await agent.processInput('hi');
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds empty-answer continuations so a persistently-blank model cannot loop forever', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: '',
+      reasoning: 'thinking',
+      finishReason: 'stop',
+      steps: [],
+      response: {
+        messages: [{ role: 'assistant', content: [{ type: 'reasoning', text: 'thinking' }] }],
+      },
+      usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+    });
+    const agent = makeAgent(makeConfig(), toolOptions, store);
+    await agent.processInput('hi');
+    // initial call + MAX_EMPTY_ANSWER_RETRIES (2) = 3 total.
+    expect(mockGenerateText).toHaveBeenCalledTimes(3);
+  });
+
   it('clearHistory resets messages and clears scratch', () => {
     store.writeScratch('todo', 'test');
     const agent = makeAgent(makeConfig(), toolOptions, store);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -648,6 +648,54 @@ export class Agent {
             }
           }
 
+          // Reasoning-model safety net: some reasoning models end a turn having
+          // emitted only *reasoning* content and an EMPTY answer — finishReason
+          // 'stop', completion tokens spent, but `result.text` is blank. The
+          // user sees the thinking trail cut off mid-sentence ("...the dates
+          // are:") with no actual answer. The `length` loop above doesn't catch
+          // this (finishReason isn't 'length'), so without a guard the blank
+          // turn is accepted as "complete." Nudge the model to write its answer
+          // as plain text. Bounded and abort-aware like the length path.
+          const MAX_EMPTY_ANSWER_RETRIES = 2;
+          let emptyAnswerRetries = 0;
+          // Trigger only on the "reasoning dump" signature: the model produced
+          // reasoning but routed its whole answer there, leaving `text` blank.
+          // An empty-text 'stop' with NO reasoning is a legitimately silent turn
+          // (e.g. a model that has nothing more to say) and must NOT loop.
+          const hasReasoning = (reasoning: unknown): boolean => {
+            if (typeof reasoning === 'string') return reasoning.trim().length > 0;
+            if (Array.isArray(reasoning)) return reasoning.length > 0;
+            return false;
+          };
+          while (
+            emptyAnswerRetries < MAX_EMPTY_ANSWER_RETRIES &&
+            result.finishReason === 'stop' &&
+            (result.text ?? '').trim() === '' &&
+            (result.usage?.completionTokens ?? 0) > 0 &&
+            hasReasoning((result as { reasoning?: unknown }).reasoning)
+          ) {
+            if (this.abortController?.signal.aborted) break;
+            emptyAnswerRetries++;
+            debugLog('agent:empty-answer-continue', {
+              attempt: emptyAnswerRetries,
+              completionTokens: result.usage?.completionTokens ?? 0,
+            });
+
+            const partialMessages = truncateToolResults(result.response.messages as CoreMessage[]);
+            this.history.push(...partialMessages);
+            this.history.push({
+              role: 'user' as const,
+              content:
+                '[You produced reasoning but no visible answer. Write your final answer to me now, as plain text.]',
+            });
+
+            if (this.spinnerStats) {
+              startSpinner(() => buildSpinnerMessage(this.spinnerStats!));
+            }
+
+            result = await inner(innerOpts);
+          }
+
           if (result.finishReason === 'tool-calls' && result.steps.length >= maxStepsForCall) {
             this.lastStepLimitHit = true;
             this.stepLimitHitCount++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ import {
   getAvailableProviders,
 } from './config.js';
 import { normalizeStoredModelMode } from './model-policy.js';
-import { loadLineups, resolveActiveLineupWithCorrection } from './lineups.js';
+import { loadLineups, resolveActiveLineup, resolveActiveLineupWithCorrection } from './lineups.js';
+import { validateLineup, formatLineupValidation } from './model-validate.js';
 import { setMaxConcurrentAgents, MAX_CONCURRENT_AGENTS_LIMIT } from './tools/agent-pool.js';
 import {
   loadCustomProviders,
@@ -576,6 +577,26 @@ program
       printInfo(
         'To add a custom provider: bernard add-provider <name> --sdk <openai|anthropic|xai> --base-url <url> --model <model>',
       );
+    }
+  });
+
+program
+  .command('validate-lineup [id]')
+  .description('Live-probe every model in a lineup (defaults to the active one). Exits non-zero if any model is unreachable.')
+  .action(async (id?: string) => {
+    const config = loadConfig();
+    const lineups = loadLineups();
+    const target = id && lineups[id] ? lineups[id] : resolveActiveLineup(lineups, config.activeLineupId, config.provider);
+    if (id && !lineups[id]) {
+      printError(`No lineup with id "${id}". Available: ${Object.keys(lineups).join(', ')}.`);
+      process.exit(1);
+    }
+    printInfo(`Validating lineup "${target.name}" (${target.id})…`);
+    const v = await validateLineup(config, target);
+    printInfo(formatLineupValidation(v));
+    if (!v.ok) {
+      printInfo('\nNote: a reachable model can still be too weak for a real task — a probe only checks access.');
+      process.exit(1);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   getAvailableProviders,
 } from './config.js';
 import { normalizeStoredModelMode } from './model-policy.js';
+import { loadLineups, resolveActiveLineupWithCorrection } from './lineups.js';
 import { setMaxConcurrentAgents, MAX_CONCURRENT_AGENTS_LIMIT } from './tools/agent-pool.js';
 import {
   loadCustomProviders,
@@ -305,6 +306,46 @@ async function runInkRepl(args: {
     getToolPermissions: () => config.toolPermissions,
   };
 
+  // Auto-correct a dangling `activeLineupId` (#264 follow-up). A stale id —
+  // left over from a deleted lineup, or a typo in a hand-edited profile —
+  // otherwise falls back silently inside model-policy, so the user has no idea
+  // their selection isn't in effect. Detect it here, persist the corrected id
+  // to the active profile, and pass a transcript notice into <App> so the
+  // switch is visible. Best-effort: a persistence failure still keeps the
+  // in-memory correction for this session.
+  let startupNotice: string | undefined;
+  if (config.activeLineupId) {
+    try {
+      const resolution = resolveActiveLineupWithCorrection(
+        loadLineups(),
+        config.activeLineupId,
+        config.provider,
+      );
+      if (resolution.corrected) {
+        const { requestedId, resolvedId } = resolution.corrected;
+        config.activeLineupId = resolvedId;
+        try {
+          savePreferences({
+            provider: config.provider,
+            model: config.model,
+            activeLineupId: resolvedId,
+          });
+        } catch {
+          // best-effort; the in-memory correction still applies this session
+        }
+        startupNotice =
+          `Heads up — your selected model lineup "${requestedId}" no longer exists, ` +
+          `so I switched you to "${resolution.lineup.name}" (${resolvedId}) and saved that choice. ` +
+          `Use /lineups to pick a different one.`;
+        debugLog('lineup:auto-corrected', { requestedId, resolvedId });
+      }
+    } catch (err: unknown) {
+      // loadLineups always seeds, so this should be unreachable — but never let
+      // a lineup-resolution hiccup block REPL startup.
+      debugLog('lineup:auto-correct-error', err instanceof Error ? err.message : String(err));
+    }
+  }
+
   let initialHistory: CoreMessage[] | undefined;
   if (resume) {
     const loaded = historyStore.load();
@@ -467,6 +508,7 @@ async function runInkRepl(args: {
       onExit: async () => {},
       alertBanner,
       isFreshInstall,
+      startupNotice,
     }),
   );
 

--- a/src/lineups.test.ts
+++ b/src/lineups.test.ts
@@ -225,6 +225,42 @@ describe('lineups store', () => {
     });
   });
 
+  describe('resolveActiveLineupWithCorrection', () => {
+    it('reports no correction when the explicit id exists', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const res = m.resolveActiveLineupWithCorrection(lineups, 'openai', 'anthropic');
+      expect(res.lineup.id).toBe('openai');
+      expect(res.corrected).toBeUndefined();
+    });
+
+    it('reports no correction when no explicit id is set (normal fallback)', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const res = m.resolveActiveLineupWithCorrection(lineups, undefined, 'xai');
+      expect(res.lineup.id).toBe('xai');
+      expect(res.corrected).toBeUndefined();
+    });
+
+    it('reports a correction when the explicit id is missing, falling back by provider', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const res = m.resolveActiveLineupWithCorrection(lineups, 'openai-only', 'xai');
+      // 'openai-only' doesn't exist; provider 'xai' does → fall back to it.
+      expect(res.lineup.id).toBe('xai');
+      expect(res.corrected).toEqual({ requestedId: 'openai-only', resolvedId: 'xai' });
+    });
+
+    it('reports a correction and falls back to the first lineup when nothing matches', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const first = Object.values(lineups)[0];
+      const res = m.resolveActiveLineupWithCorrection(lineups, 'gone', 'unknown-provider');
+      expect(res.lineup.id).toBe(first.id);
+      expect(res.corrected).toEqual({ requestedId: 'gone', resolvedId: first.id });
+    });
+  });
+
   describe('saveLineup / renameLineup / deleteLineup', () => {
     it('writes a new lineup with a derived id', async () => {
       const m = await loadModule();

--- a/src/lineups.test.ts
+++ b/src/lineups.test.ts
@@ -2,11 +2,34 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { ALL_ROLE_IDS } from './model-roles.js';
 
 async function loadModule() {
   vi.resetModules();
   return import('./lineups.js');
 }
+
+type Slot = { provider: string; model: string };
+type Ladder = { premium: Slot; mid: Slot; cheap: Slot };
+
+/** Builds a full `role → ladder` map by replicating one ladder across roles. */
+function fullRoles(ladder: Ladder): Record<string, Ladder> {
+  const out: Record<string, Ladder> = {};
+  for (const r of ALL_ROLE_IDS) {
+    out[r] = {
+      premium: { ...ladder.premium },
+      mid: { ...ladder.mid },
+      cheap: { ...ladder.cheap },
+    };
+  }
+  return out;
+}
+
+const SAMPLE: Ladder = {
+  premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
+  mid: { provider: 'openai', model: 'gpt-4.1' },
+  cheap: { provider: 'xai', model: 'grok-3-mini' },
+};
 
 describe('lineups store', () => {
   let tmpDir: string;
@@ -55,13 +78,11 @@ describe('lineups store', () => {
         mixed: {
           id: 'mixed',
           name: 'Mixed',
-          premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
-          mid: { provider: 'anthropic', model: 'claude-sonnet' },
-          cheap: { provider: 'anthropic', model: 'claude-haiku' },
+          roles: fullRoles(SAMPLE),
           createdAt: 'x',
           updatedAt: 'x',
         },
-      };
+      } as never;
       expect(m.uniqueLineupId('Mixed', existing)).toBe('mixed-2');
     });
   });
@@ -74,12 +95,16 @@ describe('lineups store', () => {
       // Models are derived dynamically from the catalog; assert structural
       // shape rather than exact names so a catalog refresh doesn't break this.
       for (const provider of ['anthropic', 'openai', 'xai'] as const) {
-        expect(lineups[provider].premium.provider).toBe(provider);
-        expect(lineups[provider].mid.provider).toBe(provider);
-        expect(lineups[provider].cheap.provider).toBe(provider);
-        expect(lineups[provider].premium.model.length).toBeGreaterThan(0);
-        expect(lineups[provider].mid.model.length).toBeGreaterThan(0);
-        expect(lineups[provider].cheap.model.length).toBeGreaterThan(0);
+        // Every role is present and seeded to the same provider for all tiers.
+        for (const role of ALL_ROLE_IDS) {
+          const ladder = lineups[provider].roles[role];
+          expect(ladder.premium.provider).toBe(provider);
+          expect(ladder.mid.provider).toBe(provider);
+          expect(ladder.cheap.provider).toBe(provider);
+          expect(ladder.premium.model.length).toBeGreaterThan(0);
+          expect(ladder.mid.model.length).toBeGreaterThan(0);
+          expect(ladder.cheap.model.length).toBeGreaterThan(0);
+        }
       }
     });
 
@@ -90,6 +115,7 @@ describe('lineups store', () => {
       expect(fs.existsSync(filePath)).toBe(true);
       const onDisk = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
       expect(onDisk.lineups.anthropic.name).toBe('Anthropic-only');
+      expect(onDisk.lineups.anthropic.roles.orchestrator.premium.provider).toBe('anthropic');
     });
 
     it('reseeds when the file is corrupt JSON', async () => {
@@ -110,6 +136,71 @@ describe('lineups store', () => {
       const lineups = m.loadLineups();
       expect(lineups.junk).toBeUndefined();
       expect(lineups.anthropic).toBeDefined();
+    });
+  });
+
+  describe('migration (legacy flat → role-keyed)', () => {
+    it('replicates a legacy flat lineup across all roles and rewrites the file', async () => {
+      fs.mkdirSync(path.join(tmpDir, 'bernard'), { recursive: true });
+      const filePath = path.join(tmpDir, 'bernard', 'lineups.json');
+      // Pre-#264 flat shape: premium/mid/cheap at the top level, no `roles`.
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({
+          lineups: {
+            legacy: {
+              id: 'legacy',
+              name: 'Legacy',
+              premium: SAMPLE.premium,
+              mid: SAMPLE.mid,
+              cheap: SAMPLE.cheap,
+              createdAt: 'c',
+              updatedAt: 'u',
+            },
+          },
+        }),
+      );
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(lineups.legacy).toBeDefined();
+      // Every role inherits the old cost ladder verbatim.
+      for (const role of ALL_ROLE_IDS) {
+        expect(lineups.legacy.roles[role].premium).toEqual(SAMPLE.premium);
+        expect(lineups.legacy.roles[role].mid).toEqual(SAMPLE.mid);
+        expect(lineups.legacy.roles[role].cheap).toEqual(SAMPLE.cheap);
+      }
+      // The on-disk shape was upgraded: role-keyed, no top-level flat slots.
+      const onDisk = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(onDisk.lineups.legacy.roles).toBeDefined();
+      expect(onDisk.lineups.legacy.premium).toBeUndefined();
+    });
+
+    it('backfills a role missing from a stored role-keyed lineup', async () => {
+      fs.mkdirSync(path.join(tmpDir, 'bernard'), { recursive: true });
+      const partial = fullRoles(SAMPLE);
+      // Simulate a lineup saved before the `coder` role existed.
+      delete partial.coder;
+      fs.writeFileSync(
+        path.join(tmpDir, 'bernard', 'lineups.json'),
+        JSON.stringify({
+          lineups: {
+            partial: {
+              id: 'partial',
+              name: 'Partial',
+              roles: partial,
+              createdAt: 'c',
+              updatedAt: 'u',
+            },
+          },
+        }),
+      );
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      // coder is backfilled from the orchestrator anchor.
+      expect(lineups.partial.roles.coder).toBeDefined();
+      expect(lineups.partial.roles.coder.premium).toEqual(
+        lineups.partial.roles.orchestrator.premium,
+      );
     });
   });
 
@@ -139,45 +230,32 @@ describe('lineups store', () => {
       const m = await loadModule();
       const entry = m.saveLineup({
         name: 'My Mix',
-        premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
-        mid: { provider: 'openai', model: 'gpt-4.1' },
-        cheap: { provider: 'xai', model: 'grok-3-mini' },
+        roles: fullRoles(SAMPLE) as never,
       });
       expect(entry.id).toBe('my-mix');
-      expect(entry.mid.provider).toBe('openai');
+      expect(entry.roles.executor.mid.provider).toBe('openai');
       const all = m.loadLineups();
       expect(all['my-mix']).toBeDefined();
     });
 
     it('updates an existing lineup in place', async () => {
       const m = await loadModule();
-      m.saveLineup({
-        id: 'mix',
-        name: 'Mix',
-        premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
-        mid: { provider: 'openai', model: 'gpt-4.1' },
-        cheap: { provider: 'xai', model: 'grok-3-mini' },
-      });
-      const updated = m.saveLineup({
-        id: 'mix',
-        name: 'Mix',
-        premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
-        mid: { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-        cheap: { provider: 'xai', model: 'grok-3-mini' },
-      });
-      expect(updated.mid.provider).toBe('anthropic');
+      m.saveLineup({ id: 'mix', name: 'Mix', roles: fullRoles(SAMPLE) as never });
+      const tweaked = fullRoles(SAMPLE);
+      tweaked.executor.mid = { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' };
+      const updated = m.saveLineup({ id: 'mix', name: 'Mix', roles: tweaked as never });
+      expect(updated.roles.executor.mid.provider).toBe('anthropic');
+      // Other roles untouched.
+      expect(updated.roles.orchestrator.mid.provider).toBe('openai');
     });
 
-    it('rejects empty slot fields', async () => {
+    it('rejects empty slot fields with a role+tier message', async () => {
       const m = await loadModule();
-      expect(() =>
-        m.saveLineup({
-          name: 'Bad',
-          premium: { provider: '', model: 'x' },
-          mid: { provider: 'anthropic', model: 'x' },
-          cheap: { provider: 'anthropic', model: 'x' },
-        }),
-      ).toThrow(/premium/);
+      const bad = fullRoles(SAMPLE);
+      bad.orchestrator.premium = { provider: '', model: 'x' };
+      expect(() => m.saveLineup({ name: 'Bad', roles: bad as never })).toThrow(
+        /orchestrator.*premium/,
+      );
     });
 
     it('renameLineup updates the display name', async () => {

--- a/src/lineups.test.ts
+++ b/src/lineups.test.ts
@@ -3,26 +3,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { ALL_ROLE_IDS } from './model-roles.js';
+import { fullRoles, type Ladder } from './__tests__/lineup-fixtures.js';
 
 async function loadModule() {
   vi.resetModules();
   return import('./lineups.js');
-}
-
-type Slot = { provider: string; model: string };
-type Ladder = { premium: Slot; mid: Slot; cheap: Slot };
-
-/** Builds a full `role → ladder` map by replicating one ladder across roles. */
-function fullRoles(ladder: Ladder): Record<string, Ladder> {
-  const out: Record<string, Ladder> = {};
-  for (const r of ALL_ROLE_IDS) {
-    out[r] = {
-      premium: { ...ladder.premium },
-      mid: { ...ladder.mid },
-      cheap: { ...ladder.cheap },
-    };
-  }
-  return out;
 }
 
 const SAMPLE: Ladder = {

--- a/src/lineups.ts
+++ b/src/lineups.ts
@@ -1,22 +1,32 @@
 /**
  * @module lineups
  *
- * Disk-backed registry of **tier lineups**. A lineup is a user-named mapping
- * of `{premium, mid, cheap}` → `(provider, model)` pairs. The active profile
- * (`ProfileSettings.activeLineupId`) selects which lineup `resolveSiteModel`
- * consults when `config.modelMode` is on, replacing the legacy hard-coded
- * `PROVIDER_TIERS` table.
+ * Disk-backed registry of **lineups**. A lineup is a user-named 2D matrix
+ * binding `(role, cost-tier) → (provider, model)` (#264). The *cost tier*
+ * (`premium / mid / cheap`) is how much model to spend; the *role*
+ * (orchestrator, executor, function-caller, summarizer, classifier, coder —
+ * see {@link module:model-roles}) is what kind of work the call site does.
+ * Each role carries its own `{premium, mid, cheap}` ladder, so a user can give
+ * e.g. their `coder` role a top-tier model in performance mode and a cheaper
+ * one in token-saving mode.
  *
- * Lineups may freely mix providers — built-in or custom — for any tier. This
- * dissolves the previous "active provider" concept (which silently broke
- * tiered model-resolution for custom/local providers because they had no
- * `PROVIDER_TIERS` entry).
+ * The active profile (`ProfileSettings.activeLineupId`) selects which lineup
+ * `resolveSiteModel` consults: `site → role` (static) → `tier`
+ * (via `config.modelMode`) → `lineup.roles[role][tier]`.
+ *
+ * Lineups may freely mix providers — built-in or custom — for any (role, tier)
+ * cell. This dissolves the previous "active provider" concept.
  *
  * Storage: `~/.config/bernard/lineups.json`.
  *
  * Lineups themselves are **global**, shared across profiles, just like
  * `custom-providers.json` and `keys.json`. Only the *selection* is profile-
  * scoped.
+ *
+ * Pre-#264 lineups stored flat top-level `{premium, mid, cheap}` slots; those
+ * are auto-migrated on load by replicating each cost slot across all roles
+ * (see {@link migrateLineupShape}), so behavior is identical until a user
+ * customizes a role.
  */
 
 import * as fs from 'node:fs';
@@ -26,8 +36,9 @@ import { atomicWriteFileSync } from './fs-utils.js';
 import { getCatalogForProvider } from './providers/catalog.js';
 import { deriveTiers } from './providers/tiers.js';
 import { BUILTIN_PROVIDERS, type BuiltinProvider } from './providers/types.js';
+import { ALL_ROLE_IDS, type RoleId } from './model-roles.js';
 
-/** The three tier slots every lineup must define. */
+/** The three cost-tier slots every role defines. */
 export const LINEUP_TIERS = ['premium', 'mid', 'cheap'] as const;
 export type LineupTier = (typeof LINEUP_TIERS)[number];
 
@@ -37,15 +48,17 @@ export interface LineupSlot {
   model: string;
 }
 
-/** A single named tier lineup. */
+/** The `{premium, mid, cheap}` cost ladder for one role. */
+export type RoleSlots = Record<LineupTier, LineupSlot>;
+
+/** A single named lineup: a `role → {premium, mid, cheap}` matrix. */
 export interface Lineup {
   /** Stable id used for `activeLineupId` lookups. Lowercase slug. */
   id: string;
   /** User-editable display name. */
   name: string;
-  premium: LineupSlot;
-  mid: LineupSlot;
-  cheap: LineupSlot;
+  /** Per-role cost ladders. Always covers every {@link RoleId}. */
+  roles: Record<RoleId, RoleSlots>;
   createdAt: string;
   updatedAt: string;
 }
@@ -154,6 +167,27 @@ function isLineupSlot(v: unknown): v is LineupSlot {
   );
 }
 
+function isRoleSlots(v: unknown): v is RoleSlots {
+  if (!v || typeof v !== 'object') return false;
+  return LINEUP_TIERS.every((tier) => isLineupSlot((v as Record<string, unknown>)[tier]));
+}
+
+/** Deep-copies one `{premium, mid, cheap}` ladder (no shared slot refs). */
+function cloneRoleSlots(slots: RoleSlots): RoleSlots {
+  return {
+    premium: { ...slots.premium },
+    mid: { ...slots.mid },
+    cheap: { ...slots.cheap },
+  };
+}
+
+/** Builds a full `role → ladder` map, replicating one ladder across every role. */
+function replicateAcrossRoles(slots: RoleSlots): Record<RoleId, RoleSlots> {
+  const out = {} as Record<RoleId, RoleSlots>;
+  for (const role of ALL_ROLE_IDS) out[role] = cloneRoleSlots(slots);
+  return out;
+}
+
 function writeFile(lineups: Record<string, Lineup>): void {
   fs.mkdirSync(path.dirname(LINEUPS_PATH), { recursive: true });
   const payload: LineupsFile = { lineups };
@@ -172,12 +206,15 @@ function seedForProvider(provider: BuiltinProvider, now: string): Lineup {
   } else {
     tiers = FALLBACK_TIERS[provider];
   }
-  return {
-    id: provider,
-    name: `${PROVIDER_DISPLAY_NAMES[provider]}-only`,
+  const ladder: RoleSlots = {
     premium: { provider, model: tiers.premium },
     mid: { provider, model: tiers.mid },
     cheap: { provider, model: tiers.cheap },
+  };
+  return {
+    id: provider,
+    name: `${PROVIDER_DISPLAY_NAMES[provider]}-only`,
+    roles: replicateAcrossRoles(ladder),
     createdAt: now,
     updatedAt: now,
   };
@@ -217,10 +254,78 @@ export function seedDefaultLineups(existing: Record<string, Lineup>): Record<str
 }
 
 /**
+ * Normalizes one stored lineup entry into the current role-keyed shape,
+ * migrating where needed. Returns `null` for unrecoverable entries (caller
+ * drops them and re-seeds if the map ends up empty).
+ *
+ * Handled shapes:
+ *  1. **Old flat** (`{premium, mid, cheap}` at top level, no `roles`): replicate
+ *     the cost ladder across every role → behavior identical to pre-#264.
+ *  2. **Role-keyed** (`{roles: {...}}`): validate each known role; backfill any
+ *     role missing from `ALL_ROLE_IDS` (e.g. a role added after this lineup was
+ *     saved) from an anchor role (`orchestrator`, else the first valid role).
+ *  3. **Neither**: `null`.
+ *
+ * Sets `mutatedRef.value = true` whenever it changes the on-disk shape so the
+ * caller can persist the upgrade.
+ */
+function migrateLineupShape(
+  id: string,
+  entry: unknown,
+  mutatedRef: { value: boolean },
+): Lineup | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = entry as Record<string, unknown>;
+  if (typeof e.id !== 'string' || typeof e.name !== 'string') return null;
+  const createdAt = typeof e.createdAt === 'string' ? e.createdAt : nowIso();
+  const updatedAt = typeof e.updatedAt === 'string' ? e.updatedAt : nowIso();
+
+  // Case 2 — already role-keyed.
+  if (e.roles && typeof e.roles === 'object') {
+    const stored = e.roles as Record<string, unknown>;
+    // Anchor for backfilling missing roles: prefer orchestrator, else any valid.
+    const anchorId =
+      ALL_ROLE_IDS.find((r) => isRoleSlots(stored[r])) ?? null;
+    if (!anchorId) return null;
+    const anchor = stored[anchorId] as RoleSlots;
+    const roles = {} as Record<RoleId, RoleSlots>;
+    for (const role of ALL_ROLE_IDS) {
+      if (isRoleSlots(stored[role])) {
+        roles[role] = cloneRoleSlots(stored[role] as RoleSlots);
+      } else {
+        roles[role] = cloneRoleSlots(anchor);
+        mutatedRef.value = true; // backfilled a missing/invalid role
+      }
+    }
+    return { id: e.id, name: e.name, roles, createdAt, updatedAt };
+  }
+
+  // Case 1 — legacy flat shape.
+  if (isLineupSlot(e.premium) && isLineupSlot(e.mid) && isLineupSlot(e.cheap)) {
+    mutatedRef.value = true;
+    const ladder: RoleSlots = {
+      premium: e.premium,
+      mid: e.mid,
+      cheap: e.cheap,
+    };
+    return {
+      id: e.id,
+      name: e.name,
+      roles: replicateAcrossRoles(ladder),
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  return null;
+}
+
+/**
  * Reads `lineups.json`. If the file is missing or unparseable, seeds the
  * three built-in provider lineups, persists them, and returns the result.
  * Always returns at least the seeded set so callers never have to handle an
- * empty-map case.
+ * empty-map case. Auto-migrates legacy flat lineups and backfills newly-added
+ * roles, persisting the upgraded shape when anything changed.
  */
 export function loadLineups(): Record<string, Lineup> {
   try {
@@ -233,28 +338,22 @@ export function loadLineups(): Record<string, Lineup> {
       typeof parsed.lineups === 'object'
     ) {
       const out: Record<string, Lineup> = {};
+      const mutatedRef = { value: false };
       for (const [id, entry] of Object.entries(parsed.lineups)) {
-        if (!entry || typeof entry !== 'object') continue;
-        const e = entry as Partial<Lineup>;
-        if (
-          typeof e.id === 'string' &&
-          typeof e.name === 'string' &&
-          isLineupSlot(e.premium) &&
-          isLineupSlot(e.mid) &&
-          isLineupSlot(e.cheap)
-        ) {
-          out[id] = {
-            id: e.id,
-            name: e.name,
-            premium: e.premium,
-            mid: e.mid,
-            cheap: e.cheap,
-            createdAt: typeof e.createdAt === 'string' ? e.createdAt : nowIso(),
-            updatedAt: typeof e.updatedAt === 'string' ? e.updatedAt : nowIso(),
-          };
-        }
+        const migrated = migrateLineupShape(id, entry, mutatedRef);
+        if (migrated) out[id] = migrated;
+        else mutatedRef.value = true; // dropped a corrupt entry
       }
-      if (Object.keys(out).length > 0) return out;
+      if (Object.keys(out).length > 0) {
+        if (mutatedRef.value) {
+          try {
+            writeFile(out);
+          } catch {
+            // best-effort; the in-memory migration still applies this session
+          }
+        }
+        return out;
+      }
     }
   } catch {
     // fall through to seed
@@ -295,9 +394,7 @@ export function resolveActiveLineup(
 export interface SaveLineupInput {
   id?: string;
   name: string;
-  premium: LineupSlot;
-  mid: LineupSlot;
-  cheap: LineupSlot;
+  roles: Record<RoleId, RoleSlots>;
 }
 
 /**
@@ -309,10 +406,14 @@ export interface SaveLineupInput {
 export function saveLineup(input: SaveLineupInput): Lineup {
   const nameErr = validateLineupName(input.name);
   if (nameErr) throw new Error(nameErr);
-  for (const tier of LINEUP_TIERS) {
-    const slot = input[tier];
-    if (!isLineupSlot(slot)) {
-      throw new Error(`Tier "${tier}" must have non-empty provider and model.`);
+  for (const role of ALL_ROLE_IDS) {
+    const ladder = input.roles[role];
+    for (const tier of LINEUP_TIERS) {
+      if (!isLineupSlot(ladder?.[tier])) {
+        throw new Error(
+          `Role "${role}" tier "${tier}" must have non-empty provider and model.`,
+        );
+      }
     }
   }
   const existing = loadLineups();
@@ -320,12 +421,12 @@ export function saveLineup(input: SaveLineupInput): Lineup {
   const idErr = validateLineupId(id);
   if (idErr) throw new Error(idErr);
   const now = nowIso();
+  const roles = {} as Record<RoleId, RoleSlots>;
+  for (const role of ALL_ROLE_IDS) roles[role] = cloneRoleSlots(input.roles[role]);
   const entry: Lineup = {
     id,
     name: input.name.trim(),
-    premium: input.premium,
-    mid: input.mid,
-    cheap: input.cheap,
+    roles,
     createdAt: existing[id]?.createdAt ?? now,
     updatedAt: now,
   };

--- a/src/lineups.ts
+++ b/src/lineups.ts
@@ -391,6 +391,40 @@ export function resolveActiveLineup(
   return first;
 }
 
+/** Outcome of {@link resolveActiveLineupWithCorrection}. */
+export interface LineupResolution {
+  /** The lineup that will actually be used. */
+  lineup: Lineup;
+  /**
+   * Set only when `activeLineupId` was non-empty but pointed at a lineup that
+   * doesn't exist (e.g. a stale id left over from a deleted lineup, or a typo in
+   * a hand-edited profile). Carries the id that was requested and the id we fell
+   * back to, so the caller can persist the correction and tell the user.
+   */
+  corrected?: { requestedId: string; resolvedId: string };
+}
+
+/**
+ * Like {@link resolveActiveLineup}, but additionally reports whether the
+ * requested `activeLineupId` was *invalid* (set, but absent from `lineups`).
+ * When that happens the caller should persist `corrected.resolvedId` back onto
+ * the active profile and surface a note so the silent fallback isn't invisible.
+ *
+ * An empty/undefined `activeLineupId` is NOT a correction — that's the normal
+ * "no explicit selection, use the provider/first fallback" path.
+ */
+export function resolveActiveLineupWithCorrection(
+  lineups: Record<string, Lineup>,
+  activeLineupId: string | undefined,
+  fallbackProviderName: string | undefined,
+): LineupResolution {
+  const lineup = resolveActiveLineup(lineups, activeLineupId, fallbackProviderName);
+  if (activeLineupId && !lineups[activeLineupId]) {
+    return { lineup, corrected: { requestedId: activeLineupId, resolvedId: lineup.id } };
+  }
+  return { lineup };
+}
+
 export interface SaveLineupInput {
   id?: string;
   name: string;

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -4,6 +4,23 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { BernardConfig } from './config.js';
 import type { Specialist } from './specialists.js';
+import { ALL_ROLE_IDS } from './model-roles.js';
+
+type Slot = { provider: string; model: string };
+type Ladder = { premium: Slot; mid: Slot; cheap: Slot };
+
+/** Replicates one cost ladder across all 6 roles (the migration shape). */
+function fullRoles(ladder: Ladder): Record<string, Ladder> {
+  const out: Record<string, Ladder> = {};
+  for (const r of ALL_ROLE_IDS) {
+    out[r] = {
+      premium: { ...ladder.premium },
+      mid: { ...ladder.mid },
+      cheap: { ...ladder.cheap },
+    };
+  }
+  return out;
+}
 
 vi.mock('./logger.js', () => ({
   debugLog: vi.fn(),
@@ -81,27 +98,33 @@ function seedTestLineups(dir: string): void {
           anthropic: {
             id: 'anthropic',
             name: 'Anthropic-only',
-            premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
-            mid: { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-            cheap: { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
+            roles: fullRoles({
+              premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
+              mid: { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
+              cheap: { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' },
+            }),
             createdAt: now,
             updatedAt: now,
           },
           openai: {
             id: 'openai',
             name: 'OpenAI-only',
-            premium: { provider: 'openai', model: 'gpt-5.2' },
-            mid: { provider: 'openai', model: 'gpt-4.1' },
-            cheap: { provider: 'openai', model: 'gpt-4.1-mini' },
+            roles: fullRoles({
+              premium: { provider: 'openai', model: 'gpt-5.2' },
+              mid: { provider: 'openai', model: 'gpt-4.1' },
+              cheap: { provider: 'openai', model: 'gpt-4.1-mini' },
+            }),
             createdAt: now,
             updatedAt: now,
           },
           xai: {
             id: 'xai',
             name: 'xAI-only',
-            premium: { provider: 'xai', model: 'grok-4-1-fast-reasoning' },
-            mid: { provider: 'xai', model: 'grok-4-fast-non-reasoning' },
-            cheap: { provider: 'xai', model: 'grok-3-mini' },
+            roles: fullRoles({
+              premium: { provider: 'xai', model: 'grok-4-1-fast-reasoning' },
+              mid: { provider: 'xai', model: 'grok-4-fast-non-reasoning' },
+              cheap: { provider: 'xai', model: 'grok-3-mini' },
+            }),
             createdAt: now,
             updatedAt: now,
           },
@@ -271,9 +294,11 @@ describe('resolveSiteModel — cross-provider lineup', () => {
           mixed: {
             id: 'mixed',
             name: 'Mixed',
-            premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
-            mid: { provider: 'openai', model: 'gpt-4.1' },
-            cheap: { provider: 'xai', model: 'grok-3-mini' },
+            roles: fullRoles({
+              premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
+              mid: { provider: 'openai', model: 'gpt-4.1' },
+              cheap: { provider: 'xai', model: 'grok-3-mini' },
+            }),
             createdAt: '2026-01-01T00:00:00.000Z',
             updatedAt: '2026-01-01T00:00:00.000Z',
           },

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -4,23 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { BernardConfig } from './config.js';
 import type { Specialist } from './specialists.js';
-import { ALL_ROLE_IDS } from './model-roles.js';
-
-type Slot = { provider: string; model: string };
-type Ladder = { premium: Slot; mid: Slot; cheap: Slot };
-
-/** Replicates one cost ladder across all 6 roles (the migration shape). */
-function fullRoles(ladder: Ladder): Record<string, Ladder> {
-  const out: Record<string, Ladder> = {};
-  for (const r of ALL_ROLE_IDS) {
-    out[r] = {
-      premium: { ...ladder.premium },
-      mid: { ...ladder.mid },
-      cheap: { ...ladder.cheap },
-    };
-  }
-  return out;
-}
+import { fullRoles } from './__tests__/lineup-fixtures.js';
 
 vi.mock('./logger.js', () => ({
   debugLog: vi.fn(),

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -38,14 +38,15 @@ export type ModelMode = 'optimize-tokens' | 'balanced' | 'optimize-performance';
 export type ModelTier = 'cheap' | 'mid' | 'premium';
 
 /**
- * Resolves the cost tier for a call site under the active `modelMode`. Two
- * steps, both data-driven from {@link module:model-roles}: `site → role`
- * (via {@link SITE_ROLE}) → `tier` (via {@link DEFAULT_ROLE_TIERS}). This
- * replaces the legacy hardcoded per-site `TIER_TABLE`; the role tier rows
- * reproduce the old per-site assignments exactly (#264).
+ * Resolves the cost tier for a functional role under the active `modelMode`,
+ * data-driven from {@link DEFAULT_ROLE_TIERS} in {@link module:model-roles}.
+ * Callers map `site → role` via {@link SITE_ROLE} first (they already need the
+ * role for the lineup-slot lookup and the snapshot log). This replaces the
+ * legacy hardcoded per-site `TIER_TABLE`; the role tier rows reproduce the old
+ * per-site assignments exactly (#264).
  */
-function tierForSite(mode: ModelMode, site: ModelSite): ModelTier {
-  return DEFAULT_ROLE_TIERS[mode][SITE_ROLE[site]];
+function tierForRole(mode: ModelMode, role: RoleId): ModelTier {
+  return DEFAULT_ROLE_TIERS[mode][role];
 }
 
 /** True when `mode` is a recognized {@link ModelMode}. */
@@ -209,7 +210,7 @@ export function resolveSiteModel(
   // test fixtures) to `'balanced'` so resolution never crashes.
   const mode: ModelMode = isKnownMode(config.modelMode) ? config.modelMode : 'balanced';
   const role = SITE_ROLE[site];
-  const tier = tierForSite(mode, site);
+  const tier = tierForRole(mode, role);
   const lineup = getActiveLineup();
   const slot = lineup.roles[role][tier];
   if (hasProviderKey(config, slot.provider)) {
@@ -350,7 +351,7 @@ export function snapshotSiteModels(config: BernardConfig): SiteModelSnapshot {
   const sites = {} as Record<ModelSite, SiteModelSnapshotEntry>;
   for (const site of ALL_MODEL_SITES) {
     const role = SITE_ROLE[site];
-    const tier = tierForSite(mode, site);
+    const tier = tierForRole(mode, role);
     const slot = lineup.roles[role][tier];
     if (hasProviderKey(config, slot.provider)) {
       sites[site] = {

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -9,6 +9,7 @@ import {
 } from './config.js';
 import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
 import { loadLineups, resolveActiveLineup, type Lineup } from './lineups.js';
+import { DEFAULT_ROLE_TIERS, SITE_ROLE, type RoleId } from './model-roles.js';
 import { debugLog } from './logger.js';
 
 /**
@@ -37,41 +38,20 @@ export type ModelMode = 'optimize-tokens' | 'balanced' | 'optimize-performance';
 export type ModelTier = 'cheap' | 'mid' | 'premium';
 
 /**
- * Per-site tier assignment for each `ModelMode`. The tier maps to a concrete
- * `(provider, model)` via the user's active lineup (`src/lineups.ts`).
+ * Resolves the cost tier for a call site under the active `modelMode`. Two
+ * steps, both data-driven from {@link module:model-roles}: `site → role`
+ * (via {@link SITE_ROLE}) → `tier` (via {@link DEFAULT_ROLE_TIERS}). This
+ * replaces the legacy hardcoded per-site `TIER_TABLE`; the role tier rows
+ * reproduce the old per-site assignments exactly (#264).
  */
-const TIER_TABLE: Record<ModelMode, Record<ModelSite, ModelTier>> = {
-  'optimize-tokens': {
-    main: 'mid',
-    specialist: 'cheap',
-    'tool-wrapper': 'cheap',
-    compressor: 'cheap',
-    'specialist-detector': 'cheap',
-    rewriter: 'cheap',
-    'reference-resolver': 'cheap',
-    'reference-lookup': 'cheap',
-  },
-  balanced: {
-    main: 'premium',
-    specialist: 'mid',
-    'tool-wrapper': 'mid',
-    compressor: 'mid',
-    'specialist-detector': 'cheap',
-    rewriter: 'cheap',
-    'reference-resolver': 'cheap',
-    'reference-lookup': 'cheap',
-  },
-  'optimize-performance': {
-    main: 'premium',
-    specialist: 'premium',
-    'tool-wrapper': 'premium',
-    compressor: 'premium',
-    'specialist-detector': 'premium',
-    rewriter: 'premium',
-    'reference-resolver': 'premium',
-    'reference-lookup': 'premium',
-  },
-};
+function tierForSite(mode: ModelMode, site: ModelSite): ModelTier {
+  return DEFAULT_ROLE_TIERS[mode][SITE_ROLE[site]];
+}
+
+/** True when `mode` is a recognized {@link ModelMode}. */
+function isKnownMode(mode: unknown): mode is ModelMode {
+  return mode === 'optimize-tokens' || mode === 'balanced' || mode === 'optimize-performance';
+}
 
 /**
  * Normalizes any modelMode-shaped value read from disk or env. Returns the
@@ -190,11 +170,7 @@ export function resolveSiteModel(
         specialistProvider: specialist.provider,
         specialistModel: specialist.model,
         lineupId: activeLineup.id,
-        lineupProviders: [
-          activeLineup.premium.provider,
-          activeLineup.mid.provider,
-          activeLineup.cheap.provider,
-        ],
+        lineupProviders: lineupProviders(activeLineup),
         reason: 'pin-dropped',
       });
       specialist.provider = undefined;
@@ -231,10 +207,11 @@ export function resolveSiteModel(
   // Step 3 — tier-table lookup against the active lineup. Defensively
   // normalize an unknown/undefined `modelMode` (legacy `'off'`, missing key in
   // test fixtures) to `'balanced'` so resolution never crashes.
-  const mode: ModelMode = TIER_TABLE[config.modelMode] ? config.modelMode : 'balanced';
-  const tier = TIER_TABLE[mode][site];
+  const mode: ModelMode = isKnownMode(config.modelMode) ? config.modelMode : 'balanced';
+  const role = SITE_ROLE[site];
+  const tier = tierForSite(mode, site);
   const lineup = getActiveLineup();
-  const slot = lineup[tier];
+  const slot = lineup.roles[role][tier];
   if (hasProviderKey(config, slot.provider)) {
     return buildSiteModel(config, slot.provider, slot.model, 'policy', site, tier, lineup);
   }
@@ -274,13 +251,23 @@ function loadActiveLineup(config: BernardConfig): Lineup {
   return resolveActiveLineup(lineups, config.activeLineupId, config.provider);
 }
 
-/** True when any tier slot of the lineup is bound to the given provider. */
+/** True when any role×tier slot of the lineup is bound to the given provider. */
 function isProviderInLineup(provider: string, lineup: Lineup): boolean {
-  return (
-    lineup.premium.provider === provider ||
-    lineup.mid.provider === provider ||
-    lineup.cheap.provider === provider
-  );
+  for (const ladder of Object.values(lineup.roles)) {
+    for (const slot of Object.values(ladder)) {
+      if (slot.provider === provider) return true;
+    }
+  }
+  return false;
+}
+
+/** Unique provider names referenced anywhere in the lineup (debug logging). */
+function lineupProviders(lineup: Lineup): string[] {
+  const out = new Set<string>();
+  for (const ladder of Object.values(lineup.roles)) {
+    for (const slot of Object.values(ladder)) out.add(slot.provider);
+  }
+  return [...out];
 }
 
 function buildSiteModel(
@@ -333,6 +320,7 @@ export function _resetModelPolicyLogCacheForTests(): void {
 
 export interface SiteModelSnapshotEntry {
   site: ModelSite;
+  role: RoleId;
   tier: ModelTier | undefined;
   provider: string;
   model: string;
@@ -357,15 +345,17 @@ export interface SiteModelSnapshot {
  * implementation note below).
  */
 export function snapshotSiteModels(config: BernardConfig): SiteModelSnapshot {
-  const mode: ModelMode = TIER_TABLE[config.modelMode] ? config.modelMode : 'balanced';
+  const mode: ModelMode = isKnownMode(config.modelMode) ? config.modelMode : 'balanced';
   const lineup = loadActiveLineup(config);
   const sites = {} as Record<ModelSite, SiteModelSnapshotEntry>;
   for (const site of ALL_MODEL_SITES) {
-    const tier = TIER_TABLE[mode][site];
-    const slot = lineup[tier];
+    const role = SITE_ROLE[site];
+    const tier = tierForSite(mode, site);
+    const slot = lineup.roles[role][tier];
     if (hasProviderKey(config, slot.provider)) {
       sites[site] = {
         site,
+        role,
         tier,
         provider: slot.provider,
         model: slot.model,
@@ -374,6 +364,7 @@ export function snapshotSiteModels(config: BernardConfig): SiteModelSnapshot {
     } else {
       sites[site] = {
         site,
+        role,
         tier,
         provider: config.provider,
         model: config.model,

--- a/src/model-roles.ts
+++ b/src/model-roles.ts
@@ -38,6 +38,12 @@ export interface ModelRole {
   /** One-line description shown in the lineup editor for discoverability. */
   description: string;
   /**
+   * Guidance shown in the lineup editor's detail card: *what kind of model to
+   * look for* when binding this role. Phrased as advice to the user choosing a
+   * model, not a description of the role's job (that's {@link description}).
+   */
+  lookFor: string;
+  /**
    * Per-`ModelMode` cost-tier assignment for this role. This is the data behind
    * the legacy `TIER_TABLE` — re-keyed from `[mode][site]` to `[mode][role]`.
    * The values reproduce Bernard's pre-#264 per-site behavior exactly (every
@@ -64,6 +70,8 @@ export const MODEL_ROLES: readonly ModelRole[] = [
     id: 'orchestrator',
     label: 'Orchestrator',
     description: 'Main interactive agent + cron — long-context planning & tool orchestration.',
+    lookFor:
+      'A strong long-context reasoner with dependable tool-calling. This model drives every turn — favor capability over cost.',
     defaultTiers: {
       'optimize-tokens': 'mid',
       balanced: 'premium',
@@ -74,6 +82,8 @@ export const MODEL_ROLES: readonly ModelRole[] = [
     id: 'executor',
     label: 'Task executor',
     description: 'Sub-agents, specialists & tasks — focused multi-step execution of delegated work.',
+    lookFor:
+      'A capable all-rounder that follows multi-step instructions and uses tools reliably. Balance cost against how much delegated work you run.',
     defaultTiers: {
       'optimize-tokens': 'cheap',
       balanced: 'mid',
@@ -84,6 +94,8 @@ export const MODEL_ROLES: readonly ModelRole[] = [
     id: 'function-caller',
     label: 'Function caller',
     description: 'Tool-wrapper specialists — natural language → schema-conformant structured calls.',
+    lookFor:
+      'A fast model with strong structured-output / JSON adherence. Argument accuracy matters more than deep reasoning here.',
     defaultTiers: {
       'optimize-tokens': 'cheap',
       balanced: 'mid',
@@ -94,6 +106,8 @@ export const MODEL_ROLES: readonly ModelRole[] = [
     id: 'summarizer',
     label: 'Summarizer',
     description: 'History compression & fact extraction — synthesis, not reasoning.',
+    lookFor:
+      'A model good at faithful synthesis and extraction. It runs on every compression, so lean cost-efficient.',
     defaultTiers: {
       'optimize-tokens': 'cheap',
       balanced: 'mid',
@@ -104,6 +118,8 @@ export const MODEL_ROLES: readonly ModelRole[] = [
     id: 'classifier',
     label: 'Classifier / router',
     description: 'Rewriter, reference resolver/lookup, specialist detector — cheap single-shot decisions.',
+    lookFor:
+      'The cheapest model that still judges reliably. These are quick single-shot routing calls where latency and price dominate.',
     defaultTiers: {
       'optimize-tokens': 'cheap',
       balanced: 'cheap',
@@ -114,6 +130,8 @@ export const MODEL_ROLES: readonly ModelRole[] = [
     id: 'coder',
     label: 'Coder',
     description: 'Reserved for a future dedicated code-generation role (no call site yet).',
+    lookFor:
+      'A model strong at code generation and editing. Reserved — no call site uses this role yet, but it is fully configurable.',
     defaultTiers: {
       'optimize-tokens': 'cheap',
       balanced: 'mid',

--- a/src/model-roles.ts
+++ b/src/model-roles.ts
@@ -1,0 +1,167 @@
+/**
+ * @module model-roles
+ *
+ * **Single source of truth** for Bernard's functional model *roles* (#264).
+ *
+ * A lineup binds models along two orthogonal axes:
+ *  - **Cost tier** (`premium / mid / cheap`, see {@link module:lineups}) — how
+ *    much model to spend. `config.modelMode` moves every call site up/down this
+ *    axis.
+ *  - **Role** (defined here) — *what kind of work* the call site is doing
+ *    (orchestration, delegated execution, structured tool-calling, summarizing,
+ *    classification, …). The role selects which model *family* does the job;
+ *    the tier selects how strong a model within that family.
+ *
+ * Everything role-related derives from {@link MODEL_ROLES}: the lineup slot
+ * keys, the per-mode tier table ({@link DEFAULT_ROLE_TIERS}), the editor menu,
+ * and the snapshot logging. Adding a 7th role is a one-place additive edit
+ * here — declare it in `MODEL_ROLES` (and point a call site at it via
+ * {@link SITE_ROLE} when one exists).
+ */
+
+import type { ModelSite, ModelTier, ModelMode } from './model-policy.js';
+
+/** Stable identifier for a functional model role. */
+export type RoleId =
+  | 'orchestrator'
+  | 'executor'
+  | 'function-caller'
+  | 'summarizer'
+  | 'classifier'
+  | 'coder';
+
+/** A single role definition. The whole role system is derived from this list. */
+export interface ModelRole {
+  id: RoleId;
+  /** Short human label for menus. */
+  label: string;
+  /** One-line description shown in the lineup editor for discoverability. */
+  description: string;
+  /**
+   * Per-`ModelMode` cost-tier assignment for this role. This is the data behind
+   * the legacy `TIER_TABLE` — re-keyed from `[mode][site]` to `[mode][role]`.
+   * The values reproduce Bernard's pre-#264 per-site behavior exactly (every
+   * site that maps to a role inherits that role's tier row).
+   */
+  defaultTiers: Record<ModelMode, ModelTier>;
+}
+
+/**
+ * The canonical role list. ORDER MATTERS — it's the display order in the
+ * lineup editor.
+ *
+ * Tier rows reproduce the legacy `TIER_TABLE`:
+ *  - orchestrator ← old `main` row
+ *  - executor     ← old `specialist` row
+ *  - function-caller ← old `tool-wrapper` row
+ *  - summarizer   ← old `compressor` row
+ *  - classifier   ← old `rewriter`/`reference-*`/`specialist-detector` row
+ *  - coder        ← new; mirrors `executor` (mid in balanced) as a reasonable
+ *                   default until a real code-gen call site is wired up.
+ */
+export const MODEL_ROLES: readonly ModelRole[] = [
+  {
+    id: 'orchestrator',
+    label: 'Orchestrator',
+    description: 'Main interactive agent + cron — long-context planning & tool orchestration.',
+    defaultTiers: {
+      'optimize-tokens': 'mid',
+      balanced: 'premium',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'executor',
+    label: 'Task executor',
+    description: 'Sub-agents, specialists & tasks — focused multi-step execution of delegated work.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'function-caller',
+    label: 'Function caller',
+    description: 'Tool-wrapper specialists — natural language → schema-conformant structured calls.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'summarizer',
+    label: 'Summarizer',
+    description: 'History compression & fact extraction — synthesis, not reasoning.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'classifier',
+    label: 'Classifier / router',
+    description: 'Rewriter, reference resolver/lookup, specialist detector — cheap single-shot decisions.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'cheap',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'coder',
+    label: 'Coder',
+    description: 'Reserved for a future dedicated code-generation role (no call site yet).',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+];
+
+/** Every role id, in display order. Iterate this for lineup slots / editor. */
+export const ALL_ROLE_IDS: readonly RoleId[] = MODEL_ROLES.map((r) => r.id);
+
+/** Lookup a role definition by id. */
+export function getRole(id: RoleId): ModelRole {
+  const r = MODEL_ROLES.find((x) => x.id === id);
+  if (!r) throw new Error(`Unknown model role "${id}".`);
+  return r;
+}
+
+/**
+ * `Record<ModelMode, Record<RoleId, ModelTier>>` derived from
+ * `MODEL_ROLES[*].defaultTiers`. This is the new `TIER_TABLE`: given the active
+ * `modelMode` and a role, it yields the cost tier to pull from the lineup.
+ */
+export const DEFAULT_ROLE_TIERS: Record<ModelMode, Record<RoleId, ModelTier>> = (() => {
+  const modes: ModelMode[] = ['optimize-tokens', 'balanced', 'optimize-performance'];
+  const out = {} as Record<ModelMode, Record<RoleId, ModelTier>>;
+  for (const mode of modes) {
+    const row = {} as Record<RoleId, ModelTier>;
+    for (const role of MODEL_ROLES) {
+      row[role.id] = role.defaultTiers[mode];
+    }
+    out[mode] = row;
+  }
+  return out;
+})();
+
+/**
+ * Static map from every policy-resolved call site to its functional role.
+ * Every `ModelSite` must appear here — this is the documented, single-place
+ * assignment required by #264 requirement 2.
+ */
+export const SITE_ROLE: Record<ModelSite, RoleId> = {
+  main: 'orchestrator',
+  specialist: 'executor',
+  'tool-wrapper': 'function-caller',
+  compressor: 'summarizer',
+  rewriter: 'classifier',
+  'reference-resolver': 'classifier',
+  'reference-lookup': 'classifier',
+  'specialist-detector': 'classifier',
+};

--- a/src/model-validate.test.ts
+++ b/src/model-validate.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the AI SDK so probes never hit the network. The fake generateText
+// resolves for "good-*" models and throws shaped errors for the rest.
+const generateTextMock = vi.fn();
+vi.mock('ai', () => ({ generateText: (args: unknown) => generateTextMock(args) }));
+
+// getModelForConfig / getProviderOptionsForConfig are pure passthroughs here.
+vi.mock('./providers/index.js', () => ({
+  getModelForConfig: (_c: unknown, provider: string, model: string) => ({ provider, model }),
+  getProviderOptionsForConfig: () => undefined,
+}));
+
+import { validateModel, validateLineup, formatLineupValidation } from './model-validate.js';
+import { ALL_ROLE_IDS } from './model-roles.js';
+import { LINEUP_TIERS, type Lineup } from './lineups.js';
+
+const config = { provider: 'xai', model: 'm' } as never;
+
+/** Build a full 6×3 lineup where every slot uses the same (provider, model). */
+function uniformLineup(provider: string, model: string): Lineup {
+  const roles = {} as Lineup['roles'];
+  for (const role of ALL_ROLE_IDS) {
+    roles[role] = {} as Lineup['roles'][typeof role];
+    for (const tier of LINEUP_TIERS) roles[role][tier] = { provider, model };
+  }
+  return { id: 'test', name: 'Test', roles, createdAt: 0, updatedAt: 0 };
+}
+
+beforeEach(() => {
+  generateTextMock.mockReset();
+});
+
+describe('validateModel', () => {
+  it('returns ok when the probe call resolves', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    const r = await validateModel(config, 'xai', 'grok-4.3');
+    expect(r.ok).toBe(true);
+    expect(r.category).toBeUndefined();
+    // The probe sends a tiny request (>= OpenAI's 16-token floor).
+    expect(generateTextMock).toHaveBeenCalledOnce();
+    expect(generateTextMock.mock.calls[0]![0].maxTokens).toBeGreaterThanOrEqual(16);
+  });
+
+  it('classifies a "does not exist" message as not_found even on a 400', async () => {
+    generateTextMock.mockRejectedValue(
+      Object.assign(new Error("The requested model 'gpt-5-chat' does not exist."), { statusCode: 400 }),
+    );
+    const r = await validateModel(config, 'openai', 'gpt-5-chat');
+    expect(r.ok).toBe(false);
+    expect(r.category).toBe('not_found');
+  });
+
+  it('classifies a 429 as rate_limit (quota)', async () => {
+    generateTextMock.mockRejectedValue(
+      Object.assign(new Error('You exceeded your current quota'), { statusCode: 429 }),
+    );
+    const r = await validateModel(config, 'openai', 'gpt-5.5');
+    expect(r.category).toBe('rate_limit');
+  });
+
+  it('classifies a 401 as auth', async () => {
+    generateTextMock.mockRejectedValue(Object.assign(new Error('bad key'), { statusCode: 401 }));
+    const r = await validateModel(config, 'openai', 'gpt-5.5');
+    expect(r.category).toBe('auth');
+  });
+});
+
+describe('validateLineup', () => {
+  it('dedupes identical slots to a single probe', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    const v = await validateLineup(config, uniformLineup('xai', 'grok-4.3'));
+    // 18 identical slots collapse to one distinct (provider, model) pair.
+    expect(generateTextMock).toHaveBeenCalledOnce();
+    expect(v.results).toHaveLength(1);
+    expect(v.ok).toBe(true);
+    expect(v.results[0]!.slots).toHaveLength(18);
+  });
+
+  it('reports failures and the slots that use the broken model', async () => {
+    // One bad model in a single slot, the rest good.
+    const lineup = uniformLineup('xai', 'grok-4.3');
+    lineup.roles.executor.cheap = { provider: 'xai', model: 'grok-build-0.1' };
+    generateTextMock.mockImplementation((args: { model: { model: string } }) => {
+      if (args.model.model === 'grok-build-0.1') {
+        return Promise.reject(Object.assign(new Error('Model not found'), { statusCode: 404 }));
+      }
+      return Promise.resolve({ text: 'ok' });
+    });
+    const v = await validateLineup(config, lineup);
+    expect(v.ok).toBe(false);
+    expect(v.failures).toBe(1);
+    const bad = v.results.find((r) => !r.ok)!;
+    expect(bad.model).toBe('grok-build-0.1');
+    expect(bad.category).toBe('not_found');
+    expect(bad.slots).toEqual([{ role: 'executor', tier: 'cheap' }]);
+
+    const report = formatLineupValidation(v);
+    expect(report).toContain('✗');
+    expect(report).toContain('executor/cheap');
+  });
+});

--- a/src/model-validate.ts
+++ b/src/model-validate.ts
@@ -1,0 +1,231 @@
+import { generateText } from 'ai';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { classifyError } from './error-taxonomy.js';
+import type { ToolErrorType } from './framework/tools/types.js';
+import { ALL_ROLE_IDS, type RoleId } from './model-roles.js';
+import { LINEUP_TIERS, type Lineup, type LineupTier } from './lineups.js';
+import type { BernardConfig } from './config.js';
+import { debugLog } from './logger.js';
+
+/**
+ * @module model-validate
+ *
+ * Live model validation. The model catalog (`src/providers/catalog.ts`) tells
+ * us which models *exist in the world*; it cannot tell us whether a given
+ * `(provider, model)` is actually callable with *this* user's API key on *this*
+ * endpoint. The only authoritative answer is an empirical probe: fire a tiny
+ * throwaway completion and classify the outcome.
+ *
+ * This catches the failure modes that silently broke lineups (#264 follow-up):
+ *   - `not_found`   — the model name is wrong, or the account has no access
+ *                     ("The requested model 'gpt-5-chat' does not exist").
+ *   - `auth`        — the API key is missing/invalid for this provider.
+ *   - `rate_limit`  — the account is out of quota (HTTP 429).
+ *
+ * What a probe CANNOT catch: a model that responds fine to "ping" but is too
+ * weak to follow instructions on a real task (e.g. a model that loops on tool
+ * calls without ever answering). Callers should surface that limitation.
+ */
+
+/** Wall-clock cap for a single probe before we abort it. */
+const PROBE_TIMEOUT_MS = 15_000;
+/** Default fan-out when probing many distinct models for one lineup. */
+const PROBE_CONCURRENCY = 4;
+
+export interface ModelProbeResult {
+  provider: string;
+  model: string;
+  ok: boolean;
+  /** Failure taxonomy category (undefined when `ok`). */
+  category?: ToolErrorType;
+  /** Trimmed provider error message (undefined when `ok`). */
+  message?: string;
+  latencyMs: number;
+}
+
+export interface ValidateModelOptions {
+  /** Abort the probe early (chained under an internal timeout controller). */
+  abortSignal?: AbortSignal;
+  /** Override the per-probe timeout. */
+  timeoutMs?: number;
+}
+
+/** Pull an HTTP status / errno / message out of a thrown AI SDK (or network) error. */
+function extractError(err: unknown): { httpStatus?: number; errno?: string; message: string } {
+  const e = err as { message?: unknown; statusCode?: unknown; status?: unknown; code?: unknown; errno?: unknown };
+  const message = typeof e?.message === 'string' && e.message ? e.message : String(err);
+  let httpStatus: number | undefined;
+  if (typeof e?.statusCode === 'number') httpStatus = e.statusCode;
+  else if (typeof e?.status === 'number') httpStatus = e.status;
+  let errno: string | undefined;
+  if (typeof e?.code === 'string') errno = e.code;
+  else if (typeof e?.errno === 'string') errno = e.errno;
+  return { httpStatus, errno, message };
+}
+
+/**
+ * Refine the taxonomy category for the model-validation context. Providers
+ * report "model does not exist" with inconsistent HTTP codes (400 *or* 404), so
+ * `classifyError` (which keys off status) may land on `invalid_args` for a 400.
+ * A message-level signal corrects that to `not_found` so the user sees the real
+ * cause ("this model name is wrong / inaccessible") rather than a generic
+ * argument error.
+ */
+const NOT_FOUND_RE = /does not exist|model_not_found|no such model|not found|unknown model|invalid model|model.*not.*available/i;
+
+function refineCategory(category: ToolErrorType, message: string): ToolErrorType {
+  // Never downgrade an auth/quota signal — those are more actionable than not_found.
+  if (category === 'auth' || category === 'rate_limit' || category === 'permission') return category;
+  if (NOT_FOUND_RE.test(message)) return 'not_found';
+  return category;
+}
+
+/**
+ * Live-probe a single `(provider, model)` with the user's configured key. Sends
+ * a 1-token "ping" and reports whether it succeeded. Never throws — every
+ * failure path resolves to `{ ok: false, category, message }`.
+ */
+export async function validateModel(
+  config: BernardConfig,
+  provider: string,
+  model: string,
+  opts: ValidateModelOptions = {},
+): Promise<ModelProbeResult> {
+  const t0 = Date.now();
+  const ctrl = new AbortController();
+  const onParentAbort = () => ctrl.abort();
+  if (opts.abortSignal) {
+    if (opts.abortSignal.aborted) ctrl.abort();
+    else opts.abortSignal.addEventListener('abort', onParentAbort, { once: true });
+  }
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? PROBE_TIMEOUT_MS);
+  try {
+    await generateText({
+      model: getModelForConfig(config, provider, model),
+      providerOptions: getProviderOptionsForConfig(config, provider),
+      messages: [{ role: 'user', content: 'ping' }],
+      maxSteps: 1,
+      // OpenAI's responses endpoint rejects max_output_tokens < 16; keep the
+      // probe at that floor so a too-small cap can't masquerade as a failure.
+      maxTokens: 16,
+      temperature: 0,
+      abortSignal: ctrl.signal,
+    });
+    const latencyMs = Date.now() - t0;
+    debugLog('model-validate:probe', { provider, model, ok: true, latencyMs });
+    return { provider, model, ok: true, latencyMs };
+  } catch (err) {
+    const latencyMs = Date.now() - t0;
+    const { httpStatus, errno, message } = extractError(err);
+    const aborted = ctrl.signal.aborted && !opts.abortSignal?.aborted;
+    const cls = classifyError({ message, httpStatus, errno });
+    const category = aborted ? 'timeout' : refineCategory(cls.category, message);
+    debugLog('model-validate:probe', { provider, model, ok: false, category, httpStatus, latencyMs });
+    return { provider, model, ok: false, category, message: message.slice(0, 300), latencyMs };
+  } finally {
+    clearTimeout(timer);
+    if (opts.abortSignal) opts.abortSignal.removeEventListener('abort', onParentAbort);
+  }
+}
+
+/** A distinct `(provider, model)` pair and the role×tier slots that reference it. */
+export interface LineupSlotRef {
+  role: RoleId;
+  tier: LineupTier;
+}
+
+export interface LineupModelResult extends ModelProbeResult {
+  /** Which role×tier cells in the lineup use this pair (for "fix this slot" hints). */
+  slots: LineupSlotRef[];
+}
+
+export interface LineupValidation {
+  lineupId: string;
+  lineupName: string;
+  results: LineupModelResult[];
+  ok: boolean;
+  /** Count of distinct failing pairs. */
+  failures: number;
+}
+
+/** Collapse a lineup's 18 slots into the distinct `(provider, model)` pairs it references. */
+function distinctPairs(lineup: Lineup): Map<string, { provider: string; model: string; slots: LineupSlotRef[] }> {
+  const map = new Map<string, { provider: string; model: string; slots: LineupSlotRef[] }>();
+  for (const role of ALL_ROLE_IDS) {
+    for (const tier of LINEUP_TIERS) {
+      const slot = lineup.roles[role]?.[tier];
+      if (!slot) continue;
+      const key = `${slot.provider}/${slot.model}`;
+      const entry = map.get(key) ?? { provider: slot.provider, model: slot.model, slots: [] };
+      entry.slots.push({ role, tier });
+      map.set(key, entry);
+    }
+  }
+  return map;
+}
+
+/** Run probes with a bounded concurrency so a big lineup doesn't open 18 sockets at once. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i]!);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+/**
+ * Validate every distinct model in a lineup. Probes are deduped (a lineup that
+ * uses one model in all 18 slots costs exactly one probe) and run with bounded
+ * concurrency. Fails open: a probe that throws unexpectedly is reported as a
+ * failure result, never rejects the whole call.
+ */
+export async function validateLineup(
+  config: BernardConfig,
+  lineup: Lineup,
+  opts: ValidateModelOptions & { concurrency?: number } = {},
+): Promise<LineupValidation> {
+  const pairs = [...distinctPairs(lineup).values()];
+  const probed = await mapWithConcurrency(pairs, opts.concurrency ?? PROBE_CONCURRENCY, async (p) => {
+    const r = await validateModel(config, p.provider, p.model, opts);
+    return { ...r, slots: p.slots } as LineupModelResult;
+  });
+  const failures = probed.filter((r) => !r.ok).length;
+  return {
+    lineupId: lineup.id,
+    lineupName: lineup.name,
+    results: probed,
+    ok: failures === 0,
+    failures,
+  };
+}
+
+/** One-line summary per probed model, e.g. `✓ openai/gpt-5.5` / `✗ xai/grok-build-0.1 — not_found`. */
+export function formatProbeLine(r: ModelProbeResult): string {
+  if (r.ok) return `✓ ${r.provider}/${r.model} (${r.latencyMs}ms)`;
+  const detail = r.message ? `: ${r.message.split('\n')[0]!.slice(0, 120)}` : '';
+  return `✗ ${r.provider}/${r.model} — ${r.category ?? 'error'}${detail}`;
+}
+
+/** Human-readable report for a whole lineup validation (CLI + agent tool share this). */
+export function formatLineupValidation(v: LineupValidation): string {
+  const header = v.ok
+    ? `✓ Lineup "${v.lineupName}" (${v.lineupId}): all ${v.results.length} model(s) reachable.`
+    : `✗ Lineup "${v.lineupName}" (${v.lineupId}): ${v.failures} of ${v.results.length} model(s) failed.`;
+  const lines = v.results.map((r) => {
+    const base = formatProbeLine(r);
+    if (r.ok) return `  ${base}`;
+    const where = r.slots.map((s) => `${s.role}/${s.tier}`).join(', ');
+    return `  ${base}\n      used by: ${where}`;
+  });
+  return [header, ...lines].join('\n');
+}

--- a/src/output.ts
+++ b/src/output.ts
@@ -307,7 +307,7 @@ export function printHelp(): void {
     '  /mcp     — List MCP servers and tools',
     '  /cron    — Show cron jobs and daemon status',
     '  /facts   — Show RAG facts in current context window',
-    '  /lineup  — Edit the active tier lineup (premium/mid/cheap)',
+    '  /lineup  — Edit the active lineup (per-role × premium/mid/cheap grid)',
     '  /lineups — List, switch, or create tier lineups',
     '  /models  — Browse the model catalog and add custom providers',
     '  /provider — Manage providers (alias of /models)',

--- a/src/providers/catalog.test.ts
+++ b/src/providers/catalog.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Tests for `refreshCatalogWithDiff` — the startup hook that force-refreshes
+ * the model catalog and reports newly-available models (#264 follow-up).
+ *
+ * Each test seeds a baseline catalog on disk (so the "previous source" is a
+ * real `disk` cache, not the vendored snapshot), stubs `fetch` to return a
+ * controlled gateway payload, then asserts the diff.
+ */
+
+async function loadModule() {
+  vi.resetModules();
+  const mod = await import('./catalog.js');
+  mod._resetCatalogCacheForTests();
+  return mod;
+}
+
+interface GatewayModel {
+  id: string;
+  type?: string;
+  name?: string;
+}
+
+function gatewayPayload(models: GatewayModel[]): string {
+  return JSON.stringify({ object: 'list', data: models });
+}
+
+function stubFetchOk(models: GatewayModel[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => JSON.parse(gatewayPayload(models)),
+    })),
+  );
+}
+
+function stubFetchFail() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) })),
+  );
+}
+
+describe('refreshCatalogWithDiff', () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-catalog-'));
+    origHome = process.env.BERNARD_HOME;
+    process.env.BERNARD_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (origHome === undefined) delete process.env.BERNARD_HOME;
+    else process.env.BERNARD_HOME = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Writes a `disk`-sourced baseline cache so previousSource === 'disk'. */
+  function seedDiskCache(models: { provider: string; model: string }[]) {
+    const entries = models.map((m) => ({
+      provider: m.provider,
+      model: m.model,
+      displayName: m.model,
+      contextWindow: 0,
+      maxOutputTokens: 0,
+      tags: [],
+      pricing: { inputPerMTok: 0, outputPerMTok: 0 },
+      released: 0,
+    }));
+    // BERNARD_HOME isn't flat — CACHE_DIR is `<BERNARD_HOME>/bernard`.
+    const cacheDir = path.join(tmpDir, 'bernard');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    // fetchedAt=1 → stale → force still re-fetches; source is 'disk' on read.
+    fs.writeFileSync(
+      path.join(cacheDir, 'model-catalog.json'),
+      JSON.stringify({ fetchedAt: 1, entries }, null, 2),
+    );
+  }
+
+  it('reports models present after the refresh but not before as added', async () => {
+    seedDiskCache([{ provider: 'xai', model: 'grok-3-mini' }]);
+    stubFetchOk([
+      { id: 'xai/grok-3-mini', type: 'language' },
+      { id: 'xai/grok-code-fast', type: 'language' },
+    ]);
+    const m = await loadModule();
+    const diff = await m.refreshCatalogWithDiff();
+    expect(diff.error).toBeUndefined();
+    expect(diff.previousSource).toBe('disk');
+    expect(diff.source).toBe('network');
+    expect(diff.added.map((e) => e.model)).toEqual(['grok-code-fast']);
+    expect(diff.removed).toEqual([]);
+    expect(diff.total).toBe(2);
+  });
+
+  it('reports models gone after the refresh as removed', async () => {
+    seedDiskCache([
+      { provider: 'xai', model: 'grok-3-mini' },
+      { provider: 'xai', model: 'grok-legacy' },
+    ]);
+    stubFetchOk([{ id: 'xai/grok-3-mini', type: 'language' }]);
+    const m = await loadModule();
+    const diff = await m.refreshCatalogWithDiff();
+    expect(diff.added).toEqual([]);
+    expect(diff.removed.map((e) => e.model)).toEqual(['grok-legacy']);
+  });
+
+  it('returns an empty diff with no error when nothing changed', async () => {
+    seedDiskCache([{ provider: 'openai', model: 'gpt-4.1' }]);
+    stubFetchOk([{ id: 'openai/gpt-4.1', type: 'language' }]);
+    const m = await loadModule();
+    const diff = await m.refreshCatalogWithDiff();
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.error).toBeUndefined();
+  });
+
+  it('surfaces a fetch failure as error with an empty diff (fail-silent)', async () => {
+    seedDiskCache([{ provider: 'openai', model: 'gpt-4.1' }]);
+    stubFetchFail();
+    const m = await loadModule();
+    const diff = await m.refreshCatalogWithDiff();
+    expect(diff.error).toBeInstanceOf(Error);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    // Falls back to the prior catalog's source/count.
+    expect(diff.previousSource).toBe('disk');
+    expect(diff.total).toBe(1);
+  });
+
+  it('flags previousSource as vendored when there was no disk baseline', async () => {
+    // No disk cache seeded → loadCatalogSync falls to the bundled snapshot.
+    stubFetchOk([{ id: 'openai/gpt-4.1', type: 'language' }]);
+    const m = await loadModule();
+    const diff = await m.refreshCatalogWithDiff();
+    expect(diff.previousSource).toBe('vendored');
+  });
+});

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -282,6 +282,60 @@ export function getCatalogSource(): CatalogSource {
   return loadCatalogSync().source;
 }
 
+/** Stable identity for a catalog entry — `provider/model`. */
+function entryKey(e: ModelCatalogEntry): string {
+  return `${e.provider}/${e.model}`;
+}
+
+/** Outcome of {@link refreshCatalogWithDiff}. */
+export interface CatalogRefreshDiff {
+  /** Entries present after the refresh but not before. */
+  added: ModelCatalogEntry[];
+  /** Entries present before the refresh but gone after. */
+  removed: ModelCatalogEntry[];
+  /** Total entry count after the refresh. */
+  total: number;
+  /** Source of the catalog after the refresh. */
+  source: CatalogSource;
+  /** Source of the catalog *before* the refresh (`'vendored'` ⇒ no real baseline). */
+  previousSource: CatalogSource;
+  /** Set when the forced network fetch failed; the diff is empty in that case. */
+  error?: Error;
+}
+
+/**
+ * Force-refresh the catalog from the gateway and report what changed relative
+ * to the previously-loaded copy. Used by the REPL startup hook to notify the
+ * user when new models become available.
+ *
+ * Never throws — a network failure is reported in `error` with an empty diff,
+ * so startup is never blocked or crashed by an offline gateway. Callers should
+ * treat `previousSource === 'vendored'` as "no real baseline" and skip
+ * notifying (a fresh install diffing the bundled snapshot against the live
+ * gateway would otherwise produce noise).
+ */
+export async function refreshCatalogWithDiff(): Promise<CatalogRefreshDiff> {
+  const prev = loadCatalogSync();
+  const previousSource = prev.source;
+  const before = new Set(prev.entries.map(entryKey));
+  try {
+    const refreshed = await loadCatalog({ force: true });
+    const afterKeys = new Set(refreshed.entries.map(entryKey));
+    const added = refreshed.entries.filter((e) => !before.has(entryKey(e)));
+    const removed = prev.entries.filter((e) => !afterKeys.has(entryKey(e)));
+    return { added, removed, total: refreshed.entries.length, source: refreshed.source, previousSource };
+  } catch (err) {
+    return {
+      added: [],
+      removed: [],
+      total: prev.entries.length,
+      source: previousSource,
+      previousSource,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
 /** Test-only hook to flush the in-memory cache so a fresh load is forced. */
 export function _resetCatalogCacheForTests(): void {
   memoryCache = null;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import { createWebSearchTool } from './web-search.js';
 import { createWaitTool } from './wait.js';
 import { createFileTools } from './file.js';
 import { createRoutineTool } from './routine.js';
+import { createLineupTool } from './lineup.js';
 import { createSpecialistTool } from './specialist.js';
 import { createCiteTool } from './cite.js';
 import { toolToAISDK } from '../framework/tools/adapter.js';
@@ -54,6 +55,7 @@ export function createTools(
     memory: toolToAISDK(createMemoryTool(memoryStore, provenance)),
     scratch: toolToAISDK(createScratchTool(memoryStore, provenance)),
     routine: createRoutineTool(routineStore),
+    lineup_edit: createLineupTool(config),
     specialist: createSpecialistTool(specialistStore, candidateStore, config),
     datetime: createDateTimeTool(),
     ...createCronTools(),

--- a/src/tools/lineup.test.ts
+++ b/src/tools/lineup.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Each test gets an isolated BERNARD_HOME so loadLineups() seeds a fresh
+// anthropic/openai/xai set and saveLineup() writes to a throwaway dir.
+async function load() {
+  vi.resetModules();
+  const lineups = await import('../lineups.js');
+  const { createLineupTool } = await import('./lineup.js');
+  return { lineups, createLineupTool };
+}
+
+type ToolArgs = {
+  action: 'list' | 'update' | 'create';
+  id?: string;
+  name?: string;
+  base?: string;
+  slots?: Array<{ role: string; tier: string; provider: string; model: string }>;
+  activate?: boolean;
+};
+
+describe('lineup_edit tool', () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-lineup-tool-'));
+    origHome = process.env.BERNARD_HOME;
+    process.env.BERNARD_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.BERNARD_HOME;
+    else process.env.BERNARD_HOME = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const run = async (args: ToolArgs, config?: unknown): Promise<string> => {
+    const { createLineupTool } = await load();
+    const t = createLineupTool(config as never);
+    return (t.execute as (a: ToolArgs) => Promise<string>)(args);
+  };
+
+  it('lists existing lineups and marks the active one', async () => {
+    const out = await run({ action: 'list' }, { provider: 'openai', model: 'x' });
+    expect(out).toContain('Anthropic-only');
+    expect(out).toContain('OpenAI-only');
+    expect(out).toContain('[active]'); // openai resolves active via provider name
+  });
+
+  it('updates a single role/tier slot and persists it', async () => {
+    const out = await run({
+      action: 'update',
+      id: 'openai',
+      slots: [{ role: 'orchestrator', tier: 'premium', provider: 'openai', model: 'MY-MODEL' }],
+    });
+    expect(out).toContain('Updated lineup');
+
+    const { lineups } = await load();
+    const reloaded = lineups.loadLineups()['openai'];
+    expect(reloaded.roles.orchestrator.premium).toEqual({ provider: 'openai', model: 'MY-MODEL' });
+    // Other roles untouched.
+    expect(reloaded.roles.executor.premium.model).not.toBe('MY-MODEL');
+  });
+
+  it('role="all" fans a tier binding out across every role', async () => {
+    await run({
+      action: 'update',
+      id: 'xai',
+      slots: [{ role: 'all', tier: 'cheap', provider: 'xai', model: 'CHEAP-ALL' }],
+    });
+    const { lineups } = await load();
+    const reloaded = lineups.loadLineups()['xai'];
+    for (const roleId of Object.keys(reloaded.roles)) {
+      expect(reloaded.roles[roleId as keyof typeof reloaded.roles].cheap.model).toBe('CHEAP-ALL');
+    }
+  });
+
+  it('refuses an update with an unknown id and lists the options', async () => {
+    const out = await run({
+      action: 'update',
+      id: 'does-not-exist',
+      slots: [{ role: 'orchestrator', tier: 'mid', provider: 'openai', model: 'm' }],
+    });
+    expect(out).toContain('No lineup with id "does-not-exist"');
+    expect(out).toContain('anthropic');
+    expect(out).toContain('openai');
+  });
+
+  it('creates a new lineup, cloning unspecified slots from the base/active', async () => {
+    const out = await run(
+      {
+        action: 'create',
+        name: 'My Mix',
+        slots: [{ role: 'orchestrator', tier: 'premium', provider: 'anthropic', model: 'claude-x' }],
+      },
+      { provider: 'openai', model: 'x' },
+    );
+    expect(out).toContain('Created lineup "My Mix"');
+
+    const { lineups } = await load();
+    const all = lineups.loadLineups();
+    const created = all['my-mix'];
+    expect(created).toBeDefined();
+    // The one specified slot is applied...
+    expect(created.roles.orchestrator.premium).toEqual({ provider: 'anthropic', model: 'claude-x' });
+    // ...and the rest are inherited from the active (openai) base, so they're valid.
+    expect(created.roles.executor.premium.provider).toBe('openai');
+  });
+
+  it('activates a created lineup when activate=true (mutates config + persists prefs)', async () => {
+    const savePreferences = vi.fn();
+    vi.doMock('../config.js', async () => {
+      const actual = await vi.importActual<typeof import('../config.js')>('../config.js');
+      return { ...actual, savePreferences };
+    });
+    vi.resetModules();
+    const { createLineupTool } = await import('./lineup.js');
+    const config = { provider: 'openai', model: 'x', activeLineupId: undefined as string | undefined };
+    const t = createLineupTool(config as never);
+    const out = await (t.execute as (a: ToolArgs) => Promise<string>)({
+      action: 'create',
+      name: 'Active One',
+      activate: true,
+    });
+    expect(out).toContain('now active');
+    expect(config.activeLineupId).toBe('active-one');
+    expect(savePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({ activeLineupId: 'active-one' }),
+    );
+    vi.doUnmock('../config.js');
+  });
+
+  it('warns when a slot references a provider with no configured key', async () => {
+    const out = await run(
+      {
+        action: 'update',
+        id: 'openai',
+        slots: [{ role: 'orchestrator', tier: 'premium', provider: 'mystery-co', model: 'm' }],
+      },
+      { provider: 'openai', model: 'x', customProviders: {} },
+    );
+    expect(out).toContain('Updated lineup');
+    expect(out).toContain('mystery-co');
+    expect(out).toContain('no configured API key');
+  });
+});

--- a/src/tools/lineup.ts
+++ b/src/tools/lineup.ts
@@ -4,7 +4,6 @@ import { attachMeta } from '../framework/tools/adapter.js';
 import {
   loadLineups,
   saveLineup,
-  listLineups,
   resolveActiveLineup,
   validateLineupName,
   LINEUP_TIERS,
@@ -109,7 +108,9 @@ export function createLineupTool(config?: BernardConfig) {
         id: z
           .string()
           .optional()
-          .describe('For action="update": the id of the lineup to edit (see action="list").'),
+          .describe(
+            'The id of the lineup to act on (see action="list"). Required for action="update"; for action="validate" the lineup to probe (omit to probe the active one). Not used by action="create" — see `base` to clone slots from another lineup.',
+          ),
         name: z
           .string()
           .optional()
@@ -144,7 +145,7 @@ export function createLineupTool(config?: BernardConfig) {
           ).id;
 
           if (action === 'list') {
-            const all = listLineups();
+            const all = Object.values(lineups);
             const blocks = all.map(
               (l) =>
                 `${l.id === activeId ? '➤ ' : '  '}${l.name} (id: ${l.id})${
@@ -159,8 +160,14 @@ export function createLineupTool(config?: BernardConfig) {
 
           if (action === 'validate') {
             if (!config) return 'Cannot validate — no live config available.';
-            const targetId = id && lineups[id] ? id : activeId;
-            const target = lineups[targetId];
+            // A supplied-but-unknown id is an error, not a silent fall-through to
+            // the active lineup — otherwise the agent gets a report for the wrong
+            // lineup and never learns its id was wrong. Omitting id still probes
+            // the active one.
+            if (id && !lineups[id]) {
+              return `No lineup with id "${id}". Available: ${Object.keys(lineups).join(', ')}.`;
+            }
+            const target = lineups[id ?? activeId];
             if (!target) {
               return `No lineup to validate. Available: ${Object.keys(lineups).join(', ')}.`;
             }

--- a/src/tools/lineup.ts
+++ b/src/tools/lineup.ts
@@ -15,6 +15,7 @@ import {
 import { ALL_ROLE_IDS, getRole, type RoleId } from '../model-roles.js';
 import { savePreferences, type BernardConfig } from '../config.js';
 import { BUILTIN_PROVIDERS } from '../providers/types.js';
+import { validateLineup, formatLineupValidation } from '../model-validate.js';
 
 /**
  * Agent-facing lineup editor (feature follow-up to #264). Lets Bernard read,
@@ -98,11 +99,13 @@ export function createLineupTool(config?: BernardConfig) {
         'Use this when the user pastes provider/model values and asks you to set up or change a lineup.\n\n' +
         '- action="list": show every lineup and its current bindings. Call this first if the user did not say WHICH lineup to change — then ask them with the ask_user tool.\n' +
         '- action="update": change slots on an existing lineup (pass its `id`). Unspecified slots keep their current value.\n' +
-        '- action="create": make a new lineup (pass `name`). Unspecified slots are copied from `base` (or the active lineup).\n\n' +
+        '- action="create": make a new lineup (pass `name`). Unspecified slots are copied from `base` (or the active lineup).\n' +
+        '- action="validate": live-probe every distinct model in a lineup (pass `id`, or omit for the active lineup) with the real API key and report which are reachable.\n\n' +
         'Provide bindings via `slots`: each entry is {role, tier, provider, model}. Use role="all" to set one tier for every role at once (the usual case). ' +
-        'Set activate=true to make the lineup active immediately. Do NOT guess an id — if unsure which lineup the user means, list and ask.',
+        'Set activate=true to make the lineup active immediately. Do NOT guess an id — if unsure which lineup the user means, list and ask.\n\n' +
+        'After create/update the new bindings are AUTOMATICALLY live-validated (set validate=false to skip). A model can pass validation and still be too weak for real work, so a green check means "reachable", not "good".',
       parameters: z.object({
-        action: z.enum(['list', 'update', 'create']),
+        action: z.enum(['list', 'update', 'create', 'validate']),
         id: z
           .string()
           .optional()
@@ -124,8 +127,14 @@ export function createLineupTool(config?: BernardConfig) {
           .boolean()
           .optional()
           .describe('When true, switch Bernard to this lineup after saving it.'),
+        validate: z
+          .boolean()
+          .optional()
+          .describe(
+            'For create/update: live-probe the resulting models to confirm they are reachable (default true). Set false to skip the network calls.',
+          ),
       }),
-      execute: async ({ action, id, name, base, slots, activate }): Promise<string> => {
+      execute: async ({ action, id, name, base, slots, activate, validate }): Promise<string> => {
         try {
           const lineups = loadLineups();
           const activeId = resolveActiveLineup(
@@ -146,6 +155,17 @@ export function createLineupTool(config?: BernardConfig) {
               `Lineups (${all.length}). Roles: ${ALL_ROLE_IDS.join(', ')}. Tiers: ${LINEUP_TIERS.join('/')}.\n\n` +
               blocks.join('\n\n')
             );
+          }
+
+          if (action === 'validate') {
+            if (!config) return 'Cannot validate — no live config available.';
+            const targetId = id && lineups[id] ? id : activeId;
+            const target = lineups[targetId];
+            if (!target) {
+              return `No lineup to validate. Available: ${Object.keys(lineups).join(', ')}.`;
+            }
+            const v = await validateLineup(config, target);
+            return formatLineupValidation(v);
           }
 
           const applied = slots ?? [];
@@ -174,6 +194,20 @@ export function createLineupTool(config?: BernardConfig) {
               : '';
           };
 
+          // After create/update, live-probe the saved lineup so Bernard can tell
+          // the user which pasted models actually work. Default on; opt out with
+          // validate=false. Fails open — a probe layer error never blocks the save.
+          const validateIfAsked = async (saved: Lineup): Promise<string> => {
+            if (validate === false) return '';
+            if (!config) return '';
+            try {
+              const v = await validateLineup(config, saved);
+              return `\n\n${formatLineupValidation(v)}` + (v.ok ? '' : '\n(Note: a passing probe means reachable, not necessarily good at the task.)');
+            } catch (err) {
+              return `\n\n(Could not validate models: ${(err as Error).message})`;
+            }
+          };
+
           if (action === 'update') {
             if (!id || !lineups[id]) {
               const ids = Object.keys(lineups);
@@ -195,7 +229,8 @@ export function createLineupTool(config?: BernardConfig) {
             return (
               `Updated lineup "${saved.name}" (id: ${saved.id}).\n${formatMatrix(saved)}` +
               warnUnknown() +
-              activateIfAsked(saved)
+              activateIfAsked(saved) +
+              (await validateIfAsked(saved))
             );
           }
 
@@ -213,7 +248,8 @@ export function createLineupTool(config?: BernardConfig) {
           return (
             `Created lineup "${saved.name}" (id: ${saved.id}), based on "${baseLineup.name}".\n${formatMatrix(saved)}` +
             warnUnknown() +
-            activateIfAsked(saved)
+            activateIfAsked(saved) +
+            (await validateIfAsked(saved))
           );
         } catch (err: unknown) {
           return `Error: ${err instanceof Error ? err.message : String(err)}`;
@@ -226,9 +262,11 @@ export function createLineupTool(config?: BernardConfig) {
       deterministic: false,
       sideEffect: 'local',
       cacheable: false,
-      // action="list" is read-only; only update/create mutate on-disk lineups.
-      isWriteAction: (args: unknown) =>
-        (args as { action?: string } | undefined)?.action !== 'list',
+      // list/validate are read-only; only update/create mutate on-disk lineups.
+      isWriteAction: (args: unknown) => {
+        const a = (args as { action?: string } | undefined)?.action;
+        return a !== 'list' && a !== 'validate';
+      },
     },
   );
 }

--- a/src/tools/lineup.ts
+++ b/src/tools/lineup.ts
@@ -1,0 +1,234 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { attachMeta } from '../framework/tools/adapter.js';
+import {
+  loadLineups,
+  saveLineup,
+  listLineups,
+  resolveActiveLineup,
+  validateLineupName,
+  LINEUP_TIERS,
+  type Lineup,
+  type LineupTier,
+  type RoleSlots,
+} from '../lineups.js';
+import { ALL_ROLE_IDS, getRole, type RoleId } from '../model-roles.js';
+import { savePreferences, type BernardConfig } from '../config.js';
+import { BUILTIN_PROVIDERS } from '../providers/types.js';
+
+/**
+ * Agent-facing lineup editor (feature follow-up to #264). Lets Bernard read,
+ * update, and create model lineups when the user pastes in `(provider, model)`
+ * values — instead of the user having to drive the `/lineup` overlay by hand.
+ *
+ * A lineup is a 6-role × 3-tier matrix; this tool applies sparse slot
+ * assignments onto an existing lineup (or a clone of a base lineup, for
+ * `create`), leaving every unspecified slot at its prior value. That keeps the
+ * saved lineup fully valid (all 18 slots populated) no matter how little the
+ * user pasted.
+ *
+ * The tool deliberately does NOT decide *which* lineup to touch when the user
+ * is vague — it returns the list of options so the agent can ask via
+ * `ask_user`. This matches the requested behavior: "if you tell him what
+ * lineup to update he'll do it, otherwise he'll ask."
+ */
+
+const SlotSchema = z.object({
+  role: z
+    .enum([...ALL_ROLE_IDS, 'all'] as unknown as [string, ...string[]])
+    .describe(
+      `Functional role this binding is for. One of: ${ALL_ROLE_IDS.join(', ')}. ` +
+        `Use "all" to apply the same (provider, model) to every role at this tier — ` +
+        `the common case when the user pastes a single provider's premium/mid/cheap set.`,
+    ),
+  tier: z
+    .enum(LINEUP_TIERS as unknown as [string, ...string[]])
+    .describe('Cost tier: premium (strongest), mid, or cheap.'),
+  provider: z.string().describe('Provider id, e.g. "openai", "anthropic", "xai", or a custom one.'),
+  model: z.string().describe('Model name as the provider expects it, e.g. "gpt-5.5-pro".'),
+});
+
+function formatMatrix(l: Lineup): string {
+  const lines: string[] = [];
+  for (const roleId of ALL_ROLE_IDS) {
+    const slots = l.roles[roleId];
+    const cell = (t: LineupTier): string => `${slots[t].provider}/${slots[t].model}`;
+    lines.push(
+      `  ${getRole(roleId).label.padEnd(16)} premium=${cell('premium')}  mid=${cell('mid')}  cheap=${cell('cheap')}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Applies sparse slot assignments onto a (cloned) role matrix, mutating it in
+ * place. `role: 'all'` fans the binding out across every role at that tier.
+ */
+function applySlots(
+  roles: Record<RoleId, RoleSlots>,
+  slots: Array<z.infer<typeof SlotSchema>>,
+): void {
+  for (const s of slots) {
+    const tier = s.tier as LineupTier;
+    const binding = { provider: s.provider.trim(), model: s.model.trim() };
+    const targets: RoleId[] = s.role === 'all' ? [...ALL_ROLE_IDS] : [s.role as RoleId];
+    for (const r of targets) roles[r] = { ...roles[r], [tier]: { ...binding } };
+  }
+}
+
+/** Returns provider ids referenced by `slots` that Bernard has no key/SDK for. */
+function unknownProviders(config: BernardConfig | undefined, slots: Array<{ provider: string }>): string[] {
+  const known = new Set<string>([
+    ...BUILTIN_PROVIDERS,
+    ...Object.keys(config?.customProviders ?? {}),
+  ]);
+  const seen = new Set<string>();
+  for (const s of slots) {
+    const p = s.provider.trim();
+    if (p && !known.has(p)) seen.add(p);
+  }
+  return [...seen];
+}
+
+export function createLineupTool(config?: BernardConfig) {
+  return attachMeta(
+    tool({
+      description:
+        'Read, update, or create model lineups (the role × cost-tier matrix that decides which model each kind of work uses). ' +
+        'Use this when the user pastes provider/model values and asks you to set up or change a lineup.\n\n' +
+        '- action="list": show every lineup and its current bindings. Call this first if the user did not say WHICH lineup to change — then ask them with the ask_user tool.\n' +
+        '- action="update": change slots on an existing lineup (pass its `id`). Unspecified slots keep their current value.\n' +
+        '- action="create": make a new lineup (pass `name`). Unspecified slots are copied from `base` (or the active lineup).\n\n' +
+        'Provide bindings via `slots`: each entry is {role, tier, provider, model}. Use role="all" to set one tier for every role at once (the usual case). ' +
+        'Set activate=true to make the lineup active immediately. Do NOT guess an id — if unsure which lineup the user means, list and ask.',
+      parameters: z.object({
+        action: z.enum(['list', 'update', 'create']),
+        id: z
+          .string()
+          .optional()
+          .describe('For action="update": the id of the lineup to edit (see action="list").'),
+        name: z
+          .string()
+          .optional()
+          .describe(
+            'For action="create": display name of the new lineup. For action="update": optional, renames the lineup.',
+          ),
+        base: z
+          .string()
+          .optional()
+          .describe(
+            'For action="create": id of an existing lineup to copy unspecified slots from. Defaults to the active lineup.',
+          ),
+        slots: z.array(SlotSchema).optional().describe('Slot bindings to apply.'),
+        activate: z
+          .boolean()
+          .optional()
+          .describe('When true, switch Bernard to this lineup after saving it.'),
+      }),
+      execute: async ({ action, id, name, base, slots, activate }): Promise<string> => {
+        try {
+          const lineups = loadLineups();
+          const activeId = resolveActiveLineup(
+            lineups,
+            config?.activeLineupId,
+            config?.provider,
+          ).id;
+
+          if (action === 'list') {
+            const all = listLineups();
+            const blocks = all.map(
+              (l) =>
+                `${l.id === activeId ? '➤ ' : '  '}${l.name} (id: ${l.id})${
+                  l.id === activeId ? '  [active]' : ''
+                }\n${formatMatrix(l)}`,
+            );
+            return (
+              `Lineups (${all.length}). Roles: ${ALL_ROLE_IDS.join(', ')}. Tiers: ${LINEUP_TIERS.join('/')}.\n\n` +
+              blocks.join('\n\n')
+            );
+          }
+
+          const applied = slots ?? [];
+
+          const activateIfAsked = (saved: Lineup): string => {
+            if (!activate) return '';
+            if (!config) return '\n(Could not activate — no live config available; switch with /lineups.)';
+            config.activeLineupId = saved.id;
+            try {
+              savePreferences({
+                provider: config.provider,
+                model: config.model,
+                activeLineupId: saved.id,
+              });
+              return `\nThis lineup is now active.`;
+            } catch (err) {
+              return `\n(Saved, but failed to activate: ${(err as Error).message}. Switch with /lineups.)`;
+            }
+          };
+
+          const warnUnknown = (): string => {
+            const unknown = unknownProviders(config, applied);
+            return unknown.length > 0
+              ? `\n⚠ Provider(s) with no configured API key/SDK: ${unknown.join(', ')}. ` +
+                  `The lineup is saved, but calls will fail until you add the provider (/provider).`
+              : '';
+          };
+
+          if (action === 'update') {
+            if (!id || !lineups[id]) {
+              const ids = Object.keys(lineups);
+              return (
+                `${id ? `No lineup with id "${id}". ` : 'No lineup id given. '}` +
+                `Ask the user which one to update, then retry. Available: ${ids.join(', ')}.`
+              );
+            }
+            if (applied.length === 0 && !name) {
+              return 'Nothing to change — pass `slots` to update bindings and/or `name` to rename.';
+            }
+            const existing = lineups[id];
+            const roles = structuredClone(existing.roles);
+            applySlots(roles, applied);
+            const nextName = name?.trim() || existing.name;
+            const nameErr = validateLineupName(nextName);
+            if (nameErr) return `Invalid name: ${nameErr}`;
+            const saved = saveLineup({ id, name: nextName, roles });
+            return (
+              `Updated lineup "${saved.name}" (id: ${saved.id}).\n${formatMatrix(saved)}` +
+              warnUnknown() +
+              activateIfAsked(saved)
+            );
+          }
+
+          // action === 'create'
+          if (!name || !name.trim()) {
+            return 'To create a lineup, pass a `name`. Ask the user for one if they did not provide it.';
+          }
+          const nameErr = validateLineupName(name);
+          if (nameErr) return `Invalid name: ${nameErr}`;
+          const baseId = base && lineups[base] ? base : activeId;
+          const baseLineup = lineups[baseId];
+          const roles = structuredClone(baseLineup.roles);
+          applySlots(roles, applied);
+          const saved = saveLineup({ name: name.trim(), roles });
+          return (
+            `Created lineup "${saved.name}" (id: ${saved.id}), based on "${baseLineup.name}".\n${formatMatrix(saved)}` +
+            warnUnknown() +
+            activateIfAsked(saved)
+          );
+        } catch (err: unknown) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    }),
+    {
+      name: 'lineup_edit',
+      kind: 'write',
+      deterministic: false,
+      sideEffect: 'local',
+      cacheable: false,
+      // action="list" is read-only; only update/create mutate on-disk lineups.
+      isWriteAction: (args: unknown) =>
+        (args as { action?: string } | undefined)?.action !== 'list',
+    },
+  );
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 import type { Agent } from '../agent.js';
 import type { BernardConfig } from '../config.js';
@@ -17,7 +17,12 @@ import {
 import { MAX_CONCURRENT_AGENTS_LIMIT, setMaxConcurrentAgents } from '../tools/agent-pool.js';
 import { RESPONSE_STYLE_IDS, type ResponseStyle } from '../agent-prompt.js';
 import { getContextWindow } from '../context.js';
-import { loadCatalog, getCatalogAgeMs, getCatalogSource } from '../providers/catalog.js';
+import {
+  loadCatalog,
+  getCatalogAgeMs,
+  getCatalogSource,
+  refreshCatalogWithDiff,
+} from '../providers/catalog.js';
 import { getLocalVersion } from '../update.js';
 import { CONFIG_DIR, DATA_DIR, CACHE_DIR, STATE_DIR } from '../paths.js';
 import * as os from 'node:os';
@@ -584,6 +589,37 @@ export function App({
       }
     })();
   }, [isFreshInstall]);
+
+  // Startup model-catalog refresh (#264 follow-up). Every launch force-fetches
+  // the live gateway catalog in the background and toasts when new models
+  // appeared since the last run. Non-blocking and fail-silent — an offline
+  // gateway just leaves the cached/vendored catalog in place. We skip the
+  // notification when there was no real prior baseline (`previousSource ===
+  // 'vendored'`) so a fresh install doesn't announce the entire bundled
+  // snapshot as "new".
+  const catalogRefreshRanRef = useRef(false);
+  useEffect(() => {
+    if (catalogRefreshRanRef.current) return;
+    catalogRefreshRanRef.current = true;
+    void (async () => {
+      try {
+        const diff = await refreshCatalogWithDiff();
+        if (diff.error || diff.previousSource === 'vendored' || diff.added.length === 0) return;
+        const names = diff.added
+          .slice(0, 3)
+          .map((e) => `${e.provider}/${e.model}`)
+          .join(', ');
+        const more = diff.added.length > 3 ? ` +${diff.added.length - 3} more` : '';
+        flashToast(
+          `${diff.added.length} new model${diff.added.length === 1 ? '' : 's'} available: ${names}${more}. Use /model to switch.`,
+          'success',
+        );
+      } catch {
+        // Never block or crash startup over a catalog refresh.
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
+  }, []);
 
   const flashToast = (message: string, variant: ToastVariant = 'info') => {
     setToast({ message, variant });
@@ -3351,9 +3387,12 @@ async function pickLineupSlotInk(
     const provider = choice.provider;
     const isCustom = Object.hasOwn(customProviders, provider);
     const models = modelsForProvider(provider);
+    // Free-type is offered for every provider, not just custom ones: the
+    // built-in catalog (Vercel AI Gateway) omits some real models (e.g. xAI's
+    // grok-code-fast-1 isn't proxied under the `xai/` prefix), so without this
+    // escape hatch those models are unreachable through the picker.
     const FREE_TYPE = '+ Type a new model name…';
-    const items: string[] = [...models];
-    if (isCustom) items.push(FREE_TYPE);
+    const items: string[] = [...models, FREE_TYPE];
 
     if (items.length === 0) {
       flashToast(`No models known for provider "${provider}".`, 'error');
@@ -3380,8 +3419,13 @@ async function pickLineupSlotInk(
       const modelRes = await requestTextInput({ label: `New model name for ${provider}` });
       if (modelRes.cancelled || !modelRes.raw.trim()) continue;
       const model = modelRes.raw.trim();
-      rememberCustomModel(provider, model);
-      config.customProviders = loadCustomProviders();
+      // Only the custom-provider store remembers typed model names; built-in
+      // providers draw their list from the catalog, so a free-typed built-in
+      // model is used as-is for this slot without persisting it there.
+      if (isCustom) {
+        rememberCustomModel(provider, model);
+        config.customProviders = loadCustomProviders();
+      }
       return { provider, model };
     }
     return { provider, model: picked };
@@ -3444,6 +3488,71 @@ function summarizeRoleSlots(slots: RoleSlots): string {
     `premium ${slots.premium.provider}/${slots.premium.model} · ` +
     `mid ${slots.mid.provider}/${slots.mid.model} · ` +
     `cheap ${slots.cheap.provider}/${slots.cheap.model}`
+  );
+}
+
+/**
+ * Right-pane detail card content for the split-layout lineup editor (Style 2).
+ * A role row shows its premium/mid/cheap ladder, the role description, and an
+ * "edit" hint; a lineup-level action row shows a one-line explainer + hint. The
+ * overlay supplies the surrounding border and the row's label as the card title.
+ */
+function renderLineupDetail(item: MenuItem, draft: Lineup): ReactNode {
+  const colors = getThemeColors();
+  const value = item.value as
+    | { kind: 'role'; roleId: RoleId }
+    | { kind: 'rename' | 'save' | 'save-new' | 'delete' | 'cancel' };
+
+  if (value.kind === 'role') {
+    const role = getRole(value.roleId);
+    const slots = draft.roles[value.roleId];
+    // Dotted-leader rows: `tier ......... provider/model`, value right-aligned
+    // against a fixed inner width so the three tiers line up like a contents list.
+    const LEADER_WIDTH = 44;
+    return (
+      <Box flexDirection="column">
+        <Text dimColor>{role.description}</Text>
+        <Text> </Text>
+        {LINEUP_TIERS.map((tier) => {
+          const val = `${slots[tier].provider}/${slots[tier].model}`;
+          const dots = '.'.repeat(Math.max(2, LEADER_WIDTH - tier.length - val.length));
+          return (
+            <Text key={tier}>
+              {tier}
+              <Text dimColor>{dots}</Text>
+              <Text color={colors.accent}>{val}</Text>
+            </Text>
+          );
+        })}
+        <Text> </Text>
+        <Text dimColor>What to look for when selecting:</Text>
+        <Text>{role.lookFor}</Text>
+        <Text> </Text>
+        <Text color={colors.accent}>↵ edit this role</Text>
+      </Box>
+    );
+  }
+
+  const explain: Record<string, string> = {
+    rename: 'Give this lineup a new display name.',
+    save: 'Persist your edits to this lineup.',
+    'save-new': 'Clone the current grid into a new lineup under a name you choose.',
+    delete: 'Remove this lineup (refuses if it is the last one).',
+    cancel: 'Discard changes and close the editor.',
+  };
+  const hint: Record<string, string> = {
+    rename: '↵ rename',
+    save: '↵ save',
+    'save-new': '↵ save as new',
+    delete: '↵ delete',
+    cancel: '↵ cancel',
+  };
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{explain[value.kind]}</Text>
+      <Text> </Text>
+      <Text color={colors.accent}>{hint[value.kind]}</Text>
+    </Box>
   );
 }
 
@@ -3520,10 +3629,10 @@ async function runLineupEditorInk(
 ): Promise<Lineup | null> {
   let draft: Lineup = { ...initial };
   while (true) {
+    // Left-pane rows stay lean (just the role/action label); the right-pane
+    // detail card carries the premium/mid/cheap ladder and the description.
     const roleRows: MenuEntry[] = MODEL_ROLES.map((role) => ({
       label: role.label,
-      description: role.description,
-      annotation: summarizeRoleSlots(draft.roles[role.id]),
       value: { kind: 'role', roleId: role.id },
     }));
     const entries: MenuEntry[] = [
@@ -3541,6 +3650,8 @@ async function runLineupEditorInk(
     ];
     const pick = await requestMenu(entries, {
       title: `Lineup: ${draft.name}${opts.isNew ? ' (draft)' : ''} — pick a role`,
+      layout: 'split',
+      renderDetail: (item) => renderLineupDetail(item, draft),
     });
     if (pick.cancelled) return null;
     const value = pick.item.value as

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -621,7 +621,7 @@ export function App({
           .join(', ');
         const more = diff.added.length > 3 ? ` +${diff.added.length - 3} more` : '';
         flashToast(
-          `${diff.added.length} new model${diff.added.length === 1 ? '' : 's'} available: ${names}${more}. Use /model to switch.`,
+          `${diff.added.length} new model${diff.added.length === 1 ? '' : 's'} available: ${names}${more}. Browse with /models or bind one via /lineup.`,
           'success',
         );
       } catch {
@@ -1207,11 +1207,12 @@ export function App({
         config.activeLineupId,
         config.provider,
       ).id;
+      const primaryRole = MODEL_ROLES[0];
       const entries: MenuEntry[] = all.map((l) => ({
         label: l.name,
         annotation: `(${l.id})`,
         active: l.id === activeId,
-        description: `orchestrator — ${summarizeRoleSlots(l.roles.orchestrator)}`,
+        description: `${primaryRole.id} — ${summarizeRoleSlots(l.roles[primaryRole.id])}`,
         value: l.id,
       }));
       entries.push({ type: 'section', title: '' });
@@ -3599,34 +3600,32 @@ function renderLineupDetail(item: MenuItem, draft: Lineup): ReactNode {
     );
   }
 
-  const explain: Record<string, string> = {
-    rename: 'Give this lineup a new display name.',
-    save: 'Persist your edits to this lineup.',
-    'save-new': 'Clone the current grid into a new lineup under a name you choose.',
-    delete: 'Remove this lineup (refuses if it is the last one).',
-    cancel: 'Discard changes and close the editor.',
+  const actionDetail: Record<string, { explain: string; hint: string }> = {
+    rename: { explain: 'Give this lineup a new display name.', hint: '↵ rename' },
+    save: { explain: 'Persist your edits to this lineup.', hint: '↵ save' },
+    'save-new': {
+      explain: 'Clone the current grid into a new lineup under a name you choose.',
+      hint: '↵ save as new',
+    },
+    delete: { explain: 'Remove this lineup (refuses if it is the last one).', hint: '↵ delete' },
+    cancel: { explain: 'Discard changes and close the editor.', hint: '↵ cancel' },
   };
-  const hint: Record<string, string> = {
-    rename: '↵ rename',
-    save: '↵ save',
-    'save-new': '↵ save as new',
-    delete: '↵ delete',
-    cancel: '↵ cancel',
-  };
+  const { explain, hint } = actionDetail[value.kind];
   return (
     <Box flexDirection="column">
-      <Text dimColor>{explain[value.kind]}</Text>
+      <Text dimColor>{explain}</Text>
       <Text> </Text>
-      <Text color={colors.accent}>{hint[value.kind]}</Text>
+      <Text color={colors.accent}>{hint}</Text>
     </Box>
   );
 }
 
 /**
  * Level-2 editor: the three cost-tier slots (premium / mid / cheap) for one
- * role. Mutates a copy of `slots` and returns it on `← Back`, or `null` on Esc
- * (caller treats both the same — edits are already applied into the returned
- * ladder). Selecting a tier opens the provider→model picker.
+ * role. Mutates a copy of `slots` and returns it on both `← Back` and Esc —
+ * edits are applied live into the returned ladder, so cancel and back are
+ * equivalent (there is no discard path here; the parent editor owns that).
+ * Selecting a tier opens the provider→model picker.
  */
 async function runRoleSlotsEditorInk(
   roleId: RoleId,
@@ -3851,8 +3850,8 @@ async function runLineupEditorInk(
 
 /**
  * Sort-keys-first JSON so `{a:1,b:2}` and `{b:2,a:1}` produce the same string.
- * Mirrors `stableStringify` at `src/repl.ts:1122` — keeps the confirm-allow
- * session memo stable across re-renders that reshuffle object key order.
+ * Keeps the confirm-allow session memo stable across re-renders that reshuffle
+ * object key order.
  */
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
@@ -3862,7 +3861,7 @@ function stableStringify(value: unknown): string {
   return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
 }
 
-/** djb2 over the stable-JSON form. Matches `stableHash` at `src/repl.ts:1113`. */
+/** djb2 over the stable-JSON form. */
 function stableHash(value: unknown): string {
   let json: string;
   try {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3659,6 +3659,59 @@ async function runLineupEditorInk(
   opts: { isNew?: boolean } = {},
 ): Promise<Lineup | null> {
   let draft: Lineup = { ...initial };
+  // Snapshot the starting shape so we can tell whether the user actually
+  // changed anything. The multi-level editor only persists on an explicit
+  // "Save changes", so without this a user who edits roles and then backs out
+  // (Esc / Cancel) silently loses all their work — the #1 "lineups don't save"
+  // complaint. We compare against this baseline to decide whether to guard the
+  // exit. Rename keys off `name`; role edits off the per-role slot ladders.
+  const baseline = stableStringify({ name: initial.name, roles: initial.roles });
+  const isDirty = (): boolean =>
+    stableStringify({ name: draft.name, roles: draft.roles }) !== baseline;
+
+  /** Persist the current draft. Returns the saved lineup, or null on error. */
+  const commit = (asNew: boolean): Lineup | null => {
+    try {
+      return saveLineup({
+        // Omit id for "save as new" so saveLineup slugs a fresh one from name.
+        ...(asNew ? {} : { id: draft.id }),
+        name: draft.name,
+        roles: draft.roles,
+      });
+    } catch (err) {
+      flashToast(`Failed to save: ${(err as Error).message}`, 'error');
+      return null;
+    }
+  };
+
+  /**
+   * Common exit path for Esc / Cancel. If there are unsaved edits, prompt
+   * rather than silently discarding them. Returns `{ done: true, result }` to
+   * leave the editor, or `{ done: false }` to keep editing.
+   */
+  const handleExit = async (): Promise<
+    { done: true; result: Lineup | null } | { done: false }
+  > => {
+    if (!isDirty()) return { done: true, result: null };
+    const confirm = await requestMenu(
+      [
+        { label: opts.isNew ? 'Save as new lineup' : 'Save changes', value: 'save' },
+        { label: 'Discard changes', value: 'discard' },
+        { label: 'Keep editing', value: 'keep' },
+      ],
+      { title: 'You have unsaved lineup changes' },
+    );
+    // Esc on the guard itself = "keep editing" (safest — never lose work).
+    if (confirm.cancelled) return { done: false };
+    const action = confirm.item.value as 'save' | 'discard' | 'keep';
+    if (action === 'keep') return { done: false };
+    if (action === 'discard') return { done: true, result: null };
+    const saved = commit(opts.isNew ?? false);
+    // Save failed (toast already shown) → fall back to keep-editing so the
+    // user doesn't lose their draft to a transient validation error.
+    return saved ? { done: true, result: saved } : { done: false };
+  };
+
   while (true) {
     // Left-pane rows stay lean (just the role/action label); the right-pane
     // detail card carries the premium/mid/cheap ladder and the description.
@@ -3666,6 +3719,7 @@ async function runLineupEditorInk(
       label: role.label,
       value: { kind: 'role', roleId: role.id },
     }));
+    const dirtyMark = isDirty() ? ' •' : '';
     const entries: MenuEntry[] = [
       ...roleRows,
       { type: 'section', title: '' },
@@ -3673,22 +3727,32 @@ async function runLineupEditorInk(
       ...(opts.isNew
         ? [{ label: 'Save as new lineup', value: { kind: 'save-new' } } as MenuEntry]
         : [
-            { label: 'Save changes', value: { kind: 'save' } } as MenuEntry,
+            { label: `Save changes${dirtyMark}`, value: { kind: 'save' } } as MenuEntry,
             { label: 'Save as new lineup', value: { kind: 'save-new' } } as MenuEntry,
             { label: 'Delete lineup', value: { kind: 'delete' } } as MenuEntry,
           ]),
       { label: 'Cancel', value: { kind: 'cancel' } },
     ];
     const pick = await requestMenu(entries, {
-      title: `Lineup: ${draft.name}${opts.isNew ? ' (draft)' : ''} — pick a role`,
+      title: `Lineup: ${draft.name}${opts.isNew ? ' (draft)' : ''}${
+        dirtyMark ? ' — unsaved changes' : ''
+      } — pick a role`,
       layout: 'split',
       renderDetail: (item) => renderLineupDetail(item, draft),
     });
-    if (pick.cancelled) return null;
+    if (pick.cancelled) {
+      const exit = await handleExit();
+      if (exit.done) return exit.result;
+      continue;
+    }
     const value = pick.item.value as
       | { kind: 'role'; roleId: RoleId }
       | { kind: 'rename' | 'save' | 'save-new' | 'delete' | 'cancel' };
-    if (value.kind === 'cancel') return null;
+    if (value.kind === 'cancel') {
+      const exit = await handleExit();
+      if (exit.done) return exit.result;
+      continue;
+    }
     if (value.kind === 'role') {
       const nextSlots = await runRoleSlotsEditorInk(
         value.roleId,
@@ -3720,30 +3784,14 @@ async function runLineupEditorInk(
       continue;
     }
     if (value.kind === 'save') {
-      try {
-        const saved = saveLineup({
-          id: draft.id,
-          name: draft.name,
-          roles: draft.roles,
-        });
-        return saved;
-      } catch (err) {
-        flashToast(`Failed to save: ${(err as Error).message}`, 'error');
-        continue;
-      }
+      const saved = commit(false);
+      if (saved) return saved;
+      continue;
     }
     if (value.kind === 'save-new') {
-      try {
-        const saved = saveLineup({
-          // omit id so saveLineup slugs from name
-          name: draft.name,
-          roles: draft.roles,
-        });
-        return saved;
-      } catch (err) {
-        flashToast(`Failed to save: ${(err as Error).message}`, 'error');
-        continue;
-      }
+      const saved = commit(true);
+      if (saved) return saved;
+      continue;
     }
     if (value.kind === 'delete') {
       const confirm = await requestMenu(

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -49,6 +49,7 @@ import {
   PROVIDER_DISPLAY_NAMES,
 } from '../lineups.js';
 import { MODEL_ROLES, getRole, type RoleId } from '../model-roles.js';
+import { validateLineup, formatLineupValidation } from '../model-validate.js';
 import type { SupportedSdk } from '../providers/types.js';
 import { THEMES, getThemeKeys, getActiveThemeKey, setTheme, getThemeColors } from '../theme.js';
 import type { HistoryStore } from '../history.js';
@@ -656,6 +657,36 @@ export function App({
     setToast({ message, variant });
   };
 
+  // Push a UI-only assistant notice into the transcript (same mechanism as the
+  // startup lineup-correction notice): straight into `staticItems`, never into
+  // `agent.history`, so it isn't persisted or replayed.
+  const pushAssistantNotice = (content: string) => {
+    setStaticItems((prev) => [
+      ...prev,
+      { key: String(itemKeyRef.current++), message: { role: 'assistant', content }, toolDetails: false },
+    ]);
+  };
+
+  // Warn-only lineup validation (#264 follow-up). After a save/switch we
+  // live-probe the lineup's models in the background and, IF any are
+  // unreachable, surface a notice. Never blocks the save and fails open — a
+  // probe-layer error or offline gateway just skips the warning.
+  const warnValidateLineup = (lineup: Lineup) => {
+    void (async () => {
+      try {
+        const v = await validateLineup(config, lineup);
+        if (v.ok) return;
+        pushAssistantNotice(
+          `⚠ Lineup "${v.lineupName}" was saved, but ${v.failures} of ${v.results.length} model(s) failed a live check:\n\n` +
+            formatLineupValidation(v) +
+            `\n\nFix the names with /lineup, or switch with /lineups. (A reachable model can still be too weak for a task — this only checks access.)`,
+        );
+      } catch {
+        // fail open — never let validation noise block or crash the REPL
+      }
+    })();
+  };
+
   const showInfo = (title: string, lines: PendingInfo['lines']) => {
     setPendingInfo({ title, lines });
     setActiveOverlay('info');
@@ -1161,6 +1192,7 @@ export function App({
         });
         logSiteModelSnapshot(config, 'lineup-change');
         flashToast(`Lineup "${edited.name}" saved.`, 'success');
+        warnValidateLineup(edited);
       }
       return;
     }
@@ -1221,6 +1253,7 @@ export function App({
           });
           logSiteModelSnapshot(config, 'lineup-change');
           flashToast(`Created and switched to "${created.name}".`, 'success');
+          warnValidateLineup(created);
         }
         return;
       }
@@ -1245,6 +1278,7 @@ export function App({
           });
           logSiteModelSnapshot(config, 'lineup-change');
           flashToast(`Lineup "${edited.name}" saved.`, 'success');
+          warnValidateLineup(edited);
         }
         return;
       }
@@ -1256,6 +1290,7 @@ export function App({
       });
       logSiteModelSnapshot(config, 'lineup-change');
       flashToast(`Switched to lineup "${target.name}".`, 'success');
+      warnValidateLineup(target);
       return;
     }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -184,6 +184,14 @@ interface AppProps {
    * overlays the user's choices on top of it.
    */
   isFreshInstall?: boolean;
+  /**
+   * One-time transcript notice (#264 follow-up). Set by `src/index.ts` when the
+   * stored `activeLineupId` pointed at a lineup that no longer exists and was
+   * auto-switched to a valid one. Rendered as a synthetic assistant message at
+   * the top of the transcript on mount — UI-only, never pushed into the agent's
+   * LLM history.
+   */
+  startupNotice?: string;
 }
 
 type Overlay =
@@ -311,6 +319,7 @@ export function App({
   onExit,
   alertBanner,
   isFreshInstall,
+  startupNotice,
 }: AppProps) {
   const { exit } = useApp();
   const [activeOverlay, setActiveOverlay] = useState<Overlay | null>(null);
@@ -618,6 +627,28 @@ export function App({
         // Never block or crash startup over a catalog refresh.
       }
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
+  }, []);
+
+  // One-time lineup-correction notice (#264 follow-up). When `src/index.ts`
+  // auto-switched a dangling `activeLineupId`, surface a synthetic assistant
+  // message at the top of the transcript so the silent fallback is visible.
+  // UI-only: it goes straight into `staticItems`, never into `agent.history`,
+  // so it isn't persisted to conversation-history.json or replayed on resume.
+  // Does NOT advance `committedLenRef` (that cursor tracks the agent's real
+  // history slice); a synthetic item carries no backing history message.
+  const startupNoticeRanRef = useRef(false);
+  useEffect(() => {
+    if (startupNoticeRanRef.current || !startupNotice) return;
+    startupNoticeRanRef.current = true;
+    setStaticItems((prev) => [
+      ...prev,
+      {
+        key: String(itemKeyRef.current++),
+        message: { role: 'assistant', content: startupNotice },
+        toolDetails: false,
+      },
+    ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, []);
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -34,6 +34,7 @@ import {
   type Lineup,
   type LineupSlot,
   type LineupTier,
+  type RoleSlots,
   loadLineups,
   resolveActiveLineup,
   saveLineup,
@@ -42,6 +43,7 @@ import {
   validateLineupName,
   PROVIDER_DISPLAY_NAMES,
 } from '../lineups.js';
+import { MODEL_ROLES, getRole, type RoleId } from '../model-roles.js';
 import type { SupportedSdk } from '../providers/types.js';
 import { THEMES, getThemeKeys, getActiveThemeKey, setTheme, getThemeColors } from '../theme.js';
 import type { HistoryStore } from '../history.js';
@@ -1110,7 +1112,7 @@ export function App({
         label: l.name,
         annotation: `(${l.id})`,
         active: l.id === activeId,
-        description: `premium ${l.premium.provider}/${l.premium.model} · mid ${l.mid.provider}/${l.mid.model} · cheap ${l.cheap.provider}/${l.cheap.model}`,
+        description: `orchestrator — ${summarizeRoleSlots(l.roles.orchestrator)}`,
         value: l.id,
       }));
       entries.push({ type: 'section', title: '' });
@@ -1768,7 +1770,7 @@ export function App({
       {
         value: 'balanced',
         label: 'Balanced',
-        desc: 'Premium main; mid sub-agents; cheap routing.',
+        desc: 'Premium orchestrator; mid executor/function-caller/summarizer; cheap classifier.',
       },
       {
         value: 'optimize-tokens',
@@ -2022,7 +2024,7 @@ export function App({
           label: 'Tier lineup',
           annotation: `= ${resolveActiveLineup(loadLineups(), config.activeLineupId, config.provider).name}`,
           description:
-            'Switch, edit, or create lineups that bind premium/mid/cheap tiers to specific (provider, model) pairs.',
+            'Switch, edit, or create lineups that bind each functional role × cost tier (premium/mid/cheap) to a (provider, model) pair.',
         },
         action: () => handleSubmit('/lineups'),
       },
@@ -3260,7 +3262,10 @@ async function pickLineupSlotInk(
   requestGridMenu: RequestGridMenu,
   requestTextInput: RequestTextInput,
   flashToast: FlashToast,
+  roleLabel?: string,
 ): Promise<LineupSlot | null> {
+  const slotLabel = (t: LineupTier): string =>
+    roleLabel ? `${roleLabel} / ${t.toUpperCase()}` : `${t.toUpperCase()}`;
   const providerDisplayName = (name: string): string => {
     if (Object.hasOwn(PROVIDER_DISPLAY_NAMES, name)) {
       return PROVIDER_DISPLAY_NAMES[name as keyof typeof PROVIDER_DISPLAY_NAMES];
@@ -3323,7 +3328,7 @@ async function pickLineupSlotInk(
     entries.push({ label: '+ Add custom provider…', value: { kind: 'add-custom' } as const });
 
     const pick = await requestMenu(entries, {
-      title: `Pick provider for ${tier.toUpperCase()} slot`,
+      title: `Pick provider for ${slotLabel(tier)} slot`,
       headerLines: [formatCatalogFooter()],
     });
     if (pick.cancelled) return null;
@@ -3363,7 +3368,7 @@ async function pickLineupSlotInk(
         : 0;
 
     const result = await requestGridMenu(items, {
-      title: `Pick ${providerDisplayName(provider)} model for ${tier.toUpperCase()} slot`,
+      title: `Pick ${providerDisplayName(provider)} model for ${slotLabel(tier)} slot`,
       footer: formatCatalogFooter(),
       initialIndex,
       currentItem: currentModelForProvider,
@@ -3433,10 +3438,76 @@ async function runModelsCatalogInk(
   }
 }
 
+/** One-line `premium · mid · cheap` summary of a role's cost ladder. */
+function summarizeRoleSlots(slots: RoleSlots): string {
+  return (
+    `premium ${slots.premium.provider}/${slots.premium.model} · ` +
+    `mid ${slots.mid.provider}/${slots.mid.model} · ` +
+    `cheap ${slots.cheap.provider}/${slots.cheap.model}`
+  );
+}
+
 /**
- * Editor for one lineup. Shows three rows (premium / mid / cheap) plus
- * rename and either "Save" (existing) or "Save as new" (draft). Returns
- * the persisted lineup on save, or `null` on cancel.
+ * Level-2 editor: the three cost-tier slots (premium / mid / cheap) for one
+ * role. Mutates a copy of `slots` and returns it on `← Back`, or `null` on Esc
+ * (caller treats both the same — edits are already applied into the returned
+ * ladder). Selecting a tier opens the provider→model picker.
+ */
+async function runRoleSlotsEditorInk(
+  roleId: RoleId,
+  initial: RoleSlots,
+  config: BernardConfig,
+  requestMenu: RequestMenu,
+  requestGridMenu: RequestGridMenu,
+  requestTextInput: RequestTextInput,
+  flashToast: FlashToast,
+): Promise<RoleSlots> {
+  const role = getRole(roleId);
+  let slots: RoleSlots = {
+    premium: { ...initial.premium },
+    mid: { ...initial.mid },
+    cheap: { ...initial.cheap },
+  };
+  while (true) {
+    const tierRows: MenuEntry[] = LINEUP_TIERS.map((tier) => ({
+      label: `${tier.toUpperCase()}`,
+      annotation: `→ ${slots[tier].provider} / ${slots[tier].model}`,
+      value: { kind: 'tier', tier },
+    }));
+    const entries: MenuEntry[] = [
+      ...tierRows,
+      { type: 'section', title: '' },
+      { label: '← Back to roles', value: { kind: 'back' } },
+    ];
+    const pick = await requestMenu(entries, {
+      title: `${role.label} — pick cost tier to bind`,
+      headerLines: [role.description],
+    });
+    if (pick.cancelled) return slots;
+    const value = pick.item.value as
+      | { kind: 'tier'; tier: LineupTier }
+      | { kind: 'back' };
+    if (value.kind === 'back') return slots;
+    const next = await pickLineupSlotInk(
+      config,
+      value.tier,
+      slots[value.tier],
+      requestMenu,
+      requestGridMenu,
+      requestTextInput,
+      flashToast,
+      role.label,
+    );
+    if (next) slots = { ...slots, [value.tier]: next };
+  }
+}
+
+/**
+ * Editor for one lineup. Two levels: the top menu lists the functional roles
+ * (orchestrator / executor / …), each showing its current premium·mid·cheap
+ * binding; selecting a role opens its three cost-tier slots. Plus rename and
+ * either "Save" (existing) or "Save as new" (draft). Returns the persisted
+ * lineup on save, or `null` on cancel.
  */
 async function runLineupEditorInk(
   initial: Lineup,
@@ -3449,13 +3520,14 @@ async function runLineupEditorInk(
 ): Promise<Lineup | null> {
   let draft: Lineup = { ...initial };
   while (true) {
-    const tierRows: MenuEntry[] = LINEUP_TIERS.map((tier) => ({
-      label: `${tier.toUpperCase()}`,
-      annotation: `→ ${draft[tier].provider} / ${draft[tier].model}`,
-      value: { kind: 'tier', tier },
+    const roleRows: MenuEntry[] = MODEL_ROLES.map((role) => ({
+      label: role.label,
+      description: role.description,
+      annotation: summarizeRoleSlots(draft.roles[role.id]),
+      value: { kind: 'role', roleId: role.id },
     }));
     const entries: MenuEntry[] = [
-      ...tierRows,
+      ...roleRows,
       { type: 'section', title: '' },
       { label: 'Rename lineup', value: { kind: 'rename' } },
       ...(opts.isNew
@@ -3468,24 +3540,27 @@ async function runLineupEditorInk(
       { label: 'Cancel', value: { kind: 'cancel' } },
     ];
     const pick = await requestMenu(entries, {
-      title: `Lineup: ${draft.name}${opts.isNew ? ' (draft)' : ''}`,
+      title: `Lineup: ${draft.name}${opts.isNew ? ' (draft)' : ''} — pick a role`,
     });
     if (pick.cancelled) return null;
     const value = pick.item.value as
-      | { kind: 'tier'; tier: LineupTier }
+      | { kind: 'role'; roleId: RoleId }
       | { kind: 'rename' | 'save' | 'save-new' | 'delete' | 'cancel' };
     if (value.kind === 'cancel') return null;
-    if (value.kind === 'tier') {
-      const next = await pickLineupSlotInk(
+    if (value.kind === 'role') {
+      const nextSlots = await runRoleSlotsEditorInk(
+        value.roleId,
+        draft.roles[value.roleId],
         config,
-        value.tier,
-        draft[value.tier],
         requestMenu,
         requestGridMenu,
         requestTextInput,
         flashToast,
       );
-      if (next) draft = { ...draft, [value.tier]: next };
+      draft = {
+        ...draft,
+        roles: { ...draft.roles, [value.roleId]: nextSlots },
+      };
       continue;
     }
     if (value.kind === 'rename') {
@@ -3507,9 +3582,7 @@ async function runLineupEditorInk(
         const saved = saveLineup({
           id: draft.id,
           name: draft.name,
-          premium: draft.premium,
-          mid: draft.mid,
-          cheap: draft.cheap,
+          roles: draft.roles,
         });
         return saved;
       } catch (err) {
@@ -3522,9 +3595,7 @@ async function runLineupEditorInk(
         const saved = saveLineup({
           // omit id so saveLineup slugs from name
           name: draft.name,
-          premium: draft.premium,
-          mid: draft.mid,
-          cheap: draft.cheap,
+          roles: draft.roles,
         });
         return saved;
       } catch (err) {

--- a/src/ui/SlashHints.tsx
+++ b/src/ui/SlashHints.tsx
@@ -26,7 +26,7 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
   { name: '/rag', description: 'Toggle / inspect the RAG store' },
   { name: '/facts', description: 'Show RAG facts in the current context window' },
   { name: '/policy', description: 'Show last policy decision' },
-  { name: '/lineup', description: 'Edit the active tier lineup (premium/mid/cheap)' },
+  { name: '/lineup', description: 'Edit the active lineup (per-role × premium/mid/cheap)' },
   { name: '/lineups', description: 'List, switch, or create tier lineups' },
   { name: '/models', description: 'Browse the model catalog and add custom providers' },
   { name: '/refresh-models', description: 'Force-refresh the model catalog from the gateway' },

--- a/src/ui/__tests__/MenuOverlay.test.tsx
+++ b/src/ui/__tests__/MenuOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
+import { Text } from 'ink';
 import { MenuOverlay } from '../overlays/MenuOverlay.js';
 import type { MenuEntry } from '../menu-types.js';
 import { ESC, ENTER, ARROW_UP, ARROW_DOWN, CTRL_C, SPACE, tick } from './_keys.js';
@@ -150,6 +151,66 @@ describe('<MenuOverlay>', () => {
     expect(qIdx).toBeGreaterThanOrEqual(0);
     expect(qIdx).toBeLessThan(titleIdx);
     expect(titleIdx).toBeLessThan(itemIdx);
+  });
+});
+
+describe('<MenuOverlay> split layout', () => {
+  const SPLIT_ENTRIES: MenuEntry[] = [
+    { label: 'Orchestrator', description: 'left-list desc (should be hidden)', value: 'orch' },
+    { label: 'Coder', value: 'coder' },
+  ];
+  const renderDetail = (item: { label: string; value?: unknown }) =>
+    createElement(Text, null, `detail for ${String(item.value)}`);
+
+  function mountSplit(extra?: Partial<Parameters<typeof MenuOverlay>[0]['options']>) {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const harness = render(
+      createElement(MenuOverlay, {
+        entries: SPLIT_ENTRIES,
+        onSelect,
+        onCancel,
+        options: { layout: 'split', renderDetail, ...extra },
+      }),
+    );
+    return { ...harness, onSelect, onCancel };
+  }
+
+  it('renders the detail card for the highlighted row and hides the left-list description', () => {
+    const { lastFrame } = mountSplit();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('1. Orchestrator');
+    expect(frame).toContain('2. Coder');
+    // The card title (label) + detail content for the first (highlighted) row.
+    expect(frame).toContain('detail for orch');
+    // The per-row highlight description is suppressed in split mode.
+    expect(frame).not.toContain('left-list desc');
+  });
+
+  it('updates the detail card as the highlight moves', async () => {
+    const { lastFrame, stdin } = mountSplit();
+    await tick();
+    stdin.write(ARROW_DOWN);
+    await tick();
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('detail for coder');
+    expect(frame).not.toContain('detail for orch');
+  });
+
+  it('falls back to the list layout when renderDetail is absent', () => {
+    const { lastFrame } = mountSplit({ renderDetail: undefined });
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('1. Orchestrator');
+    expect(frame).not.toContain('detail for');
+  });
+
+  it('Enter still commits the highlighted item in split mode', async () => {
+    const { stdin, onSelect } = mountSplit();
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][1].value).toBe('orch');
   });
 });
 

--- a/src/ui/menu-types.ts
+++ b/src/ui/menu-types.ts
@@ -8,6 +8,8 @@
  * wiring keep a stable shape without importing the deleted runtime.
  */
 
+import type { ReactNode } from 'react';
+
 /** A single selectable item in a menu. */
 export interface MenuItem {
   /** Text shown next to the number. */
@@ -46,6 +48,21 @@ export interface MenuOptions {
    * the item the user just drilled into. Clamped to the item range.
    */
   initialIndex?: number;
+  /**
+   * Menu layout. `'list'` (default) is the classic single column. `'split'`
+   * renders the numbered list in a narrow left pane and a bordered detail card
+   * for the highlighted row on the right (driven by {@link renderDetail}). The
+   * per-row highlight description is suppressed in split mode — the detail card
+   * carries that information instead.
+   */
+  layout?: 'list' | 'split';
+  /**
+   * Detail renderer for the right-hand card in `'split'` layout. Receives the
+   * currently-highlighted item and returns the inner content of the card; the
+   * overlay supplies the border and the item's `label` as the card title.
+   * Ignored unless `layout === 'split'`.
+   */
+  renderDetail?: (item: MenuItem) => ReactNode;
 }
 
 /** Options for the `TextInputOverlay` component. */

--- a/src/ui/overlays/HelpOverlay.tsx
+++ b/src/ui/overlays/HelpOverlay.tsx
@@ -21,7 +21,7 @@ const HELP_ROWS: HelpRow[] = [
   { command: '/mcp', description: 'List MCP servers and tools' },
   { command: '/cron', description: 'Show cron jobs and daemon status' },
   { command: '/facts', description: 'Show RAG facts in the current context window' },
-  { command: '/lineup', description: 'Edit the active tier lineup (premium/mid/cheap)' },
+  { command: '/lineup', description: 'Edit the active lineup (per-role × premium/mid/cheap)' },
   { command: '/lineups', description: 'List, switch, or create tier lineups' },
   { command: '/models', description: 'Browse the model catalog and add custom providers' },
   { command: '/refresh-models', description: 'Force-refresh the model catalog from the gateway' },

--- a/src/ui/overlays/MenuOverlay.tsx
+++ b/src/ui/overlays/MenuOverlay.tsx
@@ -155,6 +155,13 @@ export function MenuOverlay({
     }
   });
 
+  // Split layout: numbered list on the left, a bordered detail card for the
+  // highlighted row on the right. Falls back to the classic single column when
+  // no detail renderer is supplied. Multi-select never uses split (checkboxes
+  // belong in a flat list), so the branch is single-select only.
+  const isSplit = options?.layout === 'split' && !multiSelect && !!options?.renderDetail;
+  const highlightedItem = items[highlight];
+
   return (
     <Box flexDirection="column" marginTop={1}>
       {options?.headerLines?.map((line, idx) => (
@@ -169,7 +176,41 @@ export function MenuOverlay({
           <Text> </Text>
         </>
       )}
-      <MenuList entries={entries} highlight={highlight} multiSelect={multiSelect} checked={checked} />
+      {isSplit ? (
+        <Box flexDirection="row">
+          <Box flexDirection="column" marginRight={3}>
+            <MenuList
+              entries={entries}
+              highlight={highlight}
+              multiSelect={false}
+              checked={checked}
+              suppressDescription
+            />
+          </Box>
+          {highlightedItem && (
+            <Box
+              flexDirection="column"
+              borderStyle="round"
+              borderColor={colors.muted}
+              paddingX={1}
+              minWidth={50}
+            >
+              <Text color={colors.accent} bold>
+                {highlightedItem.label}
+              </Text>
+              <Text> </Text>
+              {options!.renderDetail!(highlightedItem)}
+            </Box>
+          )}
+        </Box>
+      ) : (
+        <MenuList
+          entries={entries}
+          highlight={highlight}
+          multiSelect={multiSelect}
+          checked={checked}
+        />
+      )}
       <Text> </Text>
       <Text dimColor>
         {multiSelect
@@ -185,11 +226,14 @@ function MenuList({
   highlight,
   multiSelect = false,
   checked,
+  suppressDescription = false,
 }: {
   entries: MenuEntry[];
   highlight: number;
   multiSelect?: boolean;
   checked?: Set<number>;
+  /** Split layout hides the per-row description — the detail card shows it. */
+  suppressDescription?: boolean;
 }) {
   const colors = getThemeColors();
   let itemIndex = 0;
@@ -214,7 +258,7 @@ function MenuList({
         return (
           <Box key={`i-${idx}`} flexDirection="column">
             <MenuRow selected={isHighlighted} label={label} />
-            {isHighlighted && entry.description && (
+            {!suppressDescription && isHighlighted && entry.description && (
               <Box marginLeft={4}>
                 <Text dimColor>{entry.description}</Text>
               </Box>

--- a/src/ui/overlays/ViewerShell.tsx
+++ b/src/ui/overlays/ViewerShell.tsx
@@ -15,10 +15,14 @@ export interface OverlayTab {
 }
 
 /**
- * Height of the overlay frame. Always one short of the terminal: a dynamic
+ * Upper bound for the overlay frame, used only to size the content viewport
+ * (see {@link viewerViewport}). Always one short of the terminal: a dynamic
  * (non-Static) Ink frame that fills the last row can't be erased cleanly — the
  * trailing newline scrolls the terminal and desyncs the cursor math, leaving
  * stale rows after the overlay closes.
+ *
+ * NOTE: the shell deliberately does NOT pin its Box to this height — see the
+ * `ViewerShell` body for why. This is a windowing bound, not a layout height.
  */
 export function viewerFrameHeight(rows: number): number {
   return Math.max(1, rows - 1);
@@ -62,9 +66,18 @@ interface ViewerShellProps {
  * layered inside owns its own navigation keys via a separate `useInput` (Ink
  * dispatches to both).
  *
- * The frame is pinned to `viewerFrameHeight(rows)` so it fills the screen and
- * reads as a replacement for the thread, while `<Thread>` stays mounted
- * (unmounting it would reprint `<Static>` scrollback — see `src/ui/Thread.tsx`).
+ * The shell sizes to its (already windowed) content rather than pinning to the
+ * full terminal height. An earlier version pinned the Box to
+ * `viewerFrameHeight(rows)` to read as a full-screen "replacement" for the
+ * thread, but that ballooned Ink's dynamic region from a few lines to nearly
+ * the whole screen on open. Since the welcome splash and finalized turns live
+ * in terminal scrollback *above* Ink's region (printed pre-Ink / via `<Static>`
+ * — see `src/index.ts` `printWelcome` and `src/ui/Thread.tsx`), that growth
+ * scrolled them off the top; on close Ink shrank the region back and the prompt
+ * was stranded at the top of an otherwise-blank screen. Sizing to content keeps
+ * the region small, so closing the viewer restores the prior layout in place.
+ * The caller still windows content to `viewerViewport(rows)`, so the frame can
+ * never exceed the screen.
  */
 export function ViewerShell({
   tabs = [],
@@ -76,7 +89,6 @@ export function ViewerShell({
   onCycleTab = () => {},
 }: ViewerShellProps) {
   const { stdout } = useStdout();
-  const rows = stdout?.rows ?? 24;
   const cols = stdout?.columns ?? 80;
   // App wraps the overlay in paddingX={2}, so the usable width is cols - 4.
   const rule = '─'.repeat(Math.max(4, cols - 4));
@@ -87,9 +99,8 @@ export function ViewerShell({
   });
 
   return (
-    <Box flexDirection="column" height={viewerFrameHeight(rows)}>
+    <Box flexDirection="column">
       {children}
-      <Box flexGrow={1} />
       <Text dimColor>
         {position ? `rows ${position.first}–${position.last} of ${position.total}` : ' '}
       </Text>


### PR DESCRIPTION
## Summary

Lineups become a **2D matrix** — 6 functional roles × 3 cost tiers (premium/mid/cheap) = 18 `(provider, model)` slots. Cost and role are **orthogonal dimensions**: `model-mode` still selects the cost tier per role, while the new role dimension selects which model family does which job. This lets a user say, e.g., "my **coder** role uses a top-tier model in performance mode but a cheaper one in token-saving mode."

Closes #264.

## What changed

- **`src/model-roles.ts`** *(new — single source of truth)*: 6 roles (`orchestrator`, `executor`, `function-caller`, `summarizer`, `classifier`, `coder`), `DEFAULT_ROLE_TIERS`, `SITE_ROLE`. Adding a 7th role is a one-place additive edit.
- **`src/lineups.ts`**: `roles`-keyed schema + `migrateLineupShape` (legacy flat → replicated across all roles; missing-role backfill from the orchestrator anchor), nested role×tier validation, role-replicating seed.
- **`src/model-policy.ts`**: re-keyed tier resolution via role, 18-slot off-lineup pin guard, role-aware snapshots.
- **`src/agent-prompt.ts`**: orchestrator-ladder prompt line under the new schema (no longer crashes on `lineup.premium`).
- **`src/ui/App.tsx`**: 2-level editor — pick a role, then set its premium/mid/cheap models.
- **Discoverability**: updated `/lineup` strings in HelpOverlay, SlashHints, output.ts.

## Backward compatibility

Migration is **byte-for-byte behavior-preserving**: existing flat `{premium,mid,cheap}` lineups auto-upgrade by replicating each cost slot across all 6 roles, so the resolved `(provider, model)` is identical until a user customizes a role. Model-mode presets are unchanged.

## Testing

- `npm run build` — clean
- `src/lineups.test.ts` (18) + `src/model-policy.test.ts` (51) — pass, including new migration + backfill tests
- Full suite: 2855/2856 pass. The one failure (`/cron: Disable flips the job enabled flag`) is **pre-existing** — confirmed failing on the clean tree with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)