### PR TITLE
fix(usage): always show all tiers (incl. premium) in Usage & Cost panel

### DIFF
--- a/src/model-roles.ts
+++ b/src/model-roles.ts
@@ -169,6 +169,17 @@ export const DEFAULT_ROLE_TIERS: Record<ModelMode, Record<RoleId, ModelTier>> = 
 })();
 
 /**
+ * The set of cost tiers any role actually resolves to under a given mode. Lets
+ * callers ask "can this mode ever reach `premium`?" without traversing
+ * {@link DEFAULT_ROLE_TIERS} themselves — e.g. the Usage & Cost panel uses it to
+ * tell a *structurally unused* tier (premium under `optimize-tokens`) apart from
+ * one that was merely idle this turn.
+ */
+export function tiersReachableInMode(mode: ModelMode): Set<ModelTier> {
+  return new Set(Object.values(DEFAULT_ROLE_TIERS[mode]));
+}
+
+/**
  * Static map from every policy-resolved call site to its functional role.
  * Every `ModelSite` must appear here — this is the documented, single-place
  * assignment required by #264 requirement 2.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 import type { Agent } from '../agent.js';
 import type { BernardConfig } from '../config.js';
@@ -143,6 +143,7 @@ import { ConfirmDialog } from './overlays/ConfirmDialog.js';
 import { StatusViewer } from './overlays/StatusViewer.js';
 import { SourcesViewer } from './overlays/SourcesViewer.js';
 import { UsageViewer } from './overlays/UsageViewer.js';
+import { representativeTierModels } from '../usage-report.js';
 import { HelpOverlay } from './overlays/HelpOverlay.js';
 import { TextInputOverlay } from './overlays/TextInputOverlay.js';
 import { InfoOverlay } from './overlays/InfoOverlay.js';
@@ -337,6 +338,12 @@ export function App({
   const { exit } = useApp();
   const [activeOverlay, setActiveOverlay] = useState<Overlay | null>(null);
   const [busy, setBusy] = useState(false);
+  // Representative per-tier models for the active lineup, so the Usage & Cost
+  // panel can always render all three tiers (premium/mid/cheap) — dimmed zero-
+  // rows for tiers with no traffic — instead of silently hiding the high-end
+  // tier in modes that never reach it (#258 follow-up). `config` is a stable
+  // App-lifetime ref; the single small lineup-file read happens once on mount.
+  const usageTierModels = useMemo(() => representativeTierModels(config), [config]);
   // Append-only log of finalized turns, rendered through Ink's `<Static>` so
   // each entry becomes terminal scrollback that is never repainted (#232).
   // `<App>` commits to this at turn boundaries; the streaming message and the
@@ -2886,6 +2893,8 @@ export function App({
       {activeOverlay === 'usage' && (
         <UsageViewer
           agent={agent}
+          tierModels={usageTierModels}
+          modelMode={config.modelMode}
           onClose={() => setActiveOverlay(null)}
           onCycleTab={() => setActiveOverlay('status')}
         />

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -341,9 +341,12 @@ export function App({
   // Representative per-tier models for the active lineup, so the Usage & Cost
   // panel can always render all three tiers (premium/mid/cheap) — dimmed zero-
   // rows for tiers with no traffic — instead of silently hiding the high-end
-  // tier in modes that never reach it (#258 follow-up). Resolved lazily: the
-  // small lineup-file read only happens once the user opens the panel, not at
-  // startup for every session.
+  // tier in modes that never reach it (#258 follow-up). Resolved only while the
+  // panel is open (no read at startup if it's never opened) and re-read on each
+  // open: `config` is mutated in place on a profile/lineup switch (stable
+  // identity), so re-resolving per open is what keeps the tiers in sync with a
+  // mid-session switch. The lineup file is tiny and already read per turn by
+  // model-policy, so the per-open read is negligible.
   const usageTierModels = useMemo(
     () => (activeOverlay === 'usage' ? representativeTierModels(config) : undefined),
     [activeOverlay, config],

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -341,9 +341,13 @@ export function App({
   // Representative per-tier models for the active lineup, so the Usage & Cost
   // panel can always render all three tiers (premium/mid/cheap) — dimmed zero-
   // rows for tiers with no traffic — instead of silently hiding the high-end
-  // tier in modes that never reach it (#258 follow-up). `config` is a stable
-  // App-lifetime ref; the single small lineup-file read happens once on mount.
-  const usageTierModels = useMemo(() => representativeTierModels(config), [config]);
+  // tier in modes that never reach it (#258 follow-up). Resolved lazily: the
+  // small lineup-file read only happens once the user opens the panel, not at
+  // startup for every session.
+  const usageTierModels = useMemo(
+    () => (activeOverlay === 'usage' ? representativeTierModels(config) : undefined),
+    [activeOverlay, config],
+  );
   // Append-only log of finalized turns, rendered through Ink's `<Static>` so
   // each entry becomes terminal scrollback that is never repainted (#232).
   // `<App>` commits to this at turn boundaries; the streaming message and the

--- a/src/ui/__tests__/UsageViewer.test.tsx
+++ b/src/ui/__tests__/UsageViewer.test.tsx
@@ -43,4 +43,36 @@ describe('<UsageViewer>', () => {
     const { lastFrame } = render(createElement(UsageViewer, { agent: agentWithLedger(null) }));
     expect(lastFrame() ?? '').toContain('No usage recorded yet');
   });
+
+  it('always shows all tiers (incl. dimmed premium) with a mode note when tierModels is given', () => {
+    // optimize-tokens turn: only mid + cheap billed tokens — premium had none.
+    const agent = agentWithLedger([
+      entry({ bucket: 'mid', provider: 'xai', modelName: 'grok-4.3', site: 'main', promptTokens: 761000, completionTokens: 516, calls: 8 }),
+      entry({ bucket: 'cheap', provider: 'xai', modelName: 'grok-4.20', site: 'rewriter', promptTokens: 302000, completionTokens: 937, calls: 7 }),
+    ]);
+    const tierModels = {
+      premium: { provider: 'xai', model: 'grok-4.3' },
+      mid: { provider: 'xai', model: 'grok-4.3' },
+      cheap: { provider: 'xai', model: 'grok-4.20' },
+    };
+    const { lastFrame } = render(
+      createElement(UsageViewer, { agent, tierModels, modelMode: 'optimize-tokens' }),
+    );
+    const frame = lastFrame() ?? '';
+    // The high-end tier is now visible even though it had no calls this turn.
+    expect(frame).toContain('premium');
+    expect(frame).toContain('mid');
+    expect(frame).toContain('cheap');
+    // Footer note explains the absence: premium is structurally unused here.
+    expect(frame).toContain('optimize-tokens');
+    expect(frame).toMatch(/premium is not used in this mode/);
+  });
+
+  it('omits zero-fill (legacy behavior) when no tierModels is provided', () => {
+    const agent = agentWithLedger([
+      entry({ bucket: 'mid', provider: 'xai', modelName: 'grok-4.3', site: 'main', promptTokens: 1000, completionTokens: 100, calls: 2 }),
+    ]);
+    const { lastFrame } = render(createElement(UsageViewer, { agent }));
+    expect(lastFrame() ?? '').not.toContain('premium');
+  });
 });

--- a/src/ui/overlays/UsageViewer.tsx
+++ b/src/ui/overlays/UsageViewer.tsx
@@ -2,7 +2,10 @@ import { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import type { Agent } from '../../agent.js';
 import { formatTokenCount } from '../../output.js';
-import { computeTurnUsageReport, formatUsd, type UsageReportRow } from '../../usage-report.js';
+import { computeTurnUsageReport, fillTierRows, formatUsd, type UsageReportRow } from '../../usage-report.js';
+import { LINEUP_TIERS, type LineupTier, type LineupSlot } from '../../lineups.js';
+import { DEFAULT_ROLE_TIERS } from '../../model-roles.js';
+import type { ModelMode } from '../../model-policy.js';
 import { getThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
 import { ScrollableOverlay, type OverlayLine } from './ScrollableOverlay.js';
@@ -10,6 +13,16 @@ import { VIEWER_TABS } from './viewer-tabs.js';
 
 interface UsageViewerProps {
   agent: Agent;
+  /**
+   * Representative `(provider, model)` per cost tier for the active lineup
+   * (`representativeTierModels(config)`). When present, the panel always renders
+   * all three tiers — appending dimmed zero-rows for tiers with no usage this
+   * turn so the high-end tier is visible even in modes that never reach it.
+   * Omitted in standalone renders/tests → only used tiers are shown (legacy).
+   */
+  tierModels?: Record<LineupTier, LineupSlot>;
+  /** Active model mode — drives the footer note explaining unused tiers. */
+  modelMode?: ModelMode;
   /** Close the panel (Esc). Defaults to a no-op for standalone rendering/tests. */
   onClose?: () => void;
   /** Advance to the next Shift-Tab tab. Defaults to a no-op. */
@@ -28,10 +41,10 @@ const NUM_W = 9;
  * and renders through the shared `ScrollableOverlay` so it shares the Shift-Tab
  * tab strip + Esc/scroll keystream with the Status / Sources viewers.
  */
-export function UsageViewer({ agent, onClose, onCycleTab }: UsageViewerProps) {
+export function UsageViewer({ agent, tierModels, modelMode, onClose, onCycleTab }: UsageViewerProps) {
   // Stats are stable while the viewer owns the keystream (the agent is idle), so
   // compute the report once rather than on every scroll keystroke.
-  const lines = useMemo(() => buildLines(agent), [agent]);
+  const lines = useMemo(() => buildLines(agent, tierModels, modelMode), [agent, tierModels, modelMode]);
   return (
     <ScrollableOverlay
       tabs={VIEWER_TABS}
@@ -86,7 +99,11 @@ function Row({
   );
 }
 
-function buildLines(agent: Agent): OverlayLine[] {
+function buildLines(
+  agent: Agent,
+  tierModels?: Record<LineupTier, LineupSlot>,
+  modelMode?: ModelMode,
+): OverlayLine[] {
   const colors = getThemeColors();
   const report = computeTurnUsageReport(agent.spinnerStats);
   const lines: OverlayLine[] = [];
@@ -104,7 +121,11 @@ function buildLines(agent: Agent): OverlayLine[] {
     node: <Row cells={{ label: 'TIER / MODEL', calls: 'calls', tin: 'in', tout: 'out', cost: '~cost' }} bold dim />,
   });
 
-  for (const row of report.rows) {
+  // Always show every lineup tier when we know the active lineup's models:
+  // zero-fill the tiers that had no traffic so the high-end tier stays visible
+  // even in modes that never reach it (e.g. `optimize-tokens` → no premium).
+  const displayRows = tierModels ? fillTierRows(report.rows, tierModels) : report.rows;
+  for (const row of displayRows) {
     lines.push({ key: rowKey(row), node: <UsageRow row={row} colors={colors} /> });
   }
 
@@ -127,6 +148,10 @@ function buildLines(agent: Agent): OverlayLine[] {
 
   // Footnotes.
   lines.push({ key: 'spacer', node: <Text> </Text> });
+  const tierNote = tierModels ? buildTierNote(displayRows, modelMode) : null;
+  if (tierNote) {
+    lines.push({ key: 'tier-note', node: <Text dimColor>{tierNote}</Text> });
+  }
   if (report.totalCacheReadTokens > 0) {
     lines.push({
       key: 'cache-note',
@@ -156,9 +181,39 @@ function rowKey(row: UsageReportRow): string {
   return `row-${row.bucket}-${row.provider}-${row.modelName}`;
 }
 
+/**
+ * Footer note explaining the dimmed zero-usage tier rows. Splits the unused
+ * tiers into those the active mode *never reaches* (structurally unused — e.g.
+ * `premium` under `optimize-tokens`) and those merely idle this turn, so the
+ * absence reads as intentional rather than a bug. Returns `null` when every
+ * shown tier had traffic.
+ */
+function buildTierNote(rows: UsageReportRow[], modelMode?: ModelMode): string | null {
+  const unused = LINEUP_TIERS.filter((tier) => rows.some((r) => r.bucket === tier && r.calls === 0));
+  if (unused.length === 0) return null;
+
+  if (modelMode) {
+    const reachable = new Set(Object.values(DEFAULT_ROLE_TIERS[modelMode]));
+    const structural = unused.filter((t) => !reachable.has(t));
+    const idle = unused.filter((t) => reachable.has(t));
+    const parts: string[] = [`Mode: ${modelMode}.`];
+    if (structural.length > 0) {
+      parts.push(`${structural.join('/')} ${structural.length > 1 ? 'are' : 'is'} not used in this mode.`);
+    }
+    if (idle.length > 0) {
+      parts.push(`${idle.join('/')} had no calls this turn.`);
+    }
+    return parts.join(' ');
+  }
+  return `Dimmed tiers (${unused.join('/')}) had no calls this turn.`;
+}
+
 function UsageRow({ row, colors }: { row: UsageReportRow; colors: ReturnType<typeof getThemeColors> }) {
-  const tierColor =
-    row.bucket === 'premium'
+  const zero = row.calls === 0;
+  const dash = '—';
+  const tierColor = zero
+    ? colors.muted
+    : row.bucket === 'premium'
       ? colors.accent
       : row.bucket === 'pinned'
         ? colors.warning
@@ -167,13 +222,14 @@ function UsageRow({ row, colors }: { row: UsageReportRow; colors: ReturnType<typ
     <Row
       cells={{
         label: `${row.bucket.padEnd(7)} ${row.modelName}`,
-        calls: String(row.calls),
-        tin: formatTokenCount(row.promptTokens),
-        tout: formatTokenCount(row.completionTokens),
-        cost: row.costUsd === null ? 'n/a' : `~${formatUsd(row.costUsd)}`,
+        calls: zero ? dash : String(row.calls),
+        tin: zero ? dash : formatTokenCount(row.promptTokens),
+        tout: zero ? dash : formatTokenCount(row.completionTokens),
+        cost: zero ? dash : row.costUsd === null ? 'n/a' : `~${formatUsd(row.costUsd)}`,
       }}
       labelColor={tierColor}
-      costColor={row.costUsd === null ? colors.muted : colors.text}
+      costColor={zero ? colors.muted : row.costUsd === null ? colors.muted : colors.text}
+      dim={zero}
     />
   );
 }

--- a/src/ui/overlays/UsageViewer.tsx
+++ b/src/ui/overlays/UsageViewer.tsx
@@ -4,7 +4,7 @@ import type { Agent } from '../../agent.js';
 import { formatTokenCount } from '../../output.js';
 import { computeTurnUsageReport, fillTierRows, formatUsd, type UsageReportRow } from '../../usage-report.js';
 import { LINEUP_TIERS, type LineupTier, type LineupSlot } from '../../lineups.js';
-import { DEFAULT_ROLE_TIERS } from '../../model-roles.js';
+import { tiersReachableInMode } from '../../model-roles.js';
 import type { ModelMode } from '../../model-policy.js';
 import { getThemeColors } from '../../theme.js';
 import { truncate } from '../../text.js';
@@ -193,7 +193,7 @@ function buildTierNote(rows: UsageReportRow[], modelMode?: ModelMode): string | 
   if (unused.length === 0) return null;
 
   if (modelMode) {
-    const reachable = new Set(Object.values(DEFAULT_ROLE_TIERS[modelMode]));
+    const reachable = tiersReachableInMode(modelMode);
     const structural = unused.filter((t) => !reachable.has(t));
     const idle = unused.filter((t) => reachable.has(t));
     const parts: string[] = [`Mode: ${modelMode}.`];
@@ -228,7 +228,7 @@ function UsageRow({ row, colors }: { row: UsageReportRow; colors: ReturnType<typ
         cost: zero ? dash : row.costUsd === null ? 'n/a' : `~${formatUsd(row.costUsd)}`,
       }}
       labelColor={tierColor}
-      costColor={zero ? colors.muted : row.costUsd === null ? colors.muted : colors.text}
+      costColor={!zero && row.costUsd !== null ? colors.text : colors.muted}
       dim={zero}
     />
   );

--- a/src/usage-report.test.ts
+++ b/src/usage-report.test.ts
@@ -14,7 +14,13 @@ vi.mock('./providers/catalog.js', () => ({
   },
 }));
 
-const { computeTurnUsageReport, formatUsd, formatTurnCost, formatCostSuffix } = await import('./usage-report.js');
+const { computeTurnUsageReport, fillTierRows, formatUsd, formatTurnCost, formatCostSuffix } = await import('./usage-report.js');
+
+const TIER_MODELS = {
+  premium: { provider: 'xai', model: 'grok-4.3' },
+  mid: { provider: 'xai', model: 'grok-4.3' },
+  cheap: { provider: 'xai', model: 'grok-4.20-non-reasoning' },
+};
 
 function entry(over: Partial<TurnUsageEntry> & Pick<TurnUsageEntry, 'bucket' | 'provider' | 'modelName' | 'site'>): TurnUsageEntry {
   return {
@@ -87,6 +93,44 @@ describe('computeTurnUsageReport (#258)', () => {
     );
     expect(report.totalCostUsd).toBeNull();
     expect(report.partial).toBe(true);
+  });
+});
+
+describe('fillTierRows (always-show-all-tiers)', () => {
+  function reportRows(stats: SpinnerStats) {
+    return computeTurnUsageReport(stats).rows;
+  }
+
+  it('appends dimmed zero-rows for tiers with no usage, premium first', () => {
+    // optimize-tokens-style turn: only mid + cheap had traffic, no premium.
+    const rows = reportRows(
+      statsWith([
+        entry({ bucket: 'mid', provider: 'xai', modelName: 'grok-4.3', site: 'main', promptTokens: 761000, completionTokens: 516, calls: 8 }),
+        entry({ bucket: 'cheap', provider: 'xai', modelName: 'grok-4.20-non-reasoning', site: 'rewriter', promptTokens: 302000, completionTokens: 937, calls: 7 }),
+      ]),
+    );
+    const filled = fillTierRows(rows, TIER_MODELS);
+
+    expect(filled.map((r) => r.bucket)).toEqual(['premium', 'mid', 'cheap']);
+    const premium = filled.find((r) => r.bucket === 'premium')!;
+    expect(premium.calls).toBe(0);
+    expect(premium.promptTokens).toBe(0);
+    expect(premium.costUsd).toBeNull();
+    expect(premium.modelName).toBe('grok-4.3'); // representative from the lineup
+  });
+
+  it('leaves present tiers untouched and never duplicates them', () => {
+    const rows = reportRows(
+      statsWith([
+        entry({ bucket: 'premium', provider: 'xai', modelName: 'grok-4.3', site: 'main', promptTokens: 1000, completionTokens: 100, calls: 3 }),
+      ]),
+    );
+    const filled = fillTierRows(rows, TIER_MODELS);
+
+    expect(filled.map((r) => r.bucket)).toEqual(['premium', 'mid', 'cheap']);
+    const premium = filled.filter((r) => r.bucket === 'premium');
+    expect(premium).toHaveLength(1);
+    expect(premium[0]!.calls).toBe(3); // real usage preserved, not zeroed
   });
 });
 

--- a/src/usage-report.ts
+++ b/src/usage-report.ts
@@ -1,6 +1,7 @@
 import type { SpinnerStats, TurnUsageEntry, UsageBucket } from './output.js';
+import type { BernardConfig } from './config.js';
 import { getModelMeta } from './providers/catalog.js';
-import { LINEUP_TIERS } from './lineups.js';
+import { LINEUP_TIERS, loadLineups, resolveActiveLineup, type LineupTier, type LineupSlot } from './lineups.js';
 
 /**
  * Per-turn token + cost insights (#258). Aggregates the {@link SpinnerStats}
@@ -136,6 +137,58 @@ export function computeTurnUsageReport(stats: SpinnerStats | null): UsageReport 
     totalCostUsd: pricedCount > 0 ? costSum : null,
     partial: pricedCount < rows.length,
   };
+}
+
+/**
+ * Representative `(provider, model)` for each cost tier (premium/mid/cheap) of
+ * the active lineup, taken from the headline `orchestrator` role. The Usage &
+ * Cost panel uses this to label the **zero-usage** tier rows it always shows, so
+ * the high-end tier is visible even in modes that never reach it (e.g.
+ * `optimize-tokens` never assigns `premium`). Does a single small lineup-file
+ * read — deliberately kept out of the hot pure path (`computeTurnUsageReport`)
+ * and resolved once at panel-open time by the caller.
+ */
+export function representativeTierModels(config: BernardConfig): Record<LineupTier, LineupSlot> {
+  const lineup = resolveActiveLineup(loadLineups(), config.activeLineupId, config.provider);
+  const ladder = lineup.roles.orchestrator;
+  return { premium: ladder.premium, mid: ladder.mid, cheap: ladder.cheap };
+}
+
+/**
+ * Ensures every lineup cost tier (premium/mid/cheap) is represented in the
+ * display rows: for any tier with no usage this turn, appends a synthetic
+ * **zero-row** (`calls: 0`, all tokens 0) labelled with that tier's
+ * representative model, then re-sorts the combined set by tier order. Purely
+ * presentational — it does NOT touch the report totals (which are computed
+ * upstream over the real ledger only). Zero-rows are identified downstream by
+ * `calls === 0`. `pinned` rows (specialist pins) pass through untouched; only
+ * the three lineup tiers are zero-filled.
+ */
+export function fillTierRows(
+  rows: UsageReportRow[],
+  tierModels: Record<LineupTier, LineupSlot>,
+): UsageReportRow[] {
+  const present = new Set(rows.map((r) => r.bucket));
+  const filled = [...rows];
+  for (const tier of LINEUP_TIERS) {
+    if (present.has(tier)) continue;
+    const slot = tierModels[tier];
+    filled.push({
+      bucket: tier,
+      provider: slot.provider,
+      modelName: slot.model,
+      promptTokens: 0,
+      completionTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      calls: 0,
+      costUsd: null,
+      sites: [],
+    });
+  }
+  return filled.sort(
+    (a, b) => BUCKET_ORDER[a.bucket] - BUCKET_ORDER[b.bucket] || b.promptTokens - a.promptTokens,
+  );
 }
 
 /** Format a USD amount with precision scaled to magnitude (e.g. `$0.07`, `$0.0042`, `$1.20`). */

--- a/src/usage-report.ts
+++ b/src/usage-report.ts
@@ -48,6 +48,11 @@ const BUCKET_ORDER: Record<UsageBucket, number> = {
   pinned: LINEUP_TIERS.length,
 } as Record<UsageBucket, number>;
 
+/** Row display order: by tier (premium → cheap → pinned), then larger prompt spend first. */
+function compareUsageRows(a: UsageReportRow, b: UsageReportRow): number {
+  return BUCKET_ORDER[a.bucket] - BUCKET_ORDER[b.bucket] || b.promptTokens - a.promptTokens;
+}
+
 /**
  * Estimated USD cost of a (prompt, completion) token spend on a given model from
  * catalog pricing ($/M tok), or `null` when the model isn't in the catalog
@@ -109,7 +114,7 @@ export function computeTurnUsageReport(stats: SpinnerStats | null): UsageReport 
       sites: Array.from(siteSet).sort(),
       costUsd: priceUsageUsd(row.provider, row.modelName, row.promptTokens, row.completionTokens),
     }))
-    .sort((a, b) => BUCKET_ORDER[a.bucket] - BUCKET_ORDER[b.bucket] || b.promptTokens - a.promptTokens);
+    .sort(compareUsageRows);
 
   // Single pass over the (small) row set for every total.
   let totalPromptTokens = 0;
@@ -150,8 +155,9 @@ export function computeTurnUsageReport(stats: SpinnerStats | null): UsageReport 
  */
 export function representativeTierModels(config: BernardConfig): Record<LineupTier, LineupSlot> {
   const lineup = resolveActiveLineup(loadLineups(), config.activeLineupId, config.provider);
-  const ladder = lineup.roles.orchestrator;
-  return { premium: ladder.premium, mid: ladder.mid, cheap: ladder.cheap };
+  // `RoleSlots` is already `Record<LineupTier, LineupSlot>`, so the orchestrator
+  // ladder is exactly the shape we want (and stays correct if a tier is added).
+  return lineup.roles.orchestrator;
 }
 
 /**
@@ -168,10 +174,9 @@ export function fillTierRows(
   rows: UsageReportRow[],
   tierModels: Record<LineupTier, LineupSlot>,
 ): UsageReportRow[] {
-  const present = new Set(rows.map((r) => r.bucket));
   const filled = [...rows];
   for (const tier of LINEUP_TIERS) {
-    if (present.has(tier)) continue;
+    if (rows.some((r) => r.bucket === tier)) continue;
     const slot = tierModels[tier];
     filled.push({
       bucket: tier,
@@ -186,9 +191,7 @@ export function fillTierRows(
       sites: [],
     });
   }
-  return filled.sort(
-    (a, b) => BUCKET_ORDER[a.bucket] - BUCKET_ORDER[b.bucket] || b.promptTokens - a.promptTokens,
-  );
+  return filled.sort(compareUsageRows);
 }
 
 /** Format a USD amount with precision scaled to magnitude (e.g. `$0.07`, `$0.0042`, `$1.20`). */

--- a/src/usage-report.ts
+++ b/src/usage-report.ts
@@ -157,7 +157,10 @@ export function representativeTierModels(config: BernardConfig): Record<LineupTi
   const lineup = resolveActiveLineup(loadLineups(), config.activeLineupId, config.provider);
   // `RoleSlots` is already `Record<LineupTier, LineupSlot>`, so the orchestrator
   // ladder is exactly the shape we want (and stays correct if a tier is added).
-  return lineup.roles.orchestrator;
+  // Shallow-copy so the caller owns the object — `lineup.roles.orchestrator` is a
+  // live reference into the cached lineup, and returning it bare would let a
+  // caller's reassignment silently mutate the shared lineup for the session.
+  return { ...lineup.roles.orchestrator };
 }
 
 /**


### PR DESCRIPTION
## Problem

In the **Usage & Cost** panel (Shift+Tab → "Usage & Cost") the high-end **`premium` tier never appears** — you only see `mid` and `cheap`:

```
TIER / MODEL    calls    in     out    ~cost
mid   grok-4.3   8       761k   516    ~$0.953
cheap grok-4.3   7       302k   937    ~$0.379
TOTAL           15       1063k  1.5k   ~$1.33
```

## Root cause — not a bucketing/rendering bug

The rendering layer already fully supports `premium` (it's first in `BUCKET_ORDER` and accent-tinted). The cause is the **active mode**: under `optimize-tokens`, `orchestrator` (the main agent) runs `mid` and every other call site runs `cheap` — **no site maps to `premium`** (`src/model-roles.ts` → `DEFAULT_ROLE_TIERS`). The panel is usage-based: `computeTurnUsageReport` only emits a row per `(bucket, provider, model)` that actually billed tokens, so premium — with zero traffic — has no row. It only shows in `balanced` / `optimize-performance` (where main runs premium).

## Fix

Always render all three lineup tiers. Tiers with no traffic get a **dimmed zero-row** labelled with that tier's representative (orchestrator-role) model, plus a footer note that names the active mode and separates tiers that are *structurally unused* in the mode (e.g. "premium is not used in this mode") from those merely idle this turn:

```
TIER / MODEL       calls    in     out    ~cost
premium grok-4.3       —      —      —        —   (dim)
mid     grok-4.3       8   761k    516   ~$0.953
cheap   grok-4.3       7   302k    937   ~$0.379
TOTAL                 15  1063k    1.5k   ~$1.33

Mode: optimize-tokens. premium is not used in this mode.
```

### Changes
- **`src/usage-report.ts`** — pure `fillTierRows(rows, tierModels)` zero-fill + `representativeTierModels(config)` lineup resolver. `computeTurnUsageReport` is **untouched and still pure**, so StatusBar odometer totals are unaffected.
- **`src/ui/overlays/UsageViewer.tsx`** — optional `tierModels` / `modelMode` props drive the zero-fill, dim rendering, and footer note. No disk I/O in the viewer (kept testable).
- **`src/ui/App.tsx`** — resolves `representativeTierModels(config)` once (memoized) and passes it down with `config.modelMode`.

## Tests
- `usage-report.test.ts` — `fillTierRows` zero-fills missing tiers, preserves present ones (no dup/zeroing), orders premium→mid→cheap.
- `UsageViewer.test.tsx` — an optimize-tokens-style ledger now shows a dimmed `premium` row + mode note; empty ledger still shows "No usage recorded yet"; legacy no-`tierModels` render omits zero-fill.

Full suite green except 4 pre-existing environmental failures (cron store full, eval-harness) that also fail on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)