### PR TITLE
fix(providers): omit temperature for reasoning models

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bernard": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc && node -e \"require('fs').cpSync('src/builtin-specialists','dist/builtin-specialists',{recursive:true})\"",
+    "build": "tsc && node -e \"require('fs').cpSync('src/builtin-specialists','dist/builtin-specialists',{recursive:true})\" && node -e \"require('fs').cpSync('src/data','dist/data',{recursive:true})\"",
     "dev": "BERNARD_DEBUG=1 tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/src/__tests__/lineup-fixtures.ts
+++ b/src/__tests__/lineup-fixtures.ts
@@ -1,0 +1,22 @@
+import { ALL_ROLE_IDS } from '../model-roles.js';
+
+/** Test-only mirrors of the lineup slot shapes (see {@link module:lineups}). */
+export type Slot = { provider: string; model: string };
+export type Ladder = { premium: Slot; mid: Slot; cheap: Slot };
+
+/**
+ * Replicates one cost ladder across all roles — the migration shape a flat
+ * (role-less) lineup expands into. Mirrors the production `replicateAcrossRoles`
+ * helper, kept here so the store and policy suites share one fixture.
+ */
+export function fullRoles(ladder: Ladder): Record<string, Ladder> {
+  const out: Record<string, Ladder> = {};
+  for (const r of ALL_ROLE_IDS) {
+    out[r] = {
+      premium: { ...ladder.premium },
+      mid: { ...ladder.mid },
+      cheap: { ...ladder.cheap },
+    };
+  }
+  return out;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,9 @@ import * as fs from 'node:fs';
 import { PREFS_PATH, KEYS_PATH, ENV_PATH, LEGACY_DIR } from './paths.js';
 import { loadCustomProviders, type CustomProvider } from './custom-providers.js';
 
+/** Multi-model assignment policy modes (mirrors model-policy.ts ModelMode). */
+export type ModelMode = 'optimize-tokens' | 'balanced' | 'optimize-performance';
+
 /** Resolved runtime configuration for a Bernard session. */
 export interface BernardConfig {
   /** Active LLM provider identifier (e.g. "anthropic", "openai", "xai"). */
@@ -54,6 +57,12 @@ export interface BernardConfig {
   apiKeys?: Record<string, string>;
   /** Loaded snapshot of user-defined custom providers from `custom-providers.json`. */
   customProviders: Record<string, CustomProvider>;
+  /** Multi-model assignment policy: which tier each site uses. */
+  modelMode: ModelMode;
+  /** Active lineup id (if a lineup is selected). */
+  activeLineupId?: string;
+  /** Whether LLM sub-call and tool result caches are active. */
+  cacheEnabled: boolean;
 }
 
 const DEFAULT_PROVIDER = 'anthropic';
@@ -785,6 +794,9 @@ export function loadConfig(overrides?: { provider?: string; model?: string }): B
     xaiApiKey: process.env.XAI_API_KEY,
     apiKeys: { ...storedKeys },
     customProviders,
+    modelMode: 'balanced' as ModelMode,
+    activeLineupId: undefined,
+    cacheEnabled: true,
   };
 
   validateConfig(config);

--- a/src/data/model-catalog-fallback.json
+++ b/src/data/model-catalog-fallback.json
@@ -1,0 +1,2255 @@
+{
+  "object": "list",
+  "fetchedAt": 1780424405,
+  "data": [
+    {
+      "id": "anthropic/claude-3-haiku",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1677628800,
+      "owned_by": "anthropic",
+      "name": "Claude 3 Haiku",
+      "description": "Claude 3 Haiku is Anthropic's fastest, most compact model for near-instant responsiveness. It answers simple queries and requests with speed. Customers will be able to build seamless AI experiences that mimic human interactions. Claude 3 Haiku can process images and return text outputs, and features a 200K context window.",
+      "context_window": 200000,
+      "max_tokens": 4096,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "vision",
+        "explicit-caching"
+      ],
+      "pricing": {
+        "input": "0.00000025",
+        "output": "0.00000125",
+        "input_cache_read": "0.00000003",
+        "input_cache_write": "0.0000003"
+      }
+    },
+    {
+      "id": "anthropic/claude-3.5-haiku",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1699228800,
+      "owned_by": "anthropic",
+      "name": "Claude 3.5 Haiku",
+      "description": "Claude 3 Haiku is Anthropic's fastest, most compact model for near-instant responsiveness. It answers simple queries and requests with speed. Customers will be able to build seamless AI experiences that mimic human interactions. Claude 3 Haiku can process images and return text outputs, and features a 200K context window.",
+      "context_window": 200000,
+      "max_tokens": 8192,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "vision",
+        "explicit-caching"
+      ],
+      "pricing": {
+        "input": "0.0000008",
+        "output": "0.000004",
+        "input_cache_read": "0.00000008",
+        "input_cache_write": "0.000001"
+      }
+    },
+    {
+      "id": "anthropic/claude-haiku-4.5",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1760486400,
+      "owned_by": "anthropic",
+      "name": "Claude Haiku 4.5",
+      "description": "Claude Haiku 4.5 matches Sonnet 4's performance on coding, computer use, and agent tasks at substantially lower cost and faster speeds. It delivers near-frontier performance and Claude’s unique character at a price point that works for scaled sub-agent deployments, free tier products, and intelligence-sensitive applications with budget constraints.",
+      "context_window": 200000,
+      "max_tokens": 64000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000001",
+        "output": "0.000005",
+        "input_cache_read": "0.0000001",
+        "input_cache_write": "0.00000125",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-opus-4",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754352000,
+      "owned_by": "anthropic",
+      "name": "Claude Opus 4",
+      "description": "Claude Opus 4 is Anthropic's most powerful model yet and the best coding model in the world, leading on SWE-bench (72.5%) and Terminal-bench (43.2%). It delivers sustained performance on long-running tasks that require focused effort and thousands of steps, with the ability to work continuously for several hours—dramatically outperforming all Sonnet models and significantly expanding what AI agents can accomplish.",
+      "context_window": 200000,
+      "max_tokens": 32000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "explicit-caching"
+      ],
+      "pricing": {
+        "input": "0.000015",
+        "output": "0.000075",
+        "input_cache_read": "0.0000015",
+        "input_cache_write": "0.00001875",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-opus-4.1",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1747872000,
+      "owned_by": "anthropic",
+      "name": "Claude Opus 4.1",
+      "description": "Claude Opus 4.1 is a drop-in replacement for Opus 4 that delivers superior performance and precision for real-world coding and agentic tasks. Opus 4.1 advances state-of-the-art coding performance to 74.5% on SWE-bench Verified, and handles complex, multi-step problems with more rigor and attention to detail.",
+      "context_window": 200000,
+      "max_tokens": 32000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "explicit-caching"
+      ],
+      "pricing": {
+        "input": "0.000015",
+        "output": "0.000075",
+        "input_cache_read": "0.0000015",
+        "input_cache_write": "0.00001875",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-opus-4.5",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1732406400,
+      "owned_by": "anthropic",
+      "name": "Claude Opus 4.5",
+      "description": "Claude Opus 4.5 is Anthropic’s latest model in the Opus series, meant for demanding reasoning tasks and complex problem solving. This model has improvements in general intelligence and vision compared to previous iterations. In addition, it is suited for difficult coding tasks and agentic workflows, especially those with computer use and tool use, and can effectively handle context usage and external memory files.",
+      "context_window": 200000,
+      "max_tokens": 64000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "reasoning",
+        "vision",
+        "file-input",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000005",
+        "output": "0.000025",
+        "input_cache_read": "0.0000005",
+        "input_cache_write": "0.00000625",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-opus-4.6",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1770249600,
+      "owned_by": "anthropic",
+      "name": "Claude Opus 4.6",
+      "description": "Opus 4.6 is the world’s best model for coding and professional work, built to power agents that take on whole categories of real-world work. It excels across the entire SDLC, breaking through on hard problems, identifying complex bugs, and demonstrating deeper codebase understanding. It also delivers a step-change in knowledge work, with near-production-ready documents, presentations, and spreadsheets on the first pass.",
+      "context_window": 1000000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "reasoning",
+        "vision",
+        "file-input",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000005",
+        "output": "0.000025",
+        "input_cache_read": "0.0000005",
+        "input_cache_write": "0.00000625",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-opus-4.7",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1776297600,
+      "owned_by": "anthropic",
+      "name": "Claude Opus 4.7",
+      "description": "Opus 4.7 builds on the coding and agentic strengths of Opus 4.6 with stronger performance on complex, multi-step tasks and more reliable agentic execution. It also brings improved performance on knowledge work, from drafting documents to building presentations and analyzing data.",
+      "context_window": 1000000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "reasoning",
+        "vision",
+        "file-input",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000005",
+        "output": "0.000025",
+        "input_cache_read": "0.0000005",
+        "input_cache_write": "0.00000625",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-opus-4.8",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1779926400,
+      "owned_by": "anthropic",
+      "name": "Claude Opus 4.8",
+      "description": "Opus 4.8 is a focused upgrade to Opus 4.7 and is Anthropic's best generally available model for coding, agentic tasks, and enterprise workflows. It builds on the strengths of previous Opus models with stronger performance on complex, multi-step coding tasks. Anthropic recommends using it on long-horizon coding and agentic tasks. It is also stronger on professional work, including document drafting, data analysis, and presentations.",
+      "context_window": 1000000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "reasoning",
+        "vision",
+        "file-input",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000005",
+        "output": "0.000025",
+        "input_cache_read": "0.0000005",
+        "input_cache_write": "0.00000625",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-sonnet-4",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1747872000,
+      "owned_by": "anthropic",
+      "name": "Claude Sonnet 4",
+      "description": "Claude Sonnet 4 significantly improves on Sonnet 3.7's industry-leading capabilities, excelling in coding with a state-of-the-art 72.7% on SWE-bench. The model balances performance and efficiency for internal and external use cases, with enhanced steerability for greater control over implementations. While not matching Opus 4 in most domains, it delivers an optimal mix of capability and practicality.",
+      "context_window": 1000000,
+      "max_tokens": 64000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "explicit-caching"
+      ],
+      "pricing": {
+        "input": "0.000003",
+        "input_tiers": [
+          {
+            "cost": "0.000003",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000006",
+            "min": 200001
+          }
+        ],
+        "output": "0.000015",
+        "output_tiers": [
+          {
+            "cost": "0.000015",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000225",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000003",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000003",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000006",
+            "min": 200001
+          }
+        ],
+        "input_cache_write": "0.00000375",
+        "input_cache_write_tiers": [
+          {
+            "cost": "0.00000375",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000075",
+            "min": 200001
+          }
+        ],
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-sonnet-4.5",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1759104000,
+      "owned_by": "anthropic",
+      "name": "Claude Sonnet 4.5",
+      "description": "Claude Sonnet 4.5 is the newest model in the Sonnet series, offering improvements and updates over Sonnet 4.",
+      "context_window": 1000000,
+      "max_tokens": 64000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000003",
+        "input_tiers": [
+          {
+            "cost": "0.000003",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000006",
+            "min": 200001
+          }
+        ],
+        "output": "0.000015",
+        "output_tiers": [
+          {
+            "cost": "0.000015",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000225",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000003",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000003",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000006",
+            "min": 200001
+          }
+        ],
+        "input_cache_write": "0.00000375",
+        "input_cache_write_tiers": [
+          {
+            "cost": "0.00000375",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000075",
+            "min": 200001
+          }
+        ],
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "anthropic/claude-sonnet-4.6",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1771286400,
+      "owned_by": "anthropic",
+      "name": "Claude Sonnet 4.6",
+      "description": "Claude Sonnet 4.6 is the most capable Sonnet-class model yet, with frontier performance across coding, agents, and professional work. It excels at iterative development, complex codebase navigation, end-to-end project management with memory, polished document creation, and confident computer use for web QA and workflow automation.",
+      "context_window": 1000000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "explicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000003",
+        "output": "0.000015",
+        "input_cache_read": "0.0000003",
+        "input_cache_write": "0.00000375",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-3.5-turbo",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1685232000,
+      "owned_by": "openai",
+      "name": "GPT-3.5 Turbo",
+      "description": "OpenAI's most capable and cost effective model in the GPT-3.5 family optimized for chat purposes, but also works well for traditional completions tasks.",
+      "context_window": 16385,
+      "max_tokens": 4096,
+      "type": "language",
+      "pricing": {
+        "input": "0.0000005",
+        "output": "0.0000015"
+      }
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-instruct",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1695859200,
+      "owned_by": "openai",
+      "name": "GPT-3.5 Turbo Instruct",
+      "description": "Similar capabilities as GPT-3 era models. Compatible with legacy Completions endpoint and not Chat Completions.",
+      "context_window": 8192,
+      "max_tokens": 4096,
+      "type": "language",
+      "pricing": {
+        "input": "0.0000015",
+        "output": "0.000002"
+      }
+    },
+    {
+      "id": "openai/gpt-4-turbo",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1699228800,
+      "owned_by": "openai",
+      "name": "GPT-4 Turbo",
+      "description": "gpt-4-turbo from OpenAI has broad general knowledge and domain expertise allowing it to follow complex instructions in natural language and solve difficult problems accurately. It has a knowledge cutoff of April 2023 and a 128,000 token context window.",
+      "context_window": 128000,
+      "max_tokens": 4096,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "vision"
+      ],
+      "pricing": {
+        "input": "0.00001",
+        "output": "0.00003"
+      }
+    },
+    {
+      "id": "openai/gpt-4.1",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1744588800,
+      "owned_by": "openai",
+      "name": "GPT-4.1",
+      "description": "GPT 4.1 is OpenAI's flagship model for complex tasks. It is well suited for problem solving across domains.",
+      "context_window": 1047576,
+      "max_tokens": 32768,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000002",
+        "output": "0.000008",
+        "input_cache_read": "0.0000005",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000035",
+            "output": "0.000014",
+            "input_cache_read": "0.000000875"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-4.1-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1747180800,
+      "owned_by": "openai",
+      "name": "GPT-4.1 mini",
+      "description": "GPT 4.1 mini provides a balance between intelligence, speed, and cost that makes it an attractive model for many use cases.",
+      "context_window": 1047576,
+      "max_tokens": 32768,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.0000004",
+        "output": "0.0000016",
+        "input_cache_read": "0.0000001",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000007",
+            "output": "0.0000028",
+            "input_cache_read": "0.000000175"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-4.1-nano",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1744588800,
+      "owned_by": "openai",
+      "name": "GPT-4.1 nano",
+      "description": "GPT-4.1 nano is the fastest, most cost-effective GPT 4.1 model.",
+      "context_window": 1047576,
+      "max_tokens": 32768,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.0000001",
+        "output": "0.0000004",
+        "input_cache_read": "0.000000025",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000002",
+            "output": "0.0000008",
+            "input_cache_read": "0.00000005"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-4o",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1715558400,
+      "owned_by": "openai",
+      "name": "GPT-4o",
+      "description": "GPT-4o from OpenAI has broad general knowledge and domain expertise allowing it to follow complex instructions in natural language and solve difficult problems accurately. It matches GPT-4 Turbo performance with a faster and cheaper API.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.0000025",
+        "output": "0.00001",
+        "input_cache_read": "0.00000125",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.00000425",
+            "output": "0.000017",
+            "input_cache_read": "0.000002125"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-4o-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1721260800,
+      "owned_by": "openai",
+      "name": "GPT-4o mini",
+      "description": "GPT-4o mini from OpenAI is their most advanced and cost-efficient small model. It is multi-modal (accepting text or image inputs and outputting text) and has higher intelligence than gpt-3.5-turbo but is just as fast.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000015",
+        "output": "0.0000006",
+        "input_cache_read": "0.000000075",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.00000025",
+            "output": "0.000001",
+            "input_cache_read": "0.000000125"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-4o-mini-search-preview",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1741737600,
+      "owned_by": "openai",
+      "name": "GPT 4o Mini Search Preview",
+      "description": "GPT-4o mini Search Preview is a specialized model trained to understand and execute web search queries with the Chat Completions API. In addition to token fees, web search queries have a fee per tool call.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000015",
+        "output": "0.0000006",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754006400,
+      "owned_by": "openai",
+      "name": "GPT-5",
+      "description": "GPT-5 is OpenAI's flagship language model that excels at complex reasoning, broad real-world knowledge, code-intensive, and multi-step agentic tasks.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "image-generation",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000025",
+            "output": "0.00002",
+            "input_cache_read": "0.00000025"
+          },
+          "flex": {
+            "input": "0.000000625",
+            "output": "0.000005",
+            "input_cache_read": "0.0000000625"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5-chat",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754524800,
+      "owned_by": "openai",
+      "name": "GPT 5 Chat",
+      "description": "GPT-5 Chat points to the GPT-5 snapshot currently used in ChatGPT.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "implicit-caching",
+        "file-input",
+        "vision",
+        "reasoning",
+        "image-generation",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5-codex",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1757894400,
+      "owned_by": "openai",
+      "name": "GPT-5-Codex",
+      "description": "GPT-5-Codex is a version of GPT-5 optimized for agentic coding tasks in Codex or similar environments.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000025",
+            "output": "0.00002",
+            "input_cache_read": "0.00000025"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754524800,
+      "owned_by": "openai",
+      "name": "GPT-5 mini",
+      "description": "GPT-5 mini is a cost optimized model that excels at reasoning/chat tasks. It offers an optimal balance between speed, cost, and capability.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000025",
+        "output": "0.000002",
+        "input_cache_read": "0.000000025",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.00000045",
+            "output": "0.0000036",
+            "input_cache_read": "0.000000045"
+          },
+          "flex": {
+            "input": "0.000000125",
+            "output": "0.000001",
+            "input_cache_read": "0.0000000125"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5-nano",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754524800,
+      "owned_by": "openai",
+      "name": "GPT-5 nano",
+      "description": "GPT-5 nano is a high throughput model that excels at simple instruction or classification tasks.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "image-generation",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000005",
+        "output": "0.0000004",
+        "input_cache_read": "0.000000005",
+        "web_search": "10",
+        "service_tiers": {
+          "flex": {
+            "input": "0.000000025",
+            "output": "0.0000002",
+            "input_cache_read": "0.0000000025"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5-pro",
+      "object": "model",
+      "created": 1755815280,
+      "owned_by": "openai",
+      "name": "GPT-5 pro",
+      "description": "GPT-5 pro uses more compute to think harder and provide consistently better answers. Since GPT-5 pro is designed to tackle tough problems, some requests may take several minutes to finish.",
+      "context_window": 400000,
+      "max_tokens": 272000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "implicit-caching",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "image-generation",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000015",
+        "output": "0.00012",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5.1-codex",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1762905600,
+      "owned_by": "openai",
+      "name": "GPT-5.1-Codex",
+      "description": "GPT-5.1-Codex is a version of GPT-5.1 optimized for agentic coding tasks in Codex or similar environments.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "tool-use",
+        "reasoning",
+        "vision",
+        "web-search",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000025",
+            "output": "0.00002",
+            "input_cache_read": "0.00000025"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.1-codex-max",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1763510400,
+      "owned_by": "openai",
+      "name": "GPT 5.1 Codex Max",
+      "description": "GPT‑5.1-Codex-Max is purpose-built for agentic coding.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "file-input",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000025",
+            "output": "0.00002",
+            "input_cache_read": "0.00000025"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.1-codex-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1762905600,
+      "owned_by": "openai",
+      "name": "GPT 5.1 Codex Mini",
+      "description": "GPT-5.1 Codex mini is a smaller, faster, and cheaper version of GPT-5.1 Codex.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "file-input",
+        "vision",
+        "tool-use",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000025",
+        "output": "0.000002",
+        "input_cache_read": "0.000000025",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5.1-instant",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1762905600,
+      "owned_by": "openai",
+      "name": "GPT-5.1 Instant",
+      "description": "GPT-5.1 Instant (or GPT-5.1 chat) is a warmer and more conversational version of GPT-5-chat, with improved instruction following and adaptive reasoning for deciding when to think before responding.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "vision",
+        "file-input",
+        "reasoning",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5.1-thinking",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1762905600,
+      "owned_by": "openai",
+      "name": "GPT 5.1 Thinking",
+      "description": "An upgraded version of GPT-5 that adapts thinking time more precisely to the question to spend more time on complex questions and respond more quickly to simpler tasks.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "implicit-caching",
+        "reasoning",
+        "vision",
+        "file-input",
+        "web-search",
+        "image-generation"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "output": "0.00001",
+        "input_cache_read": "0.000000125",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000025",
+            "output": "0.00002",
+            "input_cache_read": "0.00000025"
+          },
+          "flex": {
+            "input": "0.000000625",
+            "output": "0.000005",
+            "input_cache_read": "0.0000000625"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.2",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1765411200,
+      "owned_by": "openai",
+      "name": "GPT 5.2",
+      "description": "GPT-5.2 is OpenAI's best general-purpose model, part of the GPT-5 flagship model family. It's their most intelligent model yet for both general and agentic tasks.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "vision",
+        "file-input",
+        "reasoning",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000175",
+        "output": "0.000014",
+        "input_cache_read": "0.000000175",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000035",
+            "output": "0.000028",
+            "input_cache_read": "0.00000035"
+          },
+          "flex": {
+            "input": "0.000000875",
+            "output": "0.000007",
+            "input_cache_read": "0.0000000875"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.2-chat",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1765411200,
+      "owned_by": "openai",
+      "name": "GPT 5.2 Chat",
+      "description": "The model powering ChatGPT is gpt-5.2-chat-latest: this is OpenAI's best general-purpose model, part of the GPT-5 flagship model family.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "vision",
+        "file-input",
+        "tool-use",
+        "reasoning",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000175",
+        "output": "0.000014",
+        "input_cache_read": "0.000000175",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5.2-codex",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1766016000,
+      "owned_by": "openai",
+      "name": "GPT 5.2 Codex",
+      "description": "GPT‑5.2-Codex is a version of GPT‑5.2⁠ further optimized for agentic coding in Codex, including improvements on long-horizon work through context compaction, stronger performance on large code changes like refactors and migrations, improved performance in Windows environments, and significantly stronger cybersecurity capabilities.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000175",
+        "output": "0.000014",
+        "input_cache_read": "0.000000175",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000035",
+            "output": "0.000028",
+            "input_cache_read": "0.00000035"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.2-pro",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1765411200,
+      "owned_by": "openai",
+      "name": "GPT 5.2 ",
+      "description": "Version of GPT-5.2 that produces smarter and more precise responses.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "reasoning",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000021",
+        "output": "0.000168",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5.3-chat",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1772496000,
+      "owned_by": "openai",
+      "name": "GPT-5.3 Chat",
+      "description": "The model powering ChatGPT is gpt-5.3-chat-latest: this is OpenAI's best general-purpose model, part of the GPT-5 flagship model family.",
+      "context_window": 128000,
+      "max_tokens": 16384,
+      "type": "language",
+      "tags": [
+        "vision",
+        "file-input",
+        "tool-use",
+        "reasoning",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000175",
+        "output": "0.000014",
+        "input_cache_read": "0.000000175",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/gpt-5.3-codex",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1771891200,
+      "owned_by": "openai",
+      "name": "GPT 5.3 Codex",
+      "description": "GPT-5.3-Codex advances both the frontier coding performance of GPT‑5.2-Codex and the reasoning and professional knowledge capabilities of GPT‑5.2, together in one model, which is also 25% faster. This enables it to take on long-running tasks that involve research, tool use, and complex execution.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000175",
+        "output": "0.000014",
+        "input_cache_read": "0.000000175",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000035",
+            "output": "0.000028",
+            "input_cache_read": "0.00000035"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.4",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1772668800,
+      "owned_by": "openai",
+      "name": "GPT 5.4",
+      "description": "GPT-5.4 is OpenAI's best general-purpose model, part of the GPT-5 flagship model family. It's their most intelligent model yet for both general and agentic tasks.",
+      "context_window": 1050000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "vision",
+        "file-input",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.0000025",
+        "input_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.000005",
+            "min": 272000
+          }
+        ],
+        "output": "0.000015",
+        "output_tiers": [
+          {
+            "cost": "0.000015",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.0000225",
+            "min": 272000
+          }
+        ],
+        "input_cache_read": "0.00000025",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.00000025",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.0000005",
+            "min": 272000
+          }
+        ],
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.000005",
+            "output": "0.00003",
+            "input_cache_read": "0.0000005"
+          },
+          "flex": {
+            "input": "0.00000125",
+            "output": "0.0000075",
+            "input_cache_read": "0.00000013",
+            "long_context": {
+              "threshold": 272000,
+              "input": "0.0000025",
+              "output": "0.00001125",
+              "input_cache_read": "0.00000025"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.4-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773705600,
+      "owned_by": "openai",
+      "name": "GPT 5.4 Mini",
+      "description": "GPT-5.4 Mini brings the strengths of GPT-5.4 to a faster, more efficient model designed for high-volume workloads.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "vision",
+        "file-input",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000075",
+        "output": "0.0000045",
+        "input_cache_read": "0.000000075",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000015",
+            "output": "0.000009",
+            "input_cache_read": "0.00000015"
+          },
+          "flex": {
+            "input": "0.000000375",
+            "output": "0.00000225",
+            "input_cache_read": "0.0000000375"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.4-nano",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773705600,
+      "owned_by": "openai",
+      "name": "GPT 5.4 Nano",
+      "description": "GPT-5.4 Nano is designed for tasks where speed and cost matter most like classification, data extraction, ranking, and sub-agents.",
+      "context_window": 400000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.0000002",
+        "output": "0.00000125",
+        "input_cache_read": "0.00000002",
+        "web_search": "10",
+        "service_tiers": {
+          "flex": {
+            "input": "0.0000001",
+            "output": "0.000000625",
+            "input_cache_read": "0.00000001"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.4-pro",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1772668800,
+      "owned_by": "openai",
+      "name": "GPT 5.4 Pro",
+      "description": "GPT-5.4 Pro uses more compute to think harder and provide consistently better answers. It's designed to tackle tough problems.",
+      "context_window": 1050000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "vision",
+        "file-input",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00003",
+        "input_tiers": [
+          {
+            "cost": "0.00003",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.00006",
+            "min": 272000
+          }
+        ],
+        "output": "0.00018",
+        "output_tiers": [
+          {
+            "cost": "0.00018",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.00027",
+            "min": 272000
+          }
+        ],
+        "web_search": "10",
+        "service_tiers": {
+          "flex": {
+            "input": "0.000015",
+            "output": "0.00009",
+            "long_context": {
+              "threshold": 272000,
+              "input": "0.00003",
+              "output": "0.000135"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.5",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1776988800,
+      "owned_by": "openai",
+      "name": "GPT 5.5",
+      "description": "GPT‑5.5 understands what you’re trying to do faster and can carry more of the work itself. It excels at writing and debugging code, researching online, analyzing data, creating documents and spreadsheets, operating software, and moving across tools until a task is finished. Instead of carefully managing every step, you can give GPT‑5.5 a messy, multi-part task and trust it to plan, use tools, check its work, navigate through ambiguity, and keep going.",
+      "context_window": 1000000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000005",
+        "input_tiers": [
+          {
+            "cost": "0.000005",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.00001",
+            "min": 272000
+          }
+        ],
+        "output": "0.00003",
+        "output_tiers": [
+          {
+            "cost": "0.00003",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.000045",
+            "min": 272000
+          }
+        ],
+        "input_cache_read": "0.0000005",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000005",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.000001",
+            "min": 272000
+          }
+        ],
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000125",
+            "output": "0.000075",
+            "input_cache_read": "0.00000125"
+          },
+          "flex": {
+            "input": "0.0000025",
+            "output": "0.000015",
+            "input_cache_read": "0.00000025",
+            "long_context": {
+              "threshold": 272000,
+              "input": "0.000005",
+              "output": "0.0000225",
+              "input_cache_read": "0.0000005"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-5.5-pro",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1776988800,
+      "owned_by": "openai",
+      "name": "GPT 5.5 Pro",
+      "description": "",
+      "context_window": 1000000,
+      "max_tokens": 128000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "file-input",
+        "web-search",
+        "vision"
+      ],
+      "pricing": {
+        "input": "0.00003",
+        "input_tiers": [
+          {
+            "cost": "0.00003",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.00006",
+            "min": 272000
+          }
+        ],
+        "output": "0.00018",
+        "output_tiers": [
+          {
+            "cost": "0.00018",
+            "min": 0,
+            "max": 272000
+          },
+          {
+            "cost": "0.00027",
+            "min": 272000
+          }
+        ],
+        "web_search": "14",
+        "service_tiers": {
+          "flex": {
+            "input": "0.000015",
+            "output": "0.00009"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754352000,
+      "owned_by": "openai",
+      "name": "GPT OSS 120B",
+      "description": "This model excels at efficient reasoning across science, math, and coding applications. It’s ideal for real-time coding assistance, processing large documents for Q&A and summarization, agentic research workflows, and regulated on-premises workloads.",
+      "context_window": 131072,
+      "max_tokens": 131000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.00000035",
+        "output": "0.00000075",
+        "input_cache_read": "0.00000025"
+      }
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1754352000,
+      "owned_by": "openai",
+      "name": "GPT OSS 20B",
+      "description": "A compact, open-weight language model optimized for low-latency and resource-constrained environments, including local and edge deployments.",
+      "context_window": 131072,
+      "max_tokens": 8192,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use"
+      ],
+      "pricing": {
+        "input": "0.00000005",
+        "output": "0.0000002"
+      }
+    },
+    {
+      "id": "openai/gpt-oss-safeguard-20b",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1733011200,
+      "owned_by": "openai",
+      "name": "GPT OSS Safeguard 20B",
+      "description": "OpenAI's first open weight reasoning model specifically trained for safety classification tasks. Fine-tuned from GPT-OSS, this model helps classify text content based on customizable policies, enabling bring-your-own-policy Trust & Safety AI where your own taxonomy, definitions, and thresholds guide classification decisions.",
+      "context_window": 131072,
+      "max_tokens": 65536,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use"
+      ],
+      "pricing": {
+        "input": "0.000000075",
+        "output": "0.0000003",
+        "input_cache_read": "0.000000037"
+      }
+    },
+    {
+      "id": "openai/o1",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1733356800,
+      "owned_by": "openai",
+      "name": "o1",
+      "description": "o1 is OpenAI's flagship reasoning model, designed for complex problems that require deep thinking. It provides strong reasoning capabilities with improved accuracy for complex multi-step tasks.",
+      "context_window": 200000,
+      "max_tokens": 100000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.000015",
+        "output": "0.00006",
+        "input_cache_read": "0.0000075"
+      }
+    },
+    {
+      "id": "openai/o3",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1744761600,
+      "owned_by": "openai",
+      "name": "o3",
+      "description": "OpenAI's o3 is their most powerful reasoning model, setting new state-of-the-art benchmarks in coding, math, science, and visual perception. It excels at complex queries requiring multi-faceted analysis, with particular strength in analyzing images, charts, and graphics.",
+      "context_window": 200000,
+      "max_tokens": 100000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.000002",
+        "output": "0.000008",
+        "input_cache_read": "0.0000005",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.0000035",
+            "output": "0.000014",
+            "input_cache_read": "0.000000875"
+          },
+          "flex": {
+            "input": "0.000001",
+            "output": "0.000004",
+            "input_cache_read": "0.00000025"
+          }
+        }
+      }
+    },
+    {
+      "id": "openai/o3-deep-research",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1719360000,
+      "owned_by": "openai",
+      "name": "o3-deep-research",
+      "description": "o3-deep-research is OpenAI's most advanced model for deep research, designed to tackle complex, multi-step research tasks. It can search and synthesize information from across the internet as well as from your own data—brought in through MCP connectors.",
+      "context_window": 200000,
+      "max_tokens": 100000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "file-input",
+        "tool-use",
+        "vision",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.00001",
+        "output": "0.00004",
+        "input_cache_read": "0.0000025",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/o3-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1734652800,
+      "owned_by": "openai",
+      "name": "o3-mini",
+      "description": "o3-mini is OpenAI's most recent small reasoning model, providing high intelligence at the same cost and latency targets of o1-mini.",
+      "context_window": 200000,
+      "max_tokens": 100000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.0000011",
+        "output": "0.0000044",
+        "input_cache_read": "0.00000055"
+      }
+    },
+    {
+      "id": "openai/o3-pro",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1744761600,
+      "owned_by": "openai",
+      "name": "o3 Pro",
+      "description": "The o-series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o3-pro model uses more compute to think harder and provide consistently better answers.",
+      "context_window": 200000,
+      "max_tokens": 100000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "vision",
+        "file-input",
+        "tool-use",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00002",
+        "output": "0.00008",
+        "web_search": "10"
+      }
+    },
+    {
+      "id": "openai/o4-mini",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1744761600,
+      "owned_by": "openai",
+      "name": "o4-mini",
+      "description": "OpenAI's o4-mini delivers fast, cost-efficient reasoning with exceptional performance for its size, particularly excelling in math (best-performing on AIME benchmarks), coding, and visual tasks.",
+      "context_window": 200000,
+      "max_tokens": 100000,
+      "type": "language",
+      "tags": [
+        "file-input",
+        "reasoning",
+        "tool-use",
+        "vision",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.0000011",
+        "output": "0.0000044",
+        "input_cache_read": "0.000000275",
+        "web_search": "10",
+        "service_tiers": {
+          "priority": {
+            "input": "0.000002",
+            "output": "0.000008",
+            "input_cache_read": "0.0000005"
+          },
+          "flex": {
+            "input": "0.00000055",
+            "output": "0.0000022",
+            "input_cache_read": "0.000000138"
+          }
+        }
+      }
+    },
+    {
+      "id": "xai/grok-4.1-fast-non-reasoning",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1752019200,
+      "owned_by": "xai",
+      "name": "Grok 4.1 Fast Non-Reasoning",
+      "description": "",
+      "context_window": 1000000,
+      "max_tokens": 1000000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "file-input",
+        "vision",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.0000002",
+        "output": "0.0000005",
+        "input_cache_read": "0.00000005"
+      }
+    },
+    {
+      "id": "xai/grok-4.1-fast-reasoning",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1752019200,
+      "owned_by": "xai",
+      "name": "Grok 4.1 Fast Reasoning",
+      "description": "",
+      "context_window": 1000000,
+      "max_tokens": 1000000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "file-input",
+        "vision",
+        "tool-use",
+        "implicit-caching"
+      ],
+      "pricing": {
+        "input": "0.0000002",
+        "output": "0.0000005",
+        "input_cache_read": "0.00000005"
+      }
+    },
+    {
+      "id": "xai/grok-4.20-multi-agent",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773014400,
+      "owned_by": "xai",
+      "name": "Grok 4.20 Multi-Agent",
+      "description": "Multiple agents collaborate in parallel to perform deep research tasks.",
+      "context_window": 2000000,
+      "max_tokens": 2000000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-4.20-multi-agent-beta",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773187200,
+      "owned_by": "xai",
+      "name": "Grok 4.20 Multi Agent Beta",
+      "description": "Multiple agents collaborate in parallel to perform deep research tasks.",
+      "context_window": 2000000,
+      "max_tokens": 2000000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-4.20-non-reasoning",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773014400,
+      "owned_by": "xai",
+      "name": "Grok 4.20 Non-Reasoning",
+      "description": "Grok 4.20 Beta is the newest flagship model from xAI with industry-leading speed and agentic tool calling capabilities. It combines the lowest hallucination rate on the market with strict prompt adherence, delivering consistently precise and truthful responses.",
+      "context_window": 2000000,
+      "max_tokens": 2000000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "implicit-caching",
+        "file-input",
+        "vision",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-4.20-non-reasoning-beta",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773187200,
+      "owned_by": "xai",
+      "name": "Grok 4.20 Beta Non-Reasoning",
+      "description": "Grok 4.20 Beta is the newest flagship model from xAI with industry-leading speed and agentic tool calling capabilities. It combines the lowest hallucination rate on the market with strict prompt adherance, delivering consistently precise and truthful responses.",
+      "context_window": 2000000,
+      "max_tokens": 2000000,
+      "type": "language",
+      "tags": [
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-4.20-reasoning",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773014400,
+      "owned_by": "xai",
+      "name": "Grok 4.20 Reasoning",
+      "description": "Grok 4.20 Beta is the newest flagship model from xAI with industry-leading speed and agentic tool calling capabilities. It combines the lowest hallucination rate on the market with strict prompt adherence, delivering consistently precise and truthful responses.",
+      "context_window": 2000000,
+      "max_tokens": 2000000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "vision",
+        "file-input",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-4.20-reasoning-beta",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1773187200,
+      "owned_by": "xai",
+      "name": "Grok 4.20 Beta Reasoning",
+      "description": "Grok 4.20 Beta is the newest flagship model from xAI with industry-leading speed and agentic tool calling capabilities. It combines the lowest hallucination rate on the market with strict prompt adherance, delivering consistently precise and truthful responses.",
+      "context_window": 2000000,
+      "max_tokens": 2000000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "vision",
+        "file-input",
+        "implicit-caching",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-4.3",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1777507200,
+      "owned_by": "xai",
+      "name": "Grok 4.3",
+      "description": "Grok 4.3 is a new model matching the scale of Grok 4.20 with an improved architecture and a December 2025 knowledge cutoff.",
+      "context_window": 1000000,
+      "max_tokens": 1000000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "tool-use",
+        "implicit-caching",
+        "file-input",
+        "vision",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.00000125",
+        "input_tiers": [
+          {
+            "cost": "0.00000125",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000025",
+            "min": 200001
+          }
+        ],
+        "output": "0.0000025",
+        "output_tiers": [
+          {
+            "cost": "0.0000025",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000005",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    },
+    {
+      "id": "xai/grok-build-0.1",
+      "object": "model",
+      "created": 1755815280,
+      "released": 1779235200,
+      "owned_by": "xai",
+      "name": "Grok Build 0.1",
+      "description": "xAI's fast coding model trained specifically for agentic coding.",
+      "context_window": 256000,
+      "max_tokens": 256000,
+      "type": "language",
+      "tags": [
+        "reasoning",
+        "implicit-caching",
+        "vision",
+        "tool-use",
+        "web-search"
+      ],
+      "pricing": {
+        "input": "0.000001",
+        "input_tiers": [
+          {
+            "cost": "0.000001",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000002",
+            "min": 200001
+          }
+        ],
+        "output": "0.000002",
+        "output_tiers": [
+          {
+            "cost": "0.000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.000004",
+            "min": 200001
+          }
+        ],
+        "input_cache_read": "0.0000002",
+        "input_cache_read_tiers": [
+          {
+            "cost": "0.0000002",
+            "min": 0,
+            "max": 200001
+          },
+          {
+            "cost": "0.0000004",
+            "min": 200001
+          }
+        ],
+        "web_search": "5"
+      }
+    }
+  ]
+}

--- a/src/error-taxonomy.ts
+++ b/src/error-taxonomy.ts
@@ -1,0 +1,241 @@
+// Inlined from ./framework/tools/types.js (framework not present in this build target)
+export type ToolErrorType =
+  | 'invalid_args'
+  | 'exec_failed'
+  | 'not_found'
+  | 'auth'
+  | 'rate_limit'
+  | 'permission'
+  | 'timeout'
+  | 'transient'
+  | 'parse_failed'
+  | 'pool_exhausted'
+  | 'cancelled'
+  | 'denied'
+  | 'unknown';
+
+/**
+ * Result of classifying a tool error. `correctable` gates the existing
+ * learning loops (correction-candidate enqueue, tool-profile bad-example
+ * recording) so that irreducible environmental failures (HTTP 404,
+ * rate limits, pool exhaustion, parse failures) no longer drown the
+ * call-shape mistakes the model can actually learn from.
+ */
+export interface Classification {
+  category: ToolErrorType;
+  /** Worth feeding to the correction agent / recording as a bad example. */
+  correctable: boolean;
+  /** Hint for `ToolError.retryable`. */
+  retryable: boolean;
+  /** Drives cron alert severity. */
+  severity: 'low' | 'normal' | 'critical';
+  playbook: { user: string; model: string };
+}
+
+export interface ClassifyInput {
+  message: string;
+  toolName?: string;
+  errno?: string;
+  httpStatus?: number;
+}
+
+const PLAYBOOKS: Record<ToolErrorType, { user: string; model: string }> = {
+  invalid_args: {
+    user: 'Tool was called with invalid arguments — model may retry with corrected shape.',
+    model: 'Re-issue the call with corrected arguments. Re-read the tool schema if unsure.',
+  },
+  exec_failed: {
+    user: 'Command failed — model may retry with a corrected form.',
+    model:
+      'Re-examine the command; a quoting, path, or flag issue is likely. Retry with a corrected form.',
+  },
+  not_found: {
+    user: 'Target was not found.',
+    model:
+      'The target (URL, file, command, or resource) was not found. Do not retry the same call — try a different target or report the miss.',
+  },
+  auth: {
+    user: 'Authentication failed — re-authenticate or check your API key.',
+    model:
+      'Authentication failed. Do not retry. Ask the user to re-authenticate (e.g. /models for API keys) or surface the issue.',
+  },
+  rate_limit: {
+    user: 'Rate-limited — wait or switch lineup with /lineups.',
+    model:
+      'You are rate-limited. Do not retry immediately. Suggest waiting or switching to a different tier lineup via /lineups.',
+  },
+  permission: {
+    user: 'Permission denied — check filesystem or service ACLs.',
+    model: 'Permission denied. Do not retry the same call. Surface the access issue to the user.',
+  },
+  timeout: {
+    user: 'Timed out — operation took too long.',
+    model:
+      'Operation timed out. Consider a narrower query or splitting the work. Do not blindly retry.',
+  },
+  transient: {
+    user: 'Transient upstream error — try again in a moment.',
+    model:
+      'Transient upstream failure (network or 5xx). One retry is acceptable; if it persists, surface the issue.',
+  },
+  parse_failed: {
+    user: 'Tool output failed to parse — internal model variance.',
+    model:
+      'The wrapper did not return parseable structured output. Treat as transient and retry once with simpler input.',
+  },
+  pool_exhausted: {
+    user: 'Bernard tool-wrapper pool is saturated — wait for in-flight calls to finish.',
+    model:
+      'Tool-wrapper pool is at capacity. Wait or sequence the call after current work completes. Do not retry immediately.',
+  },
+  cancelled: {
+    user: 'Cancelled.',
+    model: 'The previous call was cancelled by the user. Do not retry without instruction.',
+  },
+  denied: {
+    user: 'Denied — read-only mode is enforcing least-privilege.',
+    model:
+      'The call was blocked by the read-only mode gate (#179). Do not retry the same write call. Either ask the user to allow this tool / switch toolMode to write, or take a read-only alternative path.',
+  },
+  unknown: {
+    user: 'Tool failed with an unrecognized error.',
+    model:
+      'The error did not match any known pattern. Read the snippet, consider whether one careful retry is justified, and otherwise surface to the user.',
+  },
+};
+
+const SEVERITY: Record<ToolErrorType, 'low' | 'normal' | 'critical'> = {
+  auth: 'critical',
+  permission: 'critical',
+  rate_limit: 'normal',
+  not_found: 'normal',
+  invalid_args: 'normal',
+  exec_failed: 'normal',
+  timeout: 'low',
+  transient: 'low',
+  parse_failed: 'low',
+  pool_exhausted: 'low',
+  cancelled: 'low',
+  denied: 'normal',
+  unknown: 'low',
+};
+
+/** Categories whose retry is worth attempting without external intervention. */
+const RETRYABLE: ReadonlySet<ToolErrorType> = new Set<ToolErrorType>([
+  'transient',
+  'parse_failed',
+  'pool_exhausted',
+  'timeout',
+]);
+
+/**
+ * Classifies a tool error into a taxonomy category, deciding whether it's
+ * worth feeding to the correction loop and how to surface it.
+ *
+ * Order of inspection: explicit `httpStatus` → `errno` → string patterns on
+ * `message`. `toolName` only matters for the `not_found` correctable split:
+ * a shell "command not found" is a learnable mistake; a web 404 is not.
+ */
+export function classifyError(input: ClassifyInput): Classification {
+  const category = pickCategory(input);
+  return {
+    category,
+    correctable: isCorrectable(category, input.toolName),
+    retryable: RETRYABLE.has(category),
+    severity: SEVERITY[category],
+    playbook: PLAYBOOKS[category],
+  };
+}
+
+function pickCategory(input: ClassifyInput): ToolErrorType {
+  const { httpStatus, errno, message } = input;
+
+  if (typeof httpStatus === 'number') {
+    if (httpStatus === 401) return 'auth';
+    if (httpStatus === 403) return 'permission';
+    if (httpStatus === 404) return 'not_found';
+    if (httpStatus === 408 || httpStatus === 429) return 'rate_limit';
+    if (httpStatus >= 500 && httpStatus < 600) return 'transient';
+  }
+
+  if (errno) {
+    if (errno === 'ENOENT') return 'not_found';
+    if (errno === 'EACCES' || errno === 'EPERM') return 'permission';
+    if (errno === 'ETIMEDOUT') return 'timeout';
+    if (errno === 'ECONNREFUSED' || errno === 'ENETUNREACH' || errno === 'ECONNRESET') {
+      return 'transient';
+    }
+  }
+
+  const m = message ?? '';
+
+  // Bernard-internal markers first — they're high-confidence.
+  if (/pool_exhausted|Maximum concurrent agents/i.test(m)) return 'pool_exhausted';
+  if (/Specialist did not produce valid structured output|parse_failed/i.test(m)) {
+    return 'parse_failed';
+  }
+
+  // HTTP signatures embedded in error strings (web.ts, gh CLI, etc.). Must run
+  // before the generic `cancelled` pattern so a wrapped message like
+  // "cancelled: HTTP 401" lands as `auth`, not `cancelled`.
+  if (/\bHTTP\s*401\b|unauthori[sz]ed/i.test(m)) return 'auth';
+  if (/\bHTTP\s*403\b|forbidden/i.test(m)) return 'permission';
+  if (/\bHTTP\s*404\b|not\s*found/i.test(m)) {
+    // shell `command not found` is a call-shape mistake (correctable);
+    // a web 404 is the URL being gone (not correctable). The category is
+    // shared; the correctable split happens in isCorrectable().
+    return 'not_found';
+  }
+  if (/\bHTTP\s*(408|429)\b|rate[\s-]?limit|quota|too many requests/i.test(m)) return 'rate_limit';
+  if (/\bHTTP\s*5\d\d\b|bad gateway|service unavailable|gateway timeout/i.test(m)) {
+    return 'transient';
+  }
+
+  // User-cancel signatures. Runs after HTTP/auth so wrapped strings like
+  // "cancelled: HTTP 401" still hit `auth`.
+  if (/\bcancelled\b|aborted by user/i.test(m)) return 'cancelled';
+
+  // Filesystem / shell signatures.
+  if (/permission denied|EACCES/i.test(m)) return 'permission';
+  if (/no such file or directory|ENOENT/i.test(m)) return 'not_found';
+
+  // Timeout signatures (must come after rate_limit so 408 wins there).
+  if (/timed?\s*out|ETIMEDOUT/i.test(m)) return 'timeout';
+
+  // Auth-key signatures (missing API key on a wrapper provider).
+  if (/no api key|missing.*key|api[_\s-]?key.*(missing|required|invalid)/i.test(m)) return 'auth';
+
+  // Network-level transients.
+  if (/network|ECONNRESET|ECONNREFUSED|ENETUNREACH|fetch failed/i.test(m)) return 'transient';
+
+  // Schema-validation signatures from generateText.
+  if (/invalid (?:tool )?arguments?|schema validation|zod/i.test(m)) return 'invalid_args';
+
+  // Generic exec failure (shell, scripts). Patterns use word boundaries so a
+  // stray "stderr" substring in a web response body or MCP error doesn't
+  // mis-classify. `isCorrectable` further restricts learnability to shell.
+  if (/\bexit code\b|\bstderr\b|syntax error|command failed/i.test(m)) return 'exec_failed';
+
+  return 'unknown';
+}
+
+function isCorrectable(category: ToolErrorType, toolName?: string): boolean {
+  switch (category) {
+    case 'invalid_args':
+      return true;
+    case 'exec_failed':
+      // Only the shell tool (and its sub-categorized profiles like `shell.gh`)
+      // can learn from generic exec-failure patterns; a `stderr`-like substring
+      // in a web/MCP error body isn't a call-shape mistake the model can fix.
+      return isShellContext(toolName);
+    case 'not_found':
+      // shell command-not-found is a learnable mistake; a web/file 404 is not.
+      return isShellContext(toolName);
+    default:
+      return false;
+  }
+}
+
+function isShellContext(toolName?: string): boolean {
+  return toolName === 'shell' || (typeof toolName === 'string' && toolName.startsWith('shell.'));
+}

--- a/src/lineups.test.ts
+++ b/src/lineups.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ALL_ROLE_IDS } from './model-roles.js';
+import { fullRoles, type Ladder } from './__tests__/lineup-fixtures.js';
+
+async function loadModule() {
+  vi.resetModules();
+  return import('./lineups.js');
+}
+
+const SAMPLE: Ladder = {
+  premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
+  mid: { provider: 'openai', model: 'gpt-4.1' },
+  cheap: { provider: 'xai', model: 'grok-3-mini' },
+};
+
+describe('lineups store', () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bernard-lineups-'));
+    origHome = process.env.BERNARD_HOME;
+    process.env.BERNARD_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.BERNARD_HOME;
+    else process.env.BERNARD_HOME = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('validateLineupId', () => {
+    it('accepts valid ids and rejects malformed ones', async () => {
+      const m = await loadModule();
+      expect(m.validateLineupId('mixed')).toBeNull();
+      expect(m.validateLineupId('my-lineup')).toBeNull();
+      expect(m.validateLineupId('a1_b2')).toBeNull();
+      expect(m.validateLineupId('')).toMatch(/empty/i);
+      expect(m.validateLineupId('Mixed')).toMatch(/lowercase/);
+      expect(m.validateLineupId('1lineup')).toMatch(/lowercase/);
+      expect(m.validateLineupId('a'.repeat(33))).toMatch(/32 characters/);
+    });
+  });
+
+  describe('validateLineupName', () => {
+    it('rejects empty and overlong names', async () => {
+      const m = await loadModule();
+      expect(m.validateLineupName('   ')).toMatch(/empty/i);
+      expect(m.validateLineupName('a'.repeat(65))).toMatch(/64 characters/);
+      expect(m.validateLineupName('Mixed providers')).toBeNull();
+    });
+  });
+
+  describe('slugifyLineupName / uniqueLineupId', () => {
+    it('builds slugs and de-duplicates against existing ids', async () => {
+      const m = await loadModule();
+      expect(m.slugifyLineupName('Mixed Providers!')).toBe('mixed-providers');
+      expect(m.slugifyLineupName('123 only digits')).toBe('l-123-only-digits');
+      const existing = {
+        mixed: {
+          id: 'mixed',
+          name: 'Mixed',
+          roles: fullRoles(SAMPLE),
+          createdAt: 'x',
+          updatedAt: 'x',
+        },
+      } as never;
+      expect(m.uniqueLineupId('Mixed', existing)).toBe('mixed-2');
+    });
+  });
+
+  describe('loadLineups', () => {
+    it('seeds three default lineups on first read', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(Object.keys(lineups).sort()).toEqual(['anthropic', 'openai', 'xai']);
+      // Models are derived dynamically from the catalog; assert structural
+      // shape rather than exact names so a catalog refresh doesn't break this.
+      for (const provider of ['anthropic', 'openai', 'xai'] as const) {
+        // Every role is present and seeded to the same provider for all tiers.
+        for (const role of ALL_ROLE_IDS) {
+          const ladder = lineups[provider].roles[role];
+          expect(ladder.premium.provider).toBe(provider);
+          expect(ladder.mid.provider).toBe(provider);
+          expect(ladder.cheap.provider).toBe(provider);
+          expect(ladder.premium.model.length).toBeGreaterThan(0);
+          expect(ladder.mid.model.length).toBeGreaterThan(0);
+          expect(ladder.cheap.model.length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('persists the seed to disk', async () => {
+      const m = await loadModule();
+      m.loadLineups();
+      const filePath = path.join(tmpDir, 'bernard', 'lineups.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+      const onDisk = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(onDisk.lineups.anthropic.name).toBe('Anthropic-only');
+      expect(onDisk.lineups.anthropic.roles.orchestrator.premium.provider).toBe('anthropic');
+    });
+
+    it('reseeds when the file is corrupt JSON', async () => {
+      fs.mkdirSync(path.join(tmpDir, 'bernard'), { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, 'bernard', 'lineups.json'), 'not json');
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(lineups.anthropic).toBeDefined();
+    });
+
+    it('drops entries with missing slots and reseeds when result is empty', async () => {
+      fs.mkdirSync(path.join(tmpDir, 'bernard'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'bernard', 'lineups.json'),
+        JSON.stringify({ lineups: { junk: { id: 'junk', name: 'Junk' } } }),
+      );
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(lineups.junk).toBeUndefined();
+      expect(lineups.anthropic).toBeDefined();
+    });
+  });
+
+  describe('migration (legacy flat → role-keyed)', () => {
+    it('replicates a legacy flat lineup across all roles and rewrites the file', async () => {
+      fs.mkdirSync(path.join(tmpDir, 'bernard'), { recursive: true });
+      const filePath = path.join(tmpDir, 'bernard', 'lineups.json');
+      // Pre-#264 flat shape: premium/mid/cheap at the top level, no `roles`.
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({
+          lineups: {
+            legacy: {
+              id: 'legacy',
+              name: 'Legacy',
+              premium: SAMPLE.premium,
+              mid: SAMPLE.mid,
+              cheap: SAMPLE.cheap,
+              createdAt: 'c',
+              updatedAt: 'u',
+            },
+          },
+        }),
+      );
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(lineups.legacy).toBeDefined();
+      // Every role inherits the old cost ladder verbatim.
+      for (const role of ALL_ROLE_IDS) {
+        expect(lineups.legacy.roles[role].premium).toEqual(SAMPLE.premium);
+        expect(lineups.legacy.roles[role].mid).toEqual(SAMPLE.mid);
+        expect(lineups.legacy.roles[role].cheap).toEqual(SAMPLE.cheap);
+      }
+      // The on-disk shape was upgraded: role-keyed, no top-level flat slots.
+      const onDisk = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(onDisk.lineups.legacy.roles).toBeDefined();
+      expect(onDisk.lineups.legacy.premium).toBeUndefined();
+    });
+
+    it('backfills a role missing from a stored role-keyed lineup', async () => {
+      fs.mkdirSync(path.join(tmpDir, 'bernard'), { recursive: true });
+      const partial = fullRoles(SAMPLE);
+      // Simulate a lineup saved before the `coder` role existed.
+      delete partial.coder;
+      fs.writeFileSync(
+        path.join(tmpDir, 'bernard', 'lineups.json'),
+        JSON.stringify({
+          lineups: {
+            partial: {
+              id: 'partial',
+              name: 'Partial',
+              roles: partial,
+              createdAt: 'c',
+              updatedAt: 'u',
+            },
+          },
+        }),
+      );
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      // coder is backfilled from the orchestrator anchor.
+      expect(lineups.partial.roles.coder).toBeDefined();
+      expect(lineups.partial.roles.coder.premium).toEqual(
+        lineups.partial.roles.orchestrator.premium,
+      );
+    });
+  });
+
+  describe('resolveActiveLineup', () => {
+    it('prefers the explicit id', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(m.resolveActiveLineup(lineups, 'openai', 'anthropic').id).toBe('openai');
+    });
+
+    it('falls back to a lineup that matches the provider name', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      expect(m.resolveActiveLineup(lineups, undefined, 'xai').id).toBe('xai');
+    });
+
+    it('falls back to the first lineup when no id and no provider match', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const first = Object.values(lineups)[0];
+      expect(m.resolveActiveLineup(lineups, 'no-such-id', 'unknown-provider').id).toBe(first.id);
+    });
+  });
+
+  describe('resolveActiveLineupWithCorrection', () => {
+    it('reports no correction when the explicit id exists', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const res = m.resolveActiveLineupWithCorrection(lineups, 'openai', 'anthropic');
+      expect(res.lineup.id).toBe('openai');
+      expect(res.corrected).toBeUndefined();
+    });
+
+    it('reports no correction when no explicit id is set (normal fallback)', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const res = m.resolveActiveLineupWithCorrection(lineups, undefined, 'xai');
+      expect(res.lineup.id).toBe('xai');
+      expect(res.corrected).toBeUndefined();
+    });
+
+    it('reports a correction when the explicit id is missing, falling back by provider', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const res = m.resolveActiveLineupWithCorrection(lineups, 'openai-only', 'xai');
+      // 'openai-only' doesn't exist; provider 'xai' does → fall back to it.
+      expect(res.lineup.id).toBe('xai');
+      expect(res.corrected).toEqual({ requestedId: 'openai-only', resolvedId: 'xai' });
+    });
+
+    it('reports a correction and falls back to the first lineup when nothing matches', async () => {
+      const m = await loadModule();
+      const lineups = m.loadLineups();
+      const first = Object.values(lineups)[0];
+      const res = m.resolveActiveLineupWithCorrection(lineups, 'gone', 'unknown-provider');
+      expect(res.lineup.id).toBe(first.id);
+      expect(res.corrected).toEqual({ requestedId: 'gone', resolvedId: first.id });
+    });
+  });
+
+  describe('saveLineup / renameLineup / deleteLineup', () => {
+    it('writes a new lineup with a derived id', async () => {
+      const m = await loadModule();
+      const entry = m.saveLineup({
+        name: 'My Mix',
+        roles: fullRoles(SAMPLE) as never,
+      });
+      expect(entry.id).toBe('my-mix');
+      expect(entry.roles.executor.mid.provider).toBe('openai');
+      const all = m.loadLineups();
+      expect(all['my-mix']).toBeDefined();
+    });
+
+    it('updates an existing lineup in place', async () => {
+      const m = await loadModule();
+      m.saveLineup({ id: 'mix', name: 'Mix', roles: fullRoles(SAMPLE) as never });
+      const tweaked = fullRoles(SAMPLE);
+      tweaked.executor.mid = { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' };
+      const updated = m.saveLineup({ id: 'mix', name: 'Mix', roles: tweaked as never });
+      expect(updated.roles.executor.mid.provider).toBe('anthropic');
+      // Other roles untouched.
+      expect(updated.roles.orchestrator.mid.provider).toBe('openai');
+    });
+
+    it('rejects empty slot fields with a role+tier message', async () => {
+      const m = await loadModule();
+      const bad = fullRoles(SAMPLE);
+      bad.orchestrator.premium = { provider: '', model: 'x' };
+      expect(() => m.saveLineup({ name: 'Bad', roles: bad as never })).toThrow(
+        /orchestrator.*premium/,
+      );
+    });
+
+    it('renameLineup updates the display name', async () => {
+      const m = await loadModule();
+      m.loadLineups();
+      const renamed = m.renameLineup('anthropic', 'My Anthropic');
+      expect(renamed.name).toBe('My Anthropic');
+    });
+
+    it('deleteLineup removes an entry but refuses the last one', async () => {
+      const m = await loadModule();
+      m.loadLineups();
+      m.deleteLineup('openai');
+      m.deleteLineup('xai');
+      expect(() => m.deleteLineup('anthropic')).toThrow(/last remaining/);
+    });
+  });
+
+  describe('atomic writes', () => {
+    it('writes via a tmp file then rename (no partial file)', async () => {
+      const m = await loadModule();
+      m.loadLineups();
+      // Disk should never contain `.lineups.json.tmp` leftovers after a successful write.
+      const dir = path.join(tmpDir, 'bernard');
+      const stray = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+      expect(stray).toEqual([]);
+    });
+  });
+});

--- a/src/lineups.ts
+++ b/src/lineups.ts
@@ -1,0 +1,502 @@
+/**
+ * @module lineups
+ *
+ * Disk-backed registry of **lineups**. A lineup is a user-named 2D matrix
+ * binding `(role, cost-tier) → (provider, model)` (#264). The *cost tier*
+ * (`premium / mid / cheap`) is how much model to spend; the *role*
+ * (orchestrator, executor, function-caller, summarizer, classifier, coder —
+ * see {@link module:model-roles}) is what kind of work the call site does.
+ * Each role carries its own `{premium, mid, cheap}` ladder, so a user can give
+ * e.g. their `coder` role a top-tier model in performance mode and a cheaper
+ * one in token-saving mode.
+ *
+ * The active profile (`ProfileSettings.activeLineupId`) selects which lineup
+ * `resolveSiteModel` consults: `site → role` (static) → `tier`
+ * (via `config.modelMode`) → `lineup.roles[role][tier]`.
+ *
+ * Lineups may freely mix providers — built-in or custom — for any (role, tier)
+ * cell. This dissolves the previous "active provider" concept.
+ *
+ * Storage: `~/.config/bernard/lineups.json`.
+ *
+ * Lineups themselves are **global**, shared across profiles, just like
+ * `custom-providers.json` and `keys.json`. Only the *selection* is profile-
+ * scoped.
+ *
+ * Pre-#264 lineups stored flat top-level `{premium, mid, cheap}` slots; those
+ * are auto-migrated on load by replicating each cost slot across all roles
+ * (see {@link migrateLineupShape}), so behavior is identical until a user
+ * customizes a role.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { LINEUPS_PATH } from './paths.js';
+import { atomicWriteFileSync } from './fs-utils.js';
+import { getCatalogForProvider } from './providers/catalog.js';
+import { deriveTiers } from './providers/tiers.js';
+import { BUILTIN_PROVIDERS, type BuiltinProvider } from './providers/types.js';
+import { ALL_ROLE_IDS, type RoleId } from './model-roles.js';
+
+/** The three cost-tier slots every role defines. */
+export const LINEUP_TIERS = ['premium', 'mid', 'cheap'] as const;
+export type LineupTier = (typeof LINEUP_TIERS)[number];
+
+/** One (provider, model) binding for a single tier slot. */
+export interface LineupSlot {
+  provider: string;
+  model: string;
+}
+
+/** The `{premium, mid, cheap}` cost ladder for one role. */
+export type RoleSlots = Record<LineupTier, LineupSlot>;
+
+/** A single named lineup: a `role → {premium, mid, cheap}` matrix. */
+export interface Lineup {
+  /** Stable id used for `activeLineupId` lookups. Lowercase slug. */
+  id: string;
+  /** User-editable display name. */
+  name: string;
+  /** Per-role cost ladders. Always covers every {@link RoleId}. */
+  roles: Record<RoleId, RoleSlots>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface LineupsFile {
+  lineups: Record<string, Lineup>;
+}
+
+const ID_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const ID_MAX_LENGTH = 32;
+const NAME_MAX_LENGTH = 64;
+
+export const PROVIDER_DISPLAY_NAMES: Record<BuiltinProvider, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  xai: 'xAI',
+};
+
+/**
+ * Last-resort fallback used only when the model catalog has zero entries for a
+ * built-in provider (e.g. first run on an offline machine with a broken
+ * vendored fallback). Models here mirror the legacy hardcoded `PROVIDER_TIERS`
+ * table.
+ *
+ * Single source of truth for offline-fallback model names — `config.ts`
+ * derives its `FALLBACK_PROVIDER_MODELS` lists from this table, so a new
+ * model name only ever needs to land here.
+ */
+export const FALLBACK_TIERS: Record<
+  BuiltinProvider,
+  { premium: string; mid: string; cheap: string }
+> = {
+  anthropic: {
+    premium: 'claude-opus-4-6',
+    mid: 'claude-sonnet-4-5-20250929',
+    cheap: 'claude-haiku-4-5-20251001',
+  },
+  openai: {
+    premium: 'gpt-5.2',
+    mid: 'gpt-4.1',
+    cheap: 'gpt-4.1-mini',
+  },
+  xai: {
+    premium: 'grok-4-1-fast-reasoning',
+    mid: 'grok-4-fast-non-reasoning',
+    cheap: 'grok-3-mini',
+  },
+};
+
+export function validateLineupId(id: string): string | null {
+  if (!id) return 'Lineup id cannot be empty.';
+  if (id.length > ID_MAX_LENGTH) return `Lineup id must be ${ID_MAX_LENGTH} characters or fewer.`;
+  if (!ID_PATTERN.test(id))
+    return 'Lineup id must start with a lowercase letter and contain only lowercase letters, digits, hyphens, and underscores.';
+  return null;
+}
+
+export function validateLineupName(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return 'Lineup name cannot be empty.';
+  if (trimmed.length > NAME_MAX_LENGTH)
+    return `Lineup name must be ${NAME_MAX_LENGTH} characters or fewer.`;
+  return null;
+}
+
+export function slugifyLineupName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, ID_MAX_LENGTH);
+  if (!slug) return '';
+  if (/^[0-9]/.test(slug)) return `l-${slug}`.slice(0, ID_MAX_LENGTH);
+  return slug;
+}
+
+export function uniqueLineupId(name: string, existing: Record<string, Lineup>): string {
+  const base = slugifyLineupName(name);
+  if (!base) {
+    let i = 1;
+    while (existing[`lineup-${i}`]) i += 1;
+    return `lineup-${i}`;
+  }
+  if (!existing[base]) return base;
+  let i = 2;
+  const build = (n: number): string => {
+    const suffix = `-${n}`;
+    return `${base.slice(0, ID_MAX_LENGTH - suffix.length)}${suffix}`;
+  };
+  let candidate = build(i);
+  while (existing[candidate]) {
+    i += 1;
+    candidate = build(i);
+  }
+  return candidate;
+}
+
+function isLineupSlot(v: unknown): v is LineupSlot {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    typeof (v as LineupSlot).provider === 'string' &&
+    typeof (v as LineupSlot).model === 'string' &&
+    (v as LineupSlot).provider.length > 0 &&
+    (v as LineupSlot).model.length > 0
+  );
+}
+
+function isRoleSlots(v: unknown): v is RoleSlots {
+  if (!v || typeof v !== 'object') return false;
+  return LINEUP_TIERS.every((tier) => isLineupSlot((v as Record<string, unknown>)[tier]));
+}
+
+/** Deep-copies one `{premium, mid, cheap}` ladder (no shared slot refs). */
+function cloneRoleSlots(slots: RoleSlots): RoleSlots {
+  return {
+    premium: { ...slots.premium },
+    mid: { ...slots.mid },
+    cheap: { ...slots.cheap },
+  };
+}
+
+/** Builds a full `role → ladder` map, replicating one ladder across every role. */
+function replicateAcrossRoles(slots: RoleSlots): Record<RoleId, RoleSlots> {
+  const out = {} as Record<RoleId, RoleSlots>;
+  for (const role of ALL_ROLE_IDS) out[role] = cloneRoleSlots(slots);
+  return out;
+}
+
+function writeFile(lineups: Record<string, Lineup>): void {
+  fs.mkdirSync(path.dirname(LINEUPS_PATH), { recursive: true });
+  const payload: LineupsFile = { lineups };
+  atomicWriteFileSync(LINEUPS_PATH, JSON.stringify(payload, null, 2) + '\n');
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function seedForProvider(provider: BuiltinProvider, now: string): Lineup {
+  const entries = getCatalogForProvider(provider);
+  let tiers: { premium: string; mid: string; cheap: string };
+  if (entries.length > 0) {
+    tiers = deriveTiers(entries);
+  } else {
+    tiers = FALLBACK_TIERS[provider];
+  }
+  const ladder: RoleSlots = {
+    premium: { provider, model: tiers.premium },
+    mid: { provider, model: tiers.mid },
+    cheap: { provider, model: tiers.cheap },
+  };
+  return {
+    id: provider,
+    name: `${PROVIDER_DISPLAY_NAMES[provider]}-only`,
+    roles: replicateAcrossRoles(ladder),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildSeedLineups(): Record<string, Lineup> {
+  const now = nowIso();
+  const out: Record<string, Lineup> = {};
+  for (const provider of BUILTIN_PROVIDERS) {
+    out[provider] = seedForProvider(provider, now);
+  }
+  return out;
+}
+
+/**
+ * Adds default lineups for any built-in provider not yet present on disk.
+ * Existing lineups (including user-edited slot picks) are left untouched.
+ * Returns the merged map and only writes when something actually changed.
+ */
+export function seedDefaultLineups(existing: Record<string, Lineup>): Record<string, Lineup> {
+  const now = nowIso();
+  let mutated = false;
+  const out: Record<string, Lineup> = { ...existing };
+  for (const provider of BUILTIN_PROVIDERS) {
+    if (out[provider]) continue;
+    out[provider] = seedForProvider(provider, now);
+    mutated = true;
+  }
+  if (mutated) {
+    try {
+      writeFile(out);
+    } catch {
+      // best-effort; return the merged map regardless
+    }
+  }
+  return out;
+}
+
+/**
+ * Normalizes one stored lineup entry into the current role-keyed shape,
+ * migrating where needed. Returns `null` for unrecoverable entries (caller
+ * drops them and re-seeds if the map ends up empty).
+ *
+ * Handled shapes:
+ *  1. **Old flat** (`{premium, mid, cheap}` at top level, no `roles`): replicate
+ *     the cost ladder across every role → behavior identical to pre-#264.
+ *  2. **Role-keyed** (`{roles: {...}}`): validate each known role; backfill any
+ *     role missing from `ALL_ROLE_IDS` (e.g. a role added after this lineup was
+ *     saved) from an anchor role (`orchestrator`, else the first valid role).
+ *  3. **Neither**: `null`.
+ *
+ * Sets `mutatedRef.value = true` whenever it changes the on-disk shape so the
+ * caller can persist the upgrade.
+ */
+function migrateLineupShape(
+  id: string,
+  entry: unknown,
+  mutatedRef: { value: boolean },
+): Lineup | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = entry as Record<string, unknown>;
+  if (typeof e.id !== 'string' || typeof e.name !== 'string') return null;
+  const createdAt = typeof e.createdAt === 'string' ? e.createdAt : nowIso();
+  const updatedAt = typeof e.updatedAt === 'string' ? e.updatedAt : nowIso();
+
+  // Case 2 — already role-keyed.
+  if (e.roles && typeof e.roles === 'object') {
+    const stored = e.roles as Record<string, unknown>;
+    // Anchor for backfilling missing roles: prefer orchestrator, else any valid.
+    const anchorId =
+      ALL_ROLE_IDS.find((r) => isRoleSlots(stored[r])) ?? null;
+    if (!anchorId) return null;
+    const anchor = stored[anchorId] as RoleSlots;
+    const roles = {} as Record<RoleId, RoleSlots>;
+    for (const role of ALL_ROLE_IDS) {
+      if (isRoleSlots(stored[role])) {
+        roles[role] = cloneRoleSlots(stored[role] as RoleSlots);
+      } else {
+        roles[role] = cloneRoleSlots(anchor);
+        mutatedRef.value = true; // backfilled a missing/invalid role
+      }
+    }
+    return { id: e.id, name: e.name, roles, createdAt, updatedAt };
+  }
+
+  // Case 1 — legacy flat shape.
+  if (isLineupSlot(e.premium) && isLineupSlot(e.mid) && isLineupSlot(e.cheap)) {
+    mutatedRef.value = true;
+    const ladder: RoleSlots = {
+      premium: e.premium,
+      mid: e.mid,
+      cheap: e.cheap,
+    };
+    return {
+      id: e.id,
+      name: e.name,
+      roles: replicateAcrossRoles(ladder),
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Reads `lineups.json`. If the file is missing or unparseable, seeds the
+ * three built-in provider lineups, persists them, and returns the result.
+ * Always returns at least the seeded set so callers never have to handle an
+ * empty-map case. Auto-migrates legacy flat lineups and backfills newly-added
+ * roles, persisting the upgraded shape when anything changed.
+ */
+export function loadLineups(): Record<string, Lineup> {
+  try {
+    const raw = fs.readFileSync(LINEUPS_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<LineupsFile>;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.lineups &&
+      typeof parsed.lineups === 'object'
+    ) {
+      const out: Record<string, Lineup> = {};
+      const mutatedRef = { value: false };
+      for (const [id, entry] of Object.entries(parsed.lineups)) {
+        const migrated = migrateLineupShape(id, entry, mutatedRef);
+        if (migrated) out[id] = migrated;
+        else mutatedRef.value = true; // dropped a corrupt entry
+      }
+      if (Object.keys(out).length > 0) {
+        if (mutatedRef.value) {
+          try {
+            writeFile(out);
+          } catch {
+            // best-effort; the in-memory migration still applies this session
+          }
+        }
+        return out;
+      }
+    }
+  } catch {
+    // fall through to seed
+  }
+
+  const seeded = buildSeedLineups();
+  try {
+    writeFile(seeded);
+  } catch {
+    // best-effort; return the in-memory seed regardless
+  }
+  return seeded;
+}
+
+/**
+ * Resolves the active lineup id. Precedence:
+ *   1. Explicit `activeLineupId` arg (from `ProfileSettings.activeLineupId`).
+ *   2. A lineup whose `id` matches `fallbackProviderName` (e.g. the legacy
+ *      `config.provider`, so users upgrading land on the seeded lineup for
+ *      whichever built-in they had selected).
+ *   3. The first lineup in iteration order.
+ * Throws only if the map is empty (shouldn't happen because `loadLineups`
+ * always seeds).
+ */
+export function resolveActiveLineup(
+  lineups: Record<string, Lineup>,
+  activeLineupId: string | undefined,
+  fallbackProviderName: string | undefined,
+): Lineup {
+  if (activeLineupId && lineups[activeLineupId]) return lineups[activeLineupId];
+  if (fallbackProviderName && lineups[fallbackProviderName]) return lineups[fallbackProviderName];
+  const first = Object.values(lineups)[0];
+  if (!first)
+    throw new Error('No lineups available. This is a bug — loadLineups should always seed.');
+  return first;
+}
+
+/** Outcome of {@link resolveActiveLineupWithCorrection}. */
+export interface LineupResolution {
+  /** The lineup that will actually be used. */
+  lineup: Lineup;
+  /**
+   * Set only when `activeLineupId` was non-empty but pointed at a lineup that
+   * doesn't exist (e.g. a stale id left over from a deleted lineup, or a typo in
+   * a hand-edited profile). Carries the id that was requested and the id we fell
+   * back to, so the caller can persist the correction and tell the user.
+   */
+  corrected?: { requestedId: string; resolvedId: string };
+}
+
+/**
+ * Like {@link resolveActiveLineup}, but additionally reports whether the
+ * requested `activeLineupId` was *invalid* (set, but absent from `lineups`).
+ * When that happens the caller should persist `corrected.resolvedId` back onto
+ * the active profile and surface a note so the silent fallback isn't invisible.
+ *
+ * An empty/undefined `activeLineupId` is NOT a correction — that's the normal
+ * "no explicit selection, use the provider/first fallback" path.
+ */
+export function resolveActiveLineupWithCorrection(
+  lineups: Record<string, Lineup>,
+  activeLineupId: string | undefined,
+  fallbackProviderName: string | undefined,
+): LineupResolution {
+  const lineup = resolveActiveLineup(lineups, activeLineupId, fallbackProviderName);
+  if (activeLineupId && !lineups[activeLineupId]) {
+    return { lineup, corrected: { requestedId: activeLineupId, resolvedId: lineup.id } };
+  }
+  return { lineup };
+}
+
+export interface SaveLineupInput {
+  id?: string;
+  name: string;
+  roles: Record<RoleId, RoleSlots>;
+}
+
+/**
+ * Inserts or updates a lineup. When `input.id` is omitted, a fresh slug is
+ * derived from `input.name`. Returns the persisted entry.
+ *
+ * @throws on invalid name/id or empty slot fields.
+ */
+export function saveLineup(input: SaveLineupInput): Lineup {
+  const nameErr = validateLineupName(input.name);
+  if (nameErr) throw new Error(nameErr);
+  for (const role of ALL_ROLE_IDS) {
+    const ladder = input.roles[role];
+    for (const tier of LINEUP_TIERS) {
+      if (!isLineupSlot(ladder?.[tier])) {
+        throw new Error(
+          `Role "${role}" tier "${tier}" must have non-empty provider and model.`,
+        );
+      }
+    }
+  }
+  const existing = loadLineups();
+  const id = input.id ?? uniqueLineupId(input.name, existing);
+  const idErr = validateLineupId(id);
+  if (idErr) throw new Error(idErr);
+  const now = nowIso();
+  const roles = {} as Record<RoleId, RoleSlots>;
+  for (const role of ALL_ROLE_IDS) roles[role] = cloneRoleSlots(input.roles[role]);
+  const entry: Lineup = {
+    id,
+    name: input.name.trim(),
+    roles,
+    createdAt: existing[id]?.createdAt ?? now,
+    updatedAt: now,
+  };
+  existing[id] = entry;
+  writeFile(existing);
+  return entry;
+}
+
+export function renameLineup(id: string, newName: string): Lineup {
+  const nameErr = validateLineupName(newName);
+  if (nameErr) throw new Error(nameErr);
+  const existing = loadLineups();
+  const target = existing[id];
+  if (!target) throw new Error(`No lineup with id "${id}".`);
+  const updated: Lineup = { ...target, name: newName.trim(), updatedAt: nowIso() };
+  existing[id] = updated;
+  writeFile(existing);
+  return updated;
+}
+
+/**
+ * Deletes a lineup. Refuses to delete the last remaining lineup so callers
+ * always have something to resolve against.
+ *
+ * @throws when `id` is unknown or it's the last remaining entry.
+ */
+export function deleteLineup(id: string): void {
+  const existing = loadLineups();
+  if (!existing[id]) throw new Error(`No lineup with id "${id}".`);
+  if (Object.keys(existing).length <= 1)
+    throw new Error('Cannot delete the last remaining lineup.');
+  delete existing[id];
+  writeFile(existing);
+}
+
+/** Lists all lineups in iteration order. */
+export function listLineups(): Lineup[] {
+  return Object.values(loadLineups());
+}

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,0 +1,440 @@
+import type { LanguageModel } from 'ai';
+import type { BernardConfig } from './config.js';
+import type { Specialist } from './specialists.js';
+import {
+  defaultProviderErrorMessage,
+  hasProviderKey,
+  resolveProviderAndModel,
+  blankToUndefined,
+} from './config.js';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { loadLineups, resolveActiveLineup, type Lineup } from './lineups.js';
+import { DEFAULT_ROLE_TIERS, SITE_ROLE, type RoleId } from './model-roles.js';
+import { debugLog } from './logger.js';
+
+/**
+ * Logical LLM call sites whose model can be tiered independently when
+ * the active `config.modelMode`. Every `generateText` call in Bernard maps
+ * to exactly one site.
+ */
+export type ModelSite =
+  | 'main'
+  | 'specialist'
+  | 'tool-wrapper'
+  | 'rewriter'
+  | 'reference-resolver'
+  | 'reference-lookup'
+  | 'compressor'
+  | 'specialist-detector';
+
+/**
+ * Three-value runtime mode (#170, redesigned). The legacy `'off'` value is
+ * gone — every active call site now flows through the active lineup. Stored
+ * `'off'` is migrated to `'optimize-performance'` on first load (see
+ * {@link normalizeStoredModelMode}).
+ */
+export type ModelMode = 'optimize-tokens' | 'balanced' | 'optimize-performance';
+
+export type ModelTier = 'cheap' | 'mid' | 'premium';
+
+/**
+ * Resolves the cost tier for a functional role under the active `modelMode`,
+ * data-driven from {@link DEFAULT_ROLE_TIERS} in {@link module:model-roles}.
+ * Callers map `site → role` via {@link SITE_ROLE} first (they already need the
+ * role for the lineup-slot lookup and the snapshot log). This replaces the
+ * legacy hardcoded per-site `TIER_TABLE`; the role tier rows reproduce the old
+ * per-site assignments exactly (#264).
+ */
+function tierForRole(mode: ModelMode, role: RoleId): ModelTier {
+  return DEFAULT_ROLE_TIERS[mode][role];
+}
+
+/** True when `mode` is a recognized {@link ModelMode}. */
+function isKnownMode(mode: unknown): mode is ModelMode {
+  return mode === 'optimize-tokens' || mode === 'balanced' || mode === 'optimize-performance';
+}
+
+/**
+ * Normalizes any modelMode-shaped value read from disk or env. Returns the
+ * canonical runtime mode, or `undefined` for inputs that don't match. Migrates
+ * legacy `'off'` → `'optimize-performance'` so existing users keep their
+ * previously chosen model in the premium tier of the seeded lineup.
+ */
+export function normalizeStoredModelMode(v: unknown): ModelMode | undefined {
+  if (v === 'optimize-tokens' || v === 'balanced' || v === 'optimize-performance') return v;
+  if (v === 'off') return 'optimize-performance';
+  return undefined;
+}
+
+/**
+ * Result of {@link resolveSiteModel}. `model`/`providerOptions` are ready to
+ * pass straight into `generateText({ model, providerOptions, ... })`.
+ */
+export interface SiteModel {
+  model: LanguageModel;
+  providerOptions: ReturnType<typeof getProviderOptionsForConfig>;
+  provider: string;
+  modelName: string;
+  /**
+   * Where the (provider, model) ultimately came from. `'override'` =
+   * invocation-level args; `'specialist'` = persisted specialist record;
+   * `'policy'` = tier-table lookup; `'config'` = session global; `'fallback'`
+   * = tier lookup attempted but bailed (custom provider, unknown tier, etc.).
+   */
+  source: 'override' | 'specialist' | 'policy' | 'config' | 'fallback';
+  tier?: ModelTier;
+}
+
+/** Per-session dedupe of `model-policy:resolve` debug log lines. */
+const RESOLVE_LOG_SEEN = new Set<string>();
+
+/** Canonical list of every site whose model is policy-resolved. */
+const ALL_MODEL_SITES: readonly ModelSite[] = [
+  'main',
+  'specialist',
+  'tool-wrapper',
+  'rewriter',
+  'reference-resolver',
+  'reference-lookup',
+  'compressor',
+  'specialist-detector',
+];
+
+/**
+ * Resolves the effective (provider, model) for a given LLM call site.
+ *
+ * Precedence (highest to lowest):
+ *  1. `opts.overrides.{provider,model}` — invocation-level args (parity with
+ *     {@link resolveProviderAndModel}).
+ *  2. `opts.specialist.{provider,model}` — persisted specialist record.
+ *  3. The tier-table entry for `(modelMode, site)` mapped through the
+ *     **active lineup** (`src/lineups.ts`). When the lineup slot's provider
+ *     has no key, we fall through.
+ *  4. `config.provider`/`config.model` — last-resort fallback (used when the
+ *     lineup file is missing/corrupt, or the resolved slot lacks a key).
+ *
+ * Lineups are user-defined and may freely mix providers across tiers, so
+ * "active provider" is no longer a concept here — each tier slot carries its
+ * own provider.
+ */
+export function resolveSiteModel(
+  config: BernardConfig,
+  site: ModelSite,
+  opts?: {
+    overrides?: { provider?: string; model?: string };
+    specialist?: Specialist | undefined;
+  },
+): SiteModel {
+  const override = {
+    provider: blankToUndefined(opts?.overrides?.provider),
+    model: blankToUndefined(opts?.overrides?.model),
+  };
+  const specialist = {
+    provider: blankToUndefined(opts?.specialist?.provider),
+    model: blankToUndefined(opts?.specialist?.model),
+  };
+
+  // Loaded at most once per resolve — both the pin guard and the tier lookup
+  // need it, and `loadLineups()` is an uncached readFileSync + JSON.parse.
+  // Function-scoped (not module-memoized) so a `/lineup` edit still takes
+  // effect on the next resolve without a process restart.
+  let activeLineupCache: Lineup | null = null;
+  const getActiveLineup = (): Lineup => (activeLineupCache ??= loadActiveLineup(config));
+
+  // Off-lineup specialist pin guard. A persisted specialist may carry a
+  // `provider`/`model` baked in from when it was created — e.g. an
+  // `optimize-performance` session against OpenAI. When the user has
+  // explicitly chosen an active lineup (`config.activeLineupId` is set) and
+  // that lineup doesn't reference the specialist's provider at any tier,
+  // the pin is stale: the user has moved on (new lineup, dropped key,
+  // exhausted quota under that account). Dropping it lets the dispatch run
+  // on the active lineup's tier model instead of stalling on a 429/auth
+  // wall from a provider the user no longer relies on. Invocation-level
+  // overrides bypass the guard — those are explicit and trump persisted
+  // intent. When no `activeLineupId` is set the user hasn't expressed a
+  // lineup-level preference, so the pin is the strongest signal and we
+  // leave it alone. Custom-provider pins (Ollama, LM Studio, internal
+  // proxies) are also exempt: those are deliberate, often privacy- or
+  // cost-motivated bindings, and silently rerouting them to a lineup tier
+  // would ship a local-model workload to a remote API.
+  if (
+    config.activeLineupId &&
+    !override.provider &&
+    !override.model &&
+    specialist.provider &&
+    !Object.hasOwn(config.customProviders ?? {}, specialist.provider)
+  ) {
+    const activeLineup = getActiveLineup();
+    if (!isProviderInLineup(specialist.provider, activeLineup)) {
+      debugLog('model-policy:specialist-off-lineup', {
+        site,
+        specialistProvider: specialist.provider,
+        specialistModel: specialist.model,
+        lineupId: activeLineup.id,
+        lineupProviders: lineupProviders(activeLineup),
+        reason: 'pin-dropped',
+      });
+      specialist.provider = undefined;
+      specialist.model = undefined;
+    }
+  }
+
+  // Steps 1 & 2 — let the existing 3-tier resolver handle override + specialist.
+  // The policy never overrides an explicit user-supplied or specialist-supplied
+  // (provider, model). When the explicit choice points at a provider with no
+  // key, throw — matches pre-#170 behavior (specialist.ts / tool-wrapper.ts
+  // both relied on this).
+  if (override.provider || override.model || specialist.provider || specialist.model) {
+    const resolution = resolveProviderAndModel({
+      provider: override.provider,
+      model: override.model,
+      specialistProvider: specialist.provider,
+      specialistModel: specialist.model,
+      config,
+    });
+    if (!resolution.ok) {
+      throw new Error(
+        defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom),
+      );
+    }
+    const source: SiteModel['source'] =
+      override.provider || override.model ? 'override' : 'specialist';
+    // Pass `site` so `model-policy:resolve` logs fire on override/specialist
+    // short-circuits too. Tier/lineup intentionally omitted — those concepts
+    // don't apply when the lineup was bypassed.
+    return buildSiteModel(config, resolution.provider, resolution.model, source, site);
+  }
+
+  // Step 3 — tier-table lookup against the active lineup. Defensively
+  // normalize an unknown/undefined `modelMode` (legacy `'off'`, missing key in
+  // test fixtures) to `'balanced'` so resolution never crashes.
+  const mode: ModelMode = isKnownMode(config.modelMode) ? config.modelMode : 'balanced';
+  const role = SITE_ROLE[site];
+  const tier = tierForRole(mode, role);
+  const lineup = getActiveLineup();
+  const slot = lineup.roles[role][tier];
+  if (hasProviderKey(config, slot.provider)) {
+    return buildSiteModel(config, slot.provider, slot.model, 'policy', site, tier, lineup);
+  }
+  // Lineup slot points at a provider with no key — fall through to the
+  // session-global so the turn doesn't crash. This is the only "silent
+  // degradation" path left, and it's loud in the debug log.
+  debugLog('model-policy:fallback', {
+    site,
+    mode,
+    tier,
+    lineupId: lineup.id,
+    slotProvider: slot.provider,
+    slotModel: slot.model,
+    reason: 'missing-key',
+  });
+  return buildSiteModel(config, config.provider, config.model, 'fallback', site, tier, lineup);
+}
+
+/**
+ * Model-name string for the `'main'` LLM call site, resolved through the
+ * active lineup + model-mode policy. Use this anywhere context-window /
+ * compression math needs the model Bernard is actually talking to — the
+ * legacy `config.model` base field is only a fallback and goes stale the
+ * moment a lineup re-tiers `main` to a different provider/model (#233).
+ */
+export function resolveMainModel(config: BernardConfig): string {
+  return resolveSiteModel(config, 'main').modelName;
+}
+
+/**
+ * Loads the active lineup once per call. Cheap — `loadLineups()` is a
+ * single small JSON read; we don't memoize so a `/lineup` edit takes effect
+ * on the next turn without process restart.
+ */
+function loadActiveLineup(config: BernardConfig): Lineup {
+  const lineups = loadLineups();
+  return resolveActiveLineup(lineups, config.activeLineupId, config.provider);
+}
+
+/** True when any role×tier slot of the lineup is bound to the given provider. */
+function isProviderInLineup(provider: string, lineup: Lineup): boolean {
+  for (const ladder of Object.values(lineup.roles)) {
+    for (const slot of Object.values(ladder)) {
+      if (slot.provider === provider) return true;
+    }
+  }
+  return false;
+}
+
+/** Unique provider names referenced anywhere in the lineup (debug logging). */
+function lineupProviders(lineup: Lineup): string[] {
+  const out = new Set<string>();
+  for (const ladder of Object.values(lineup.roles)) {
+    for (const slot of Object.values(ladder)) out.add(slot.provider);
+  }
+  return [...out];
+}
+
+function buildSiteModel(
+  config: BernardConfig,
+  provider: string,
+  modelName: string,
+  source: SiteModel['source'],
+  site?: ModelSite,
+  tier?: ModelTier,
+  lineup?: Lineup,
+): SiteModel {
+  const out: SiteModel = {
+    model: getModelForConfig(config, provider, modelName),
+    providerOptions: getProviderOptionsForConfig(config, provider),
+    provider,
+    modelName,
+    source,
+    tier,
+  };
+  if (site) {
+    const key = `${site}:${provider}:${modelName}:${source}:${lineup?.id ?? '-'}`;
+    if (!RESOLVE_LOG_SEEN.has(key)) {
+      RESOLVE_LOG_SEEN.add(key);
+      debugLog('model-policy:resolve', {
+        site,
+        mode: config.modelMode,
+        tier,
+        provider,
+        model: modelName,
+        source,
+        lineupId: lineup?.id,
+        lineupName: lineup?.name,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Test-only helper to clear the per-session dedupe set so each test sees a
+ * fresh "first resolve" log entry.
+ */
+export function _resetModelPolicyLogCacheForTests(): void {
+  RESOLVE_LOG_SEEN.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot: lineup-driven baseline for every non-specialist call site.
+// ---------------------------------------------------------------------------
+
+export interface SiteModelSnapshotEntry {
+  site: ModelSite;
+  role: RoleId;
+  tier: ModelTier | undefined;
+  provider: string;
+  model: string;
+  source: SiteModel['source'];
+}
+
+export interface SiteModelSnapshot {
+  modelMode: ModelMode;
+  activeLineupId: string | undefined;
+  lineup: { id: string; name: string };
+  sites: Record<ModelSite, SiteModelSnapshotEntry>;
+}
+
+/**
+ * Captures the current `{site → (tier, provider, model)}` baseline implied
+ * by the active lineup + `config.modelMode`. Specialists and per-call
+ * overrides are intentionally excluded — they're per-record, per-call, and
+ * out of scope for the lineup-driven view.
+ *
+ * Pure: does not emit debug logs (uses the dedupe set as a side channel, but
+ * does not write a `model-policy:resolve` line for snapshot reads — see
+ * implementation note below).
+ */
+export function snapshotSiteModels(config: BernardConfig): SiteModelSnapshot {
+  const mode: ModelMode = isKnownMode(config.modelMode) ? config.modelMode : 'balanced';
+  const lineup = loadActiveLineup(config);
+  const sites = {} as Record<ModelSite, SiteModelSnapshotEntry>;
+  for (const site of ALL_MODEL_SITES) {
+    const role = SITE_ROLE[site];
+    const tier = tierForRole(mode, role);
+    const slot = lineup.roles[role][tier];
+    if (hasProviderKey(config, slot.provider)) {
+      sites[site] = {
+        site,
+        role,
+        tier,
+        provider: slot.provider,
+        model: slot.model,
+        source: 'policy',
+      };
+    } else {
+      sites[site] = {
+        site,
+        role,
+        tier,
+        provider: config.provider,
+        model: config.model,
+        source: 'fallback',
+      };
+    }
+  }
+  return {
+    modelMode: mode,
+    activeLineupId: config.activeLineupId,
+    lineup: { id: lineup.id, name: lineup.name },
+    sites,
+  };
+}
+
+let LAST_SNAPSHOT: SiteModelSnapshot | null = null;
+
+export type SnapshotReason =
+  | 'session-start'
+  | 'lineup-change'
+  | 'model-mode-change'
+  | 'profile-switch'
+  | 'provider-change';
+
+interface SiteChange {
+  site: ModelSite;
+  before: { tier: ModelTier | undefined; provider: string; model: string };
+  after: { tier: ModelTier | undefined; provider: string; model: string };
+}
+
+/**
+ * Emits a `model-policy:snapshot` debug event describing the current
+ * lineup-driven baseline. `session-start` always emits the full snapshot;
+ * subsequent calls emit a diff against the last snapshot (including the
+ * no-op `changed: []` case so the user can see that an edit didn't move
+ * any binding).
+ */
+export function logSiteModelSnapshot(config: BernardConfig, reason: SnapshotReason): void {
+  const snapshot = snapshotSiteModels(config);
+  if (LAST_SNAPSHOT === null || reason === 'session-start') {
+    debugLog('model-policy:snapshot', { reason, snapshot });
+    LAST_SNAPSHOT = snapshot;
+    return;
+  }
+  const before = LAST_SNAPSHOT;
+  const changed: SiteChange[] = [];
+  for (const site of ALL_MODEL_SITES) {
+    const a = before.sites[site];
+    const b = snapshot.sites[site];
+    if (a.provider !== b.provider || a.model !== b.model || a.tier !== b.tier) {
+      changed.push({
+        site,
+        before: { tier: a.tier, provider: a.provider, model: a.model },
+        after: { tier: b.tier, provider: b.provider, model: b.model },
+      });
+    }
+  }
+  debugLog('model-policy:snapshot', {
+    reason,
+    changed,
+    modeBefore: before.modelMode,
+    modeAfter: snapshot.modelMode,
+    lineupBefore: before.lineup,
+    lineupAfter: snapshot.lineup,
+  });
+  LAST_SNAPSHOT = snapshot;
+}
+
+/** Test-only helper: clears the LAST_SNAPSHOT cache. */
+export function _resetSnapshotCacheForTests(): void {
+  LAST_SNAPSHOT = null;
+}

--- a/src/model-roles.ts
+++ b/src/model-roles.ts
@@ -1,0 +1,196 @@
+/**
+ * @module model-roles
+ *
+ * **Single source of truth** for Bernard's functional model *roles* (#264).
+ *
+ * A lineup binds models along two orthogonal axes:
+ *  - **Cost tier** (`premium / mid / cheap`, see {@link module:lineups}) — how
+ *    much model to spend. `config.modelMode` moves every call site up/down this
+ *    axis.
+ *  - **Role** (defined here) — *what kind of work* the call site is doing
+ *    (orchestration, delegated execution, structured tool-calling, summarizing,
+ *    classification, …). The role selects which model *family* does the job;
+ *    the tier selects how strong a model within that family.
+ *
+ * Everything role-related derives from {@link MODEL_ROLES}: the lineup slot
+ * keys, the per-mode tier table ({@link DEFAULT_ROLE_TIERS}), the editor menu,
+ * and the snapshot logging. Adding a 7th role is a one-place additive edit
+ * here — declare it in `MODEL_ROLES` (and point a call site at it via
+ * {@link SITE_ROLE} when one exists).
+ */
+
+import type { ModelSite, ModelTier, ModelMode } from './model-policy.js';
+
+/** Stable identifier for a functional model role. */
+export type RoleId =
+  | 'orchestrator'
+  | 'executor'
+  | 'function-caller'
+  | 'summarizer'
+  | 'classifier'
+  | 'coder';
+
+/** A single role definition. The whole role system is derived from this list. */
+export interface ModelRole {
+  id: RoleId;
+  /** Short human label for menus. */
+  label: string;
+  /** One-line description shown in the lineup editor for discoverability. */
+  description: string;
+  /**
+   * Guidance shown in the lineup editor's detail card: *what kind of model to
+   * look for* when binding this role. Phrased as advice to the user choosing a
+   * model, not a description of the role's job (that's {@link description}).
+   */
+  lookFor: string;
+  /**
+   * Per-`ModelMode` cost-tier assignment for this role. This is the data behind
+   * the legacy `TIER_TABLE` — re-keyed from `[mode][site]` to `[mode][role]`.
+   * The values reproduce Bernard's pre-#264 per-site behavior exactly (every
+   * site that maps to a role inherits that role's tier row).
+   */
+  defaultTiers: Record<ModelMode, ModelTier>;
+}
+
+/**
+ * The canonical role list. ORDER MATTERS — it's the display order in the
+ * lineup editor.
+ *
+ * Tier rows reproduce the legacy `TIER_TABLE`:
+ *  - orchestrator ← old `main` row
+ *  - executor     ← old `specialist` row
+ *  - function-caller ← old `tool-wrapper` row
+ *  - summarizer   ← old `compressor` row
+ *  - classifier   ← old `rewriter`/`reference-*`/`specialist-detector` row
+ *  - coder        ← new; mirrors `executor` (mid in balanced) as a reasonable
+ *                   default until a real code-gen call site is wired up.
+ */
+export const MODEL_ROLES: readonly ModelRole[] = [
+  {
+    id: 'orchestrator',
+    label: 'Orchestrator',
+    description: 'Main interactive agent + cron — long-context planning & tool orchestration.',
+    lookFor:
+      'A strong long-context reasoner with dependable tool-calling. This model drives every turn — favor capability over cost.',
+    defaultTiers: {
+      'optimize-tokens': 'mid',
+      balanced: 'premium',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'executor',
+    label: 'Task executor',
+    description: 'Sub-agents, specialists & tasks — focused multi-step execution of delegated work.',
+    lookFor:
+      'A capable all-rounder that follows multi-step instructions and uses tools reliably. Balance cost against how much delegated work you run.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'function-caller',
+    label: 'Function caller',
+    description: 'Tool-wrapper specialists — natural language → schema-conformant structured calls.',
+    lookFor:
+      'A fast model with strong structured-output / JSON adherence. Argument accuracy matters more than deep reasoning here.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'summarizer',
+    label: 'Summarizer',
+    description: 'History compression & fact extraction — synthesis, not reasoning.',
+    lookFor:
+      'A model good at faithful synthesis and extraction. It runs on every compression, so lean cost-efficient.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'classifier',
+    label: 'Classifier / router',
+    description: 'Rewriter, reference resolver/lookup, specialist detector — cheap single-shot decisions.',
+    lookFor:
+      'The cheapest model that still judges reliably. These are quick single-shot routing calls where latency and price dominate.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'cheap',
+      'optimize-performance': 'premium',
+    },
+  },
+  {
+    id: 'coder',
+    label: 'Coder',
+    description: 'Reserved for a future dedicated code-generation role (no call site yet).',
+    lookFor:
+      'A model strong at code generation and editing. Reserved — no call site uses this role yet, but it is fully configurable.',
+    defaultTiers: {
+      'optimize-tokens': 'cheap',
+      balanced: 'mid',
+      'optimize-performance': 'premium',
+    },
+  },
+];
+
+/** Every role id, in display order. Iterate this for lineup slots / editor. */
+export const ALL_ROLE_IDS: readonly RoleId[] = MODEL_ROLES.map((r) => r.id);
+
+/** Lookup a role definition by id. */
+export function getRole(id: RoleId): ModelRole {
+  const r = MODEL_ROLES.find((x) => x.id === id);
+  if (!r) throw new Error(`Unknown model role "${id}".`);
+  return r;
+}
+
+/**
+ * `Record<ModelMode, Record<RoleId, ModelTier>>` derived from
+ * `MODEL_ROLES[*].defaultTiers`. This is the new `TIER_TABLE`: given the active
+ * `modelMode` and a role, it yields the cost tier to pull from the lineup.
+ */
+export const DEFAULT_ROLE_TIERS: Record<ModelMode, Record<RoleId, ModelTier>> = (() => {
+  const modes: ModelMode[] = ['optimize-tokens', 'balanced', 'optimize-performance'];
+  const out = {} as Record<ModelMode, Record<RoleId, ModelTier>>;
+  for (const mode of modes) {
+    const row = {} as Record<RoleId, ModelTier>;
+    for (const role of MODEL_ROLES) {
+      row[role.id] = role.defaultTiers[mode];
+    }
+    out[mode] = row;
+  }
+  return out;
+})();
+
+/**
+ * The set of cost tiers any role actually resolves to under a given mode. Lets
+ * callers ask "can this mode ever reach `premium`?" without traversing
+ * {@link DEFAULT_ROLE_TIERS} themselves — e.g. the Usage & Cost panel uses it to
+ * tell a *structurally unused* tier (premium under `optimize-tokens`) apart from
+ * one that was merely idle this turn.
+ */
+export function tiersReachableInMode(mode: ModelMode): Set<ModelTier> {
+  return new Set(Object.values(DEFAULT_ROLE_TIERS[mode]));
+}
+
+/**
+ * Static map from every policy-resolved call site to its functional role.
+ * Every `ModelSite` must appear here — this is the documented, single-place
+ * assignment required by #264 requirement 2.
+ */
+export const SITE_ROLE: Record<ModelSite, RoleId> = {
+  main: 'orchestrator',
+  specialist: 'executor',
+  'tool-wrapper': 'function-caller',
+  compressor: 'summarizer',
+  rewriter: 'classifier',
+  'reference-resolver': 'classifier',
+  'reference-lookup': 'classifier',
+  'specialist-detector': 'classifier',
+};

--- a/src/model-validate.test.ts
+++ b/src/model-validate.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the AI SDK so probes never hit the network. The fake generateText
+// resolves for "good-*" models and throws shaped errors for the rest.
+const generateTextMock = vi.fn();
+vi.mock('ai', () => ({ generateText: (args: unknown) => generateTextMock(args) }));
+
+// getModelForConfig / getProviderOptionsForConfig are pure passthroughs here.
+vi.mock('./providers/index.js', () => ({
+  getModelForConfig: (_c: unknown, provider: string, model: string) => ({ provider, model }),
+  getProviderOptionsForConfig: () => undefined,
+}));
+
+import { validateModel, validateLineup, formatLineupValidation } from './model-validate.js';
+import { ALL_ROLE_IDS } from './model-roles.js';
+import { LINEUP_TIERS, type Lineup } from './lineups.js';
+
+const config = { provider: 'xai', model: 'm' } as never;
+
+/** Build a full 6×3 lineup where every slot uses the same (provider, model). */
+function uniformLineup(provider: string, model: string): Lineup {
+  const roles = {} as Lineup['roles'];
+  for (const role of ALL_ROLE_IDS) {
+    roles[role] = {} as Lineup['roles'][typeof role];
+    for (const tier of LINEUP_TIERS) roles[role][tier] = { provider, model };
+  }
+  return { id: 'test', name: 'Test', roles, createdAt: 0, updatedAt: 0 };
+}
+
+beforeEach(() => {
+  generateTextMock.mockReset();
+});
+
+describe('validateModel', () => {
+  it('returns ok when the probe call resolves', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    const r = await validateModel(config, 'xai', 'grok-4.3');
+    expect(r.ok).toBe(true);
+    expect(r.category).toBeUndefined();
+    // The probe sends a tiny request (>= OpenAI's 16-token floor).
+    expect(generateTextMock).toHaveBeenCalledOnce();
+    expect(generateTextMock.mock.calls[0]![0].maxTokens).toBeGreaterThanOrEqual(16);
+  });
+
+  it('classifies a "does not exist" message as not_found even on a 400', async () => {
+    generateTextMock.mockRejectedValue(
+      Object.assign(new Error("The requested model 'gpt-5-chat' does not exist."), { statusCode: 400 }),
+    );
+    const r = await validateModel(config, 'openai', 'gpt-5-chat');
+    expect(r.ok).toBe(false);
+    expect(r.category).toBe('not_found');
+  });
+
+  it('classifies a 429 as rate_limit (quota)', async () => {
+    generateTextMock.mockRejectedValue(
+      Object.assign(new Error('You exceeded your current quota'), { statusCode: 429 }),
+    );
+    const r = await validateModel(config, 'openai', 'gpt-5.5');
+    expect(r.category).toBe('rate_limit');
+  });
+
+  it('classifies a 401 as auth', async () => {
+    generateTextMock.mockRejectedValue(Object.assign(new Error('bad key'), { statusCode: 401 }));
+    const r = await validateModel(config, 'openai', 'gpt-5.5');
+    expect(r.category).toBe('auth');
+  });
+});
+
+describe('validateModel — temperature guard (issue #267)', () => {
+  it('omits temperature for Anthropic reasoning models (claude-opus-4-8)', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    await validateModel(config, 'anthropic', 'claude-opus-4-8');
+    expect(generateTextMock).toHaveBeenCalledOnce();
+    const callArgs = generateTextMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs).not.toHaveProperty('temperature');
+  });
+
+  it('omits temperature for OpenAI o-series reasoning models', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    await validateModel(config, 'openai', 'o3');
+    const callArgs = generateTextMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs).not.toHaveProperty('temperature');
+  });
+
+  it('includes temperature: 0 for normal non-reasoning models', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    await validateModel(config, 'anthropic', 'claude-haiku-4-5-20251001');
+    const callArgs = generateTextMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs).toHaveProperty('temperature', 0);
+  });
+
+  it('includes temperature: 0 for standard OpenAI models', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    await validateModel(config, 'openai', 'gpt-4.1');
+    const callArgs = generateTextMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArgs).toHaveProperty('temperature', 0);
+  });
+});
+
+describe('validateLineup', () => {
+  it('dedupes identical slots to a single probe', async () => {
+    generateTextMock.mockResolvedValue({ text: 'ok' });
+    const v = await validateLineup(config, uniformLineup('xai', 'grok-4.3'));
+    // 18 identical slots collapse to one distinct (provider, model) pair.
+    expect(generateTextMock).toHaveBeenCalledOnce();
+    expect(v.results).toHaveLength(1);
+    expect(v.ok).toBe(true);
+    expect(v.results[0]!.slots).toHaveLength(18);
+  });
+
+  it('reports failures and the slots that use the broken model', async () => {
+    // One bad model in a single slot, the rest good.
+    const lineup = uniformLineup('xai', 'grok-4.3');
+    lineup.roles.executor.cheap = { provider: 'xai', model: 'grok-build-0.1' };
+    generateTextMock.mockImplementation((args: { model: { model: string } }) => {
+      if (args.model.model === 'grok-build-0.1') {
+        return Promise.reject(Object.assign(new Error('Model not found'), { statusCode: 404 }));
+      }
+      return Promise.resolve({ text: 'ok' });
+    });
+    const v = await validateLineup(config, lineup);
+    expect(v.ok).toBe(false);
+    expect(v.failures).toBe(1);
+    const bad = v.results.find((r) => !r.ok)!;
+    expect(bad.model).toBe('grok-build-0.1');
+    expect(bad.category).toBe('not_found');
+    expect(bad.slots).toEqual([{ role: 'executor', tier: 'cheap' }]);
+
+    const report = formatLineupValidation(v);
+    expect(report).toContain('✗');
+    expect(report).toContain('executor/cheap');
+  });
+});

--- a/src/model-validate.ts
+++ b/src/model-validate.ts
@@ -1,0 +1,233 @@
+import { generateText } from 'ai';
+import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { classifyError, type ToolErrorType } from './error-taxonomy.js';
+import { modelSupportsTemperature } from './providers/profiles.js';
+import { ALL_ROLE_IDS, type RoleId } from './model-roles.js';
+import { LINEUP_TIERS, type Lineup, type LineupTier } from './lineups.js';
+import type { BernardConfig } from './config.js';
+import { debugLog } from './logger.js';
+
+/**
+ * @module model-validate
+ *
+ * Live model validation. The model catalog (`src/providers/catalog.ts`) tells
+ * us which models *exist in the world*; it cannot tell us whether a given
+ * `(provider, model)` is actually callable with *this* user's API key on *this*
+ * endpoint. The only authoritative answer is an empirical probe: fire a tiny
+ * throwaway completion and classify the outcome.
+ *
+ * This catches the failure modes that silently broke lineups (#264 follow-up):
+ *   - `not_found`   — the model name is wrong, or the account has no access
+ *                     ("The requested model 'gpt-5-chat' does not exist").
+ *   - `auth`        — the API key is missing/invalid for this provider.
+ *   - `rate_limit`  — the account is out of quota (HTTP 429).
+ *
+ * What a probe CANNOT catch: a model that responds fine to "ping" but is too
+ * weak to follow instructions on a real task (e.g. a model that loops on tool
+ * calls without ever answering). Callers should surface that limitation.
+ */
+
+/** Wall-clock cap for a single probe before we abort it. */
+const PROBE_TIMEOUT_MS = 15_000;
+/** Default fan-out when probing many distinct models for one lineup. */
+const PROBE_CONCURRENCY = 4;
+
+export interface ModelProbeResult {
+  provider: string;
+  model: string;
+  ok: boolean;
+  /** Failure taxonomy category (undefined when `ok`). */
+  category?: ToolErrorType;
+  /** Trimmed provider error message (undefined when `ok`). */
+  message?: string;
+  latencyMs: number;
+}
+
+export interface ValidateModelOptions {
+  /** Abort the probe early (chained under an internal timeout controller). */
+  abortSignal?: AbortSignal;
+  /** Override the per-probe timeout. */
+  timeoutMs?: number;
+}
+
+/** Pull an HTTP status / errno / message out of a thrown AI SDK (or network) error. */
+function extractError(err: unknown): { httpStatus?: number; errno?: string; message: string } {
+  const e = err as { message?: unknown; statusCode?: unknown; status?: unknown; code?: unknown; errno?: unknown };
+  const message = typeof e?.message === 'string' && e.message ? e.message : String(err);
+  let httpStatus: number | undefined;
+  if (typeof e?.statusCode === 'number') httpStatus = e.statusCode;
+  else if (typeof e?.status === 'number') httpStatus = e.status;
+  let errno: string | undefined;
+  if (typeof e?.code === 'string') errno = e.code;
+  else if (typeof e?.errno === 'string') errno = e.errno;
+  return { httpStatus, errno, message };
+}
+
+/**
+ * Refine the taxonomy category for the model-validation context. Providers
+ * report "model does not exist" with inconsistent HTTP codes (400 *or* 404), so
+ * `classifyError` (which keys off status) may land on `invalid_args` for a 400.
+ * A message-level signal corrects that to `not_found` so the user sees the real
+ * cause ("this model name is wrong / inaccessible") rather than a generic
+ * argument error.
+ */
+const NOT_FOUND_RE = /does not exist|model_not_found|no such model|not found|unknown model|invalid model|model.*not.*available/i;
+
+function refineCategory(category: ToolErrorType, message: string): ToolErrorType {
+  // Never downgrade an auth/quota signal — those are more actionable than not_found.
+  if (category === 'auth' || category === 'rate_limit' || category === 'permission') return category;
+  if (NOT_FOUND_RE.test(message)) return 'not_found';
+  return category;
+}
+
+/**
+ * Live-probe a single `(provider, model)` with the user's configured key. Sends
+ * a 1-token "ping" and reports whether it succeeded. Never throws — every
+ * failure path resolves to `{ ok: false, category, message }`.
+ */
+export async function validateModel(
+  config: BernardConfig,
+  provider: string,
+  model: string,
+  opts: ValidateModelOptions = {},
+): Promise<ModelProbeResult> {
+  const t0 = Date.now();
+  const ctrl = new AbortController();
+  const onParentAbort = () => ctrl.abort();
+  if (opts.abortSignal) {
+    if (opts.abortSignal.aborted) ctrl.abort();
+    else opts.abortSignal.addEventListener('abort', onParentAbort, { once: true });
+  }
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? PROBE_TIMEOUT_MS);
+  try {
+    await generateText({
+      model: getModelForConfig(config, provider, model),
+      providerOptions: getProviderOptionsForConfig(config, provider),
+      messages: [{ role: 'user', content: 'ping' }],
+      maxSteps: 1,
+      // OpenAI's responses endpoint rejects max_output_tokens < 16; keep the
+      // probe at that floor so a too-small cap can't masquerade as a failure.
+      maxTokens: 16,
+      // Reasoning models (claude-opus-4-8, o-series, grok-4 reasoning) reject
+      // the temperature parameter with a 400 error — omit it for those models.
+      ...(modelSupportsTemperature(model, provider) ? { temperature: 0 } : {}),
+      abortSignal: ctrl.signal,
+    });
+    const latencyMs = Date.now() - t0;
+    debugLog('model-validate:probe', { provider, model, ok: true, latencyMs });
+    return { provider, model, ok: true, latencyMs };
+  } catch (err) {
+    const latencyMs = Date.now() - t0;
+    const { httpStatus, errno, message } = extractError(err);
+    const aborted = ctrl.signal.aborted && !opts.abortSignal?.aborted;
+    const cls = classifyError({ message, httpStatus, errno });
+    const category = aborted ? 'timeout' : refineCategory(cls.category, message);
+    debugLog('model-validate:probe', { provider, model, ok: false, category, httpStatus, latencyMs });
+    return { provider, model, ok: false, category, message: message.slice(0, 300), latencyMs };
+  } finally {
+    clearTimeout(timer);
+    if (opts.abortSignal) opts.abortSignal.removeEventListener('abort', onParentAbort);
+  }
+}
+
+/** A distinct `(provider, model)` pair and the role×tier slots that reference it. */
+export interface LineupSlotRef {
+  role: RoleId;
+  tier: LineupTier;
+}
+
+export interface LineupModelResult extends ModelProbeResult {
+  /** Which role×tier cells in the lineup use this pair (for "fix this slot" hints). */
+  slots: LineupSlotRef[];
+}
+
+export interface LineupValidation {
+  lineupId: string;
+  lineupName: string;
+  results: LineupModelResult[];
+  ok: boolean;
+  /** Count of distinct failing pairs. */
+  failures: number;
+}
+
+/** Collapse a lineup's 18 slots into the distinct `(provider, model)` pairs it references. */
+function distinctPairs(lineup: Lineup): Map<string, { provider: string; model: string; slots: LineupSlotRef[] }> {
+  const map = new Map<string, { provider: string; model: string; slots: LineupSlotRef[] }>();
+  for (const role of ALL_ROLE_IDS) {
+    for (const tier of LINEUP_TIERS) {
+      const slot = lineup.roles[role]?.[tier];
+      if (!slot) continue;
+      const key = `${slot.provider}/${slot.model}`;
+      const entry = map.get(key) ?? { provider: slot.provider, model: slot.model, slots: [] };
+      entry.slots.push({ role, tier });
+      map.set(key, entry);
+    }
+  }
+  return map;
+}
+
+/** Run probes with a bounded concurrency so a big lineup doesn't open 18 sockets at once. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i]!);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+/**
+ * Validate every distinct model in a lineup. Probes are deduped (a lineup that
+ * uses one model in all 18 slots costs exactly one probe) and run with bounded
+ * concurrency. Fails open: a probe that throws unexpectedly is reported as a
+ * failure result, never rejects the whole call.
+ */
+export async function validateLineup(
+  config: BernardConfig,
+  lineup: Lineup,
+  opts: ValidateModelOptions & { concurrency?: number } = {},
+): Promise<LineupValidation> {
+  const pairs = [...distinctPairs(lineup).values()];
+  const probed = await mapWithConcurrency(pairs, opts.concurrency ?? PROBE_CONCURRENCY, async (p) => {
+    const r = await validateModel(config, p.provider, p.model, opts);
+    return { ...r, slots: p.slots } as LineupModelResult;
+  });
+  const failures = probed.filter((r) => !r.ok).length;
+  return {
+    lineupId: lineup.id,
+    lineupName: lineup.name,
+    results: probed,
+    ok: failures === 0,
+    failures,
+  };
+}
+
+/** One-line summary per probed model, e.g. `✓ openai/gpt-5.5` / `✗ xai/grok-build-0.1 — not_found`. */
+export function formatProbeLine(r: ModelProbeResult): string {
+  if (r.ok) return `✓ ${r.provider}/${r.model} (${r.latencyMs}ms)`;
+  const detail = r.message ? `: ${r.message.split('\n')[0]!.slice(0, 120)}` : '';
+  return `✗ ${r.provider}/${r.model} — ${r.category ?? 'error'}${detail}`;
+}
+
+/** Human-readable report for a whole lineup validation (CLI + agent tool share this). */
+export function formatLineupValidation(v: LineupValidation): string {
+  const header = v.ok
+    ? `✓ Lineup "${v.lineupName}" (${v.lineupId}): all ${v.results.length} model(s) reachable.`
+    : `✗ Lineup "${v.lineupName}" (${v.lineupId}): ${v.failures} of ${v.results.length} model(s) failed.`;
+  const lines = v.results.map((r) => {
+    const base = formatProbeLine(r);
+    if (r.ok) return `  ${base}`;
+    const where = r.slots.map((s) => `${s.role}/${s.tier}`).join(', ');
+    return `  ${base}\n      used by: ${where}`;
+  });
+  return [header, ...lines].join('\n');
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -30,6 +30,7 @@ export const KEYS_PATH = path.join(CONFIG_DIR, 'keys.json');
 export const ENV_PATH = path.join(CONFIG_DIR, '.env');
 export const MCP_CONFIG_PATH = path.join(CONFIG_DIR, 'mcp.json');
 export const CUSTOM_PROVIDERS_PATH = path.join(CONFIG_DIR, 'custom-providers.json');
+export const LINEUPS_PATH = path.join(CONFIG_DIR, 'lineups.json');
 
 // Data
 export const MEMORY_DIR = path.join(DATA_DIR, 'memory');
@@ -49,6 +50,7 @@ export const TOOL_PROFILES_DIR = path.join(DATA_DIR, 'tool-profiles');
 // Cache
 export const MODELS_DIR = path.join(CACHE_DIR, 'models');
 export const UPDATE_CACHE_PATH = path.join(CACHE_DIR, 'update-check.json');
+export const MODEL_CATALOG_CACHE = path.join(CACHE_DIR, 'model-catalog.json');
 
 // State
 export const HISTORY_FILE = path.join(STATE_DIR, 'conversation-history.json');

--- a/src/prompt-rewriter.ts
+++ b/src/prompt-rewriter.ts
@@ -1,6 +1,6 @@
 import { generateText } from 'ai';
 import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
-import type { ModelProfile } from './providers/profiles.js';
+import { modelSupportsTemperature, type ModelProfile } from './providers/profiles.js';
 import type { ResolvedEntry } from './reference-resolver.js';
 import type { BernardConfig } from './config.js';
 import { debugLog } from './logger.js';
@@ -149,7 +149,7 @@ export async function rewritePrompt(
       messages: [{ role: 'user', content: buildUserMessage(input, resolvedEntries) }],
       maxSteps: 1,
       maxTokens: REWRITER_MAX_TOKENS,
-      temperature: 0,
+      ...(modelSupportsTemperature(config.model, config.provider) ? { temperature: 0 } : {}),
       abortSignal,
     });
 

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -1,0 +1,340 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { CACHE_DIR, MODEL_CATALOG_CACHE } from '../paths.js';
+import { debugLog } from '../logger.js';
+import type { BuiltinProvider } from './types.js';
+import { BUILTIN_PROVIDERS } from './types.js';
+
+const GATEWAY_URL = 'https://ai-gateway.vercel.sh/v1/models';
+const DEFAULT_TTL_HOURS = 24;
+const FETCH_TIMEOUT_MS = 5000;
+
+export type CatalogSource = 'network' | 'disk' | 'vendored';
+
+export interface ModelCatalogEntry {
+  provider: BuiltinProvider;
+  /** Model id as accepted by the corresponding @ai-sdk/* provider SDK. */
+  model: string;
+  displayName: string;
+  contextWindow: number;
+  maxOutputTokens: number;
+  tags: string[];
+  pricing: { inputPerMTok: number; outputPerMTok: number };
+  /** Unix seconds the model was released (for recency tie-breaking). */
+  released: number;
+}
+
+interface CachedCatalog {
+  fetchedAt: number;
+  source: CatalogSource;
+  entries: ModelCatalogEntry[];
+}
+
+interface RawGatewayResponse {
+  object: string;
+  data: RawGatewayModel[];
+}
+
+interface RawGatewayModel {
+  id: string;
+  type?: string;
+  name?: string;
+  released?: number;
+  context_window?: number;
+  max_tokens?: number;
+  tags?: string[];
+  pricing?: { input?: string | number; output?: string | number };
+}
+
+let memoryCache: CachedCatalog | null = null;
+/**
+ * Shared refresh promise. Always *resolves* (never rejects) so the
+ * stale-while-revalidate path — which fires it without awaiting — can never
+ * produce an unhandled rejection. The fetch error travels in the envelope
+ * instead; forced callers unwrap it and re-throw (see {@link loadCatalog}).
+ */
+let inflight: Promise<{ catalog: CachedCatalog; error: Error | null }> | null = null;
+
+/**
+ * Anthropic gateway ids use dots (`claude-opus-4.6`) but the @ai-sdk/anthropic
+ * SDK accepts dashes (`claude-opus-4-6`). OpenAI and xAI use dots in both
+ * places. Apply the transform only for Anthropic so we hand the SDK a name it
+ * recognises.
+ */
+function gatewayIdToModel(provider: BuiltinProvider, raw: string): string {
+  if (provider === 'anthropic') return raw.replace(/\./g, '-');
+  return raw;
+}
+
+function parseGatewayEntry(raw: RawGatewayModel): ModelCatalogEntry | null {
+  if (raw.type && raw.type !== 'language') return null;
+  const slash = raw.id.indexOf('/');
+  if (slash < 0) return null;
+  const owner = raw.id.slice(0, slash);
+  const rest = raw.id.slice(slash + 1);
+  if (!BUILTIN_PROVIDERS.includes(owner as BuiltinProvider)) return null;
+  const provider = owner as BuiltinProvider;
+  const inputPrice = Number(raw.pricing?.input ?? 0);
+  const outputPrice = Number(raw.pricing?.output ?? 0);
+  return {
+    provider,
+    model: gatewayIdToModel(provider, rest),
+    displayName: raw.name ?? rest,
+    contextWindow: raw.context_window ?? 0,
+    maxOutputTokens: raw.max_tokens ?? 0,
+    tags: raw.tags ?? [],
+    // Convert per-token to per-million-tokens for human-readable numbers.
+    pricing: {
+      inputPerMTok: inputPrice * 1_000_000,
+      outputPerMTok: outputPrice * 1_000_000,
+    },
+    released: raw.released ?? 0,
+  };
+}
+
+function parseGatewayPayload(payload: RawGatewayResponse): ModelCatalogEntry[] {
+  if (!payload || !Array.isArray(payload.data)) return [];
+  const out: ModelCatalogEntry[] = [];
+  for (const raw of payload.data) {
+    const entry = parseGatewayEntry(raw);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+function vendoredPath(): string {
+  // Resolves to `<install-root>/data/model-catalog-fallback.json` whether
+  // running compiled (`dist/providers/catalog.js`) or via tsx
+  // (`src/providers/catalog.ts`). `copy-builtins.mjs` copies `src/data` to
+  // `dist/data` so the same `..` walk works in both layouts.
+  return path.join(__dirname, '..', 'data', 'model-catalog-fallback.json');
+}
+
+function loadVendored(): CachedCatalog {
+  try {
+    const raw = fs.readFileSync(vendoredPath(), 'utf-8');
+    const payload = JSON.parse(raw) as RawGatewayResponse;
+    return {
+      fetchedAt: 0,
+      source: 'vendored',
+      entries: parseGatewayPayload(payload),
+    };
+  } catch (err) {
+    debugLog('catalog:vendored:error', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return { fetchedAt: 0, source: 'vendored', entries: [] };
+  }
+}
+
+function loadDiskCache(): CachedCatalog | null {
+  try {
+    const raw = fs.readFileSync(MODEL_CATALOG_CACHE, 'utf-8');
+    const parsed = JSON.parse(raw) as { fetchedAt: number; entries: ModelCatalogEntry[] };
+    if (!Array.isArray(parsed.entries)) return null;
+    return { fetchedAt: parsed.fetchedAt ?? 0, source: 'disk', entries: parsed.entries };
+  } catch {
+    return null;
+  }
+}
+
+function saveDiskCache(entries: ModelCatalogEntry[], fetchedAt: number): void {
+  try {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.writeFileSync(MODEL_CATALOG_CACHE, JSON.stringify({ fetchedAt, entries }, null, 2));
+  } catch (err) {
+    debugLog('catalog:disk:write-error', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function ttlMs(): number {
+  const hours = Number(process.env.BERNARD_CATALOG_TTL_HOURS);
+  const v = Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_TTL_HOURS;
+  return v * 60 * 60 * 1000;
+}
+
+async function fetchFromGateway(): Promise<ModelCatalogEntry[]> {
+  debugLog('catalog:fetch:start', { url: GATEWAY_URL });
+  const t0 = Date.now();
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(GATEWAY_URL, { signal: ctrl.signal });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const payload = (await resp.json()) as RawGatewayResponse;
+    const entries = parseGatewayPayload(payload);
+    debugLog('catalog:fetch:end', {
+      durationMs: Date.now() - t0,
+      entries: entries.length,
+    });
+    return entries;
+  } catch (err) {
+    debugLog('catalog:fetch:error', {
+      durationMs: Date.now() - t0,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Synchronous load: reads the disk cache or the vendored snapshot. Never makes
+ * a network call. Safe to call at module-init time for consumers that need a
+ * catalog immediately (e.g. `PROVIDER_MODELS`).
+ */
+export function loadCatalogSync(): CachedCatalog {
+  if (memoryCache) return memoryCache;
+  const disk = loadDiskCache();
+  if (disk) {
+    memoryCache = disk;
+    debugLog('catalog:source', { source: 'disk', entries: disk.entries.length });
+    return disk;
+  }
+  const vendored = loadVendored();
+  memoryCache = vendored;
+  debugLog('catalog:source', { source: 'vendored', entries: vendored.entries.length });
+  return vendored;
+}
+
+/**
+ * Async load with stale-while-revalidate. Returns the current catalog
+ * immediately (loading synchronously if needed). When the cached copy is
+ * older than the TTL — or when `force` is true — a background fetch refreshes
+ * the disk cache + memory cache without blocking the caller.
+ */
+export async function loadCatalog(opts: { force?: boolean } = {}): Promise<CachedCatalog> {
+  const current = loadCatalogSync();
+  const stale = Date.now() - current.fetchedAt > ttlMs();
+  if (!opts.force && !stale) return current;
+  if (!inflight) {
+    inflight = (async () => {
+      try {
+        const entries = await fetchFromGateway();
+        const fetchedAt = Date.now();
+        saveDiskCache(entries, fetchedAt);
+        memoryCache = { fetchedAt, source: 'network', entries };
+        debugLog('catalog:source', { source: 'network', entries: entries.length });
+        return { catalog: memoryCache, error: null };
+      } catch (err) {
+        debugLog('catalog:refresh-error', {
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          catalog: current,
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      } finally {
+        inflight = null;
+      }
+    })();
+  }
+  if (opts.force) {
+    // A forced refresh is user-initiated (`/refresh-models`) — surface the
+    // fetch failure so the caller's error path is reachable instead of
+    // silently reporting the stale catalog as "refreshed".
+    const { catalog, error } = await inflight;
+    if (error) throw error;
+    return catalog;
+  }
+  // Stale-while-revalidate: don't await the refresh, return what we have.
+  return current;
+}
+
+/** Returns all catalog entries for a single built-in provider. */
+export function getCatalogForProvider(provider: BuiltinProvider): ModelCatalogEntry[] {
+  const cat = loadCatalogSync();
+  return cat.entries.filter((e) => e.provider === provider);
+}
+
+/** Look up a single (provider, model) pair. Returns null when unknown. */
+export function getModelMeta(provider: string, model: string): ModelCatalogEntry | null {
+  if (!BUILTIN_PROVIDERS.includes(provider as BuiltinProvider)) return null;
+  const cat = loadCatalogSync();
+  return cat.entries.find((e) => e.provider === provider && e.model === model) ?? null;
+}
+
+/**
+ * Look up a model by name across every built-in provider. Returns the first
+ * match. Useful for call sites that only know the model id (e.g.
+ * `getContextWindow`).
+ */
+export function findModelMetaByName(model: string): ModelCatalogEntry | null {
+  const cat = loadCatalogSync();
+  return cat.entries.find((e) => e.model === model) ?? null;
+}
+
+/** Catalog age in milliseconds, or `null` when sourced from the vendored fallback. */
+export function getCatalogAgeMs(): number | null {
+  const cat = loadCatalogSync();
+  if (cat.source === 'vendored' || cat.fetchedAt === 0) return null;
+  return Date.now() - cat.fetchedAt;
+}
+
+/** Where the in-memory catalog came from on its most recent load. */
+export function getCatalogSource(): CatalogSource {
+  return loadCatalogSync().source;
+}
+
+/** Stable identity for a catalog entry — `provider/model`. */
+function entryKey(e: ModelCatalogEntry): string {
+  return `${e.provider}/${e.model}`;
+}
+
+/** Outcome of {@link refreshCatalogWithDiff}. */
+export interface CatalogRefreshDiff {
+  /** Entries present after the refresh but not before. */
+  added: ModelCatalogEntry[];
+  /** Entries present before the refresh but gone after. */
+  removed: ModelCatalogEntry[];
+  /** Total entry count after the refresh. */
+  total: number;
+  /** Source of the catalog after the refresh. */
+  source: CatalogSource;
+  /** Source of the catalog *before* the refresh (`'vendored'` ⇒ no real baseline). */
+  previousSource: CatalogSource;
+  /** Set when the forced network fetch failed; the diff is empty in that case. */
+  error?: Error;
+}
+
+/**
+ * Force-refresh the catalog from the gateway and report what changed relative
+ * to the previously-loaded copy. Used by the REPL startup hook to notify the
+ * user when new models become available.
+ *
+ * Never throws — a network failure is reported in `error` with an empty diff,
+ * so startup is never blocked or crashed by an offline gateway. Callers should
+ * treat `previousSource === 'vendored'` as "no real baseline" and skip
+ * notifying (a fresh install diffing the bundled snapshot against the live
+ * gateway would otherwise produce noise).
+ */
+export async function refreshCatalogWithDiff(): Promise<CatalogRefreshDiff> {
+  const prev = loadCatalogSync();
+  const previousSource = prev.source;
+  const before = new Set(prev.entries.map(entryKey));
+  try {
+    const refreshed = await loadCatalog({ force: true });
+    const afterKeys = new Set(refreshed.entries.map(entryKey));
+    const added = refreshed.entries.filter((e) => !before.has(entryKey(e)));
+    const removed = prev.entries.filter((e) => !afterKeys.has(entryKey(e)));
+    return { added, removed, total: refreshed.entries.length, source: refreshed.source, previousSource };
+  } catch (err) {
+    return {
+      added: [],
+      removed: [],
+      total: prev.entries.length,
+      source: previousSource,
+      previousSource,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+/** Test-only hook to flush the in-memory cache so a fresh load is forced. */
+export function _resetCatalogCacheForTests(): void {
+  memoryCache = null;
+  inflight = null;
+}

--- a/src/providers/profiles.test.ts
+++ b/src/providers/profiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getModelProfile } from './profiles.js';
+import { getModelProfile, modelSupportsTemperature } from './profiles.js';
 
 describe('getModelProfile — resolution', () => {
   it('returns anthropic-claude for any anthropic model', () => {
@@ -120,6 +120,63 @@ describe('systemSuffix — per family', () => {
     const p = getModelProfile('unknown', 'mystery-model');
     expect(p.systemSuffix).toBe('');
     expect(p.wrapUserMessage('hi')).toBe('hi');
+  });
+});
+
+describe('modelSupportsTemperature', () => {
+  it('returns false for Anthropic extended-thinking models (the -4-8 generation)', () => {
+    expect(modelSupportsTemperature('claude-opus-4-8', 'anthropic')).toBe(false);
+    // Provider omitted — pattern-matching alone
+    expect(modelSupportsTemperature('claude-opus-4-8')).toBe(false);
+    // Broader -4-8 generation coverage: any future extended-thinking variant
+    expect(modelSupportsTemperature('claude-haiku-4-8', 'anthropic')).toBe(false);
+    expect(modelSupportsTemperature('claude-sonnet-4-8', 'anthropic')).toBe(false);
+  });
+
+  it('returns true for normal Anthropic models', () => {
+    expect(modelSupportsTemperature('claude-haiku-4-5-20251001', 'anthropic')).toBe(true);
+    expect(modelSupportsTemperature('claude-sonnet-4-5-20250929', 'anthropic')).toBe(true);
+    expect(modelSupportsTemperature('claude-opus-4-6', 'anthropic')).toBe(true);
+  });
+
+  it('returns false for OpenAI o-series reasoning models', () => {
+    expect(modelSupportsTemperature('o1', 'openai')).toBe(false);
+    expect(modelSupportsTemperature('o3', 'openai')).toBe(false);
+    expect(modelSupportsTemperature('o3-mini', 'openai')).toBe(false);
+    expect(modelSupportsTemperature('o4-mini', 'openai')).toBe(false);
+  });
+
+  it('returns true for normal OpenAI models', () => {
+    expect(modelSupportsTemperature('gpt-4.1', 'openai')).toBe(true);
+    expect(modelSupportsTemperature('gpt-5.2', 'openai')).toBe(true);
+    expect(modelSupportsTemperature('gpt-4o-mini', 'openai')).toBe(true);
+  });
+
+  it('returns false for xAI grok-4 reasoning variants', () => {
+    expect(modelSupportsTemperature('grok-4-fast-reasoning', 'xai')).toBe(false);
+    expect(modelSupportsTemperature('grok-4-1-fast-reasoning', 'xai')).toBe(false);
+    expect(modelSupportsTemperature('grok-4-0709', 'xai')).toBe(false);
+  });
+
+  it('returns true for xAI explicit non-reasoning variants', () => {
+    expect(modelSupportsTemperature('grok-4-fast-non-reasoning', 'xai')).toBe(true);
+    expect(modelSupportsTemperature('grok-4-1-fast-non-reasoning', 'xai')).toBe(true);
+  });
+
+  it('returns true for older non-reasoning xAI models', () => {
+    expect(modelSupportsTemperature('grok-3', 'xai')).toBe(true);
+    expect(modelSupportsTemperature('grok-3-mini', 'xai')).toBe(true);
+  });
+
+  it('returns true for unknown/custom models (fail-open)', () => {
+    expect(modelSupportsTemperature('mystery-model')).toBe(true);
+    expect(modelSupportsTemperature('llama-3', 'ollama')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(modelSupportsTemperature('Claude-Opus-4-8', 'anthropic')).toBe(false);
+    expect(modelSupportsTemperature('O3', 'openai')).toBe(false);
+    expect(modelSupportsTemperature('Grok-4-Fast-Reasoning', 'xai')).toBe(false);
   });
 });
 

--- a/src/providers/profiles.ts
+++ b/src/providers/profiles.ts
@@ -142,6 +142,46 @@ export function getModelProfile(
   return DEFAULT_PROFILE;
 }
 
+/**
+ * Returns `true` when the model accepts a `temperature` parameter.
+ *
+ * Reasoning models (Anthropic claude-opus-4-8 and newer extended-thinking
+ * variants, OpenAI o-series, xAI grok-4 reasoning variants) reject the
+ * `temperature` field with a 400 error. Omit it entirely for those models.
+ *
+ * When `provider` is supplied the check narrows to only that family; when
+ * omitted the helper falls back to pattern-matching the model name alone,
+ * which is sufficient for the deterministic sub-call sites (rewriter,
+ * reference-lookup) that derive the model from `config.model`.
+ *
+ * Non-reasoning models — and unknown models — return `true` (keep sending
+ * temperature) so the fail-open default preserves existing determinism.
+ */
+export function modelSupportsTemperature(model: string, provider?: string): boolean {
+  const m = model.toLowerCase();
+  const family = provider?.toLowerCase();
+
+  // Anthropic: extended-thinking variants reject temperature.
+  // The -4-8 suffix identifies the extended-thinking generation (claude-opus-4-8,
+  // and hypothetical future claude-haiku-4-8 / claude-sonnet-4-8 variants).
+  if (!family || family === 'anthropic') {
+    if (/-4-8(\b|$)/.test(m)) return false;
+  }
+
+  // OpenAI o-series (o1, o3, o3-mini, o4-mini, …)
+  if (!family || family === 'openai') {
+    if (/^o\d/.test(m)) return false;
+  }
+
+  // xAI: grok-4.x reasoning variants (but NOT explicit non-reasoning variants)
+  if (!family || family === 'xai') {
+    if (!m.includes('non-reasoning') && m.includes('reasoning')) return false;
+    if (!m.includes('non-reasoning') && /^grok-4(\b|[-.])/.test(m)) return false;
+  }
+
+  return true;
+}
+
 // References for maintainers updating the suffix constants:
 //   https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices
 //   https://developers.openai.com/cookbook/examples/gpt4-1_prompting_guide

--- a/src/providers/tiers.ts
+++ b/src/providers/tiers.ts
@@ -1,0 +1,68 @@
+/**
+ * @module providers/tiers
+ *
+ * Derive the three lineup tiers (`premium`, `mid`, `cheap`) from a list of
+ * catalog entries for a single provider, using output-price quantiles with a
+ * recency tie-break.
+ *
+ * Used by `seedDefaultLineups()` when a fresh install (or a built-in provider
+ * with no existing lineup) needs sensible defaults — the user can still
+ * override any slot through the `/models` lineup editor.
+ */
+
+import type { ModelCatalogEntry } from './catalog.js';
+
+export interface DerivedTiers {
+  premium: string;
+  mid: string;
+  cheap: string;
+}
+
+/**
+ * Sort entries by output price descending; tie-break by `released` descending
+ * (newer first) so when two models cost the same we prefer the more recent
+ * release.
+ */
+function sortByPriceDescThenRecency(entries: ModelCatalogEntry[]): ModelCatalogEntry[] {
+  return [...entries].sort((a, b) => {
+    if (b.pricing.outputPerMTok !== a.pricing.outputPerMTok) {
+      return b.pricing.outputPerMTok - a.pricing.outputPerMTok;
+    }
+    return b.released - a.released;
+  });
+}
+
+/**
+ * Picks `premium`, `mid`, `cheap` from a single provider's catalog entries.
+ *
+ *   - Top entry by output price → `premium`.
+ *   - Bottom entry → `cheap`.
+ *   - Median entry → `mid` (for even counts we take the lower-priced of the
+ *     two middle slots, since the array is sorted descending — i.e.
+ *     `sorted[Math.floor(n/2)]`).
+ *   - One entry collapses all three slots.
+ *   - Two entries: `premium = mid = sorted[0]`, `cheap = sorted[1]`.
+ *
+ * @throws when `entries` is empty.
+ */
+export function deriveTiers(entries: ModelCatalogEntry[]): DerivedTiers {
+  if (entries.length === 0) {
+    throw new Error('deriveTiers: cannot derive tiers from an empty catalog.');
+  }
+  const sorted = sortByPriceDescThenRecency(entries);
+  if (sorted.length === 1) {
+    const only = sorted[0]!.model;
+    return { premium: only, mid: only, cheap: only };
+  }
+  if (sorted.length === 2) {
+    return {
+      premium: sorted[0]!.model,
+      mid: sorted[0]!.model,
+      cheap: sorted[1]!.model,
+    };
+  }
+  const premium = sorted[0]!.model;
+  const cheap = sorted[sorted.length - 1]!.model;
+  const mid = sorted[Math.floor(sorted.length / 2)]!.model;
+  return { premium, mid, cheap };
+}

--- a/src/reference-tool-lookup.ts
+++ b/src/reference-tool-lookup.ts
@@ -1,5 +1,6 @@
 import { generateText } from 'ai';
 import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { modelSupportsTemperature } from './providers/profiles.js';
 import { debugLog } from './logger.js';
 import type { BernardConfig } from './config.js';
 
@@ -160,7 +161,7 @@ export async function selectLookupTool(
       messages: [{ role: 'user', content: buildSelectUserMessage(reference, candidates) }],
       maxSteps: 1,
       maxTokens: SELECT_MAX_TOKENS,
-      temperature: 0,
+      ...(modelSupportsTemperature(config.model, config.provider) ? { temperature: 0 } : {}),
       abortSignal,
     });
     if (!result.text) return null;
@@ -288,7 +289,7 @@ export async function interpretLookupResult(
       ],
       maxSteps: 1,
       maxTokens: INTERPRET_MAX_TOKENS,
-      temperature: 0,
+      ...(modelSupportsTemperature(config.model, config.provider) ? { temperature: 0 } : {}),
       abortSignal,
     });
     if (!result.text) return { status: 'none' };


### PR DESCRIPTION
## Summary

Fixes issue #267: Anthropic claude-opus-4-8 (a reasoning model) rejects `temperature: 0` with a 400 error when Bernard runs the lineup live-check probe or deterministic sub-call passes.

### Primary fix — live-check probe (`src/model-validate.ts`)

The `validateModel()` function fires a tiny "ping" probe for each lineup slot model. It previously hardcoded `temperature: 0` on every probe, causing claude-opus-4-8 and other reasoning models to 400. Fixed with `...(modelSupportsTemperature(model, provider) ? { temperature: 0 } : {})` — critically, using the **lineup's target model/provider** (not `config.model`), so any reasoning model in any slot is correctly detected.

### Supporting helper (`src/providers/profiles.ts`)

Added `modelSupportsTemperature(model, provider?)` that returns `false` for:
- Anthropic: the `-4-8` extended-thinking generation (claude-opus-4-8, and hypothetical future claude-haiku-4-8 / claude-sonnet-4-8 variants)
- OpenAI: o-series models (`/^o\d/`)
- xAI: grok-4.x variants unless explicitly tagged `non-reasoning`
- Fail-open: unknown/custom models return `true`

### Deterministic sub-call sites also fixed (`src/prompt-rewriter.ts`, `src/reference-tool-lookup.ts`)

Also applied the guard to the 3 other call sites that hardcoded `temperature: 0`.

### Lineup infrastructure added

Brings in the lineup feature files (`model-validate.ts`, `error-taxonomy.ts`, `model-roles.ts`, `model-policy.ts`, `lineups.ts`, `providers/catalog.ts`, `providers/tiers.ts`) needed to make the fix compile and test.

Closes #267

## Test plan

- [x] `npm test` — 2195 tests pass (80 test files)
- [x] `validateModel()` probe omits temperature for `claude-opus-4-8` and `o3` (4 new regression tests in `src/model-validate.test.ts`)
- [x] `validateModel()` probe retains `temperature: 0` for normal models (`claude-haiku-4-5-20251001`, `gpt-4.1`)
- [x] `modelSupportsTemperature()` returns correct values for all provider families (10 test cases in `src/providers/profiles.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lp3KzUVED95C85dMVN3dvF