### PR TITLE
feat(statusbar): animate token counters with accent-color pulse on increment (#246)

### DIFF
--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -12,6 +12,9 @@ interface StatusBarProps {
 
 const BAR_WIDTH = 10;
 
+/** Pulse decay duration in ms — short enough to feel snappy, long enough to notice. */
+const PULSE_DECAY_MS = 250;
+
 /** Serialize the fields StatusBar actually renders, for change detection. */
 function snapshotStats(stats: SpinnerStats | null, strategy: string | null): string {
   if (!stats) return `null|${strategy ?? ''}`;
@@ -38,20 +41,76 @@ function snapshotStats(stats: SpinnerStats | null, strategy: string | null): str
  * resolution) that gets louder as it fills: muted while there's >25% headroom,
  * warning between 5%–25%, and the theme's accent color once <5% of the
  * compression budget is left.
+ * Token counter pulse (#246): when `turnPromptTokens` or `turnCompletionTokens`
+ * increases, the corresponding `↑`/`↓` counter briefly brightens to the accent
+ * color for ~250 ms, then decays back to muted. Rapid successive increments
+ * restart the timer (extend the pulse) rather than stacking timeouts.
  */
 export function StatusBar({ agent }: StatusBarProps) {
   const colors = getThemeColors();
   const [, force] = useState(0);
   const lastSnapshotRef = useRef<string>(snapshotStats(agent.spinnerStats, agent.currentStrategy));
+
+  // Per-direction pulse state: true while the accent highlight is active.
+  const [upPulse, setUpPulse] = useState(false);
+  const [downPulse, setDownPulse] = useState(false);
+
+  // Track previous token values so we can detect increases.
+  const prevUpRef = useRef<number>(agent.spinnerStats?.turnPromptTokens ?? 0);
+  const prevDownRef = useRef<number>(agent.spinnerStats?.turnCompletionTokens ?? 0);
+
+  // Pending decay timeout handles — cleared on rapid successive increments and on unmount.
+  const upTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const downTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const id = setInterval(() => {
       const snap = snapshotStats(agent.spinnerStats, agent.currentStrategy);
       if (snap !== lastSnapshotRef.current) {
         lastSnapshotRef.current = snap;
+
+        const currentUp = agent.spinnerStats?.turnPromptTokens ?? 0;
+        const currentDown = agent.spinnerStats?.turnCompletionTokens ?? 0;
+
+        // Pulse the ↑ counter if prompt tokens increased.
+        if (currentUp > prevUpRef.current) {
+          setUpPulse(true);
+          if (upTimeoutRef.current !== null) clearTimeout(upTimeoutRef.current);
+          upTimeoutRef.current = setTimeout(() => {
+            setUpPulse(false);
+            upTimeoutRef.current = null;
+          }, PULSE_DECAY_MS);
+        }
+
+        // Pulse the ↓ counter if completion tokens increased.
+        if (currentDown > prevDownRef.current) {
+          setDownPulse(true);
+          if (downTimeoutRef.current !== null) clearTimeout(downTimeoutRef.current);
+          downTimeoutRef.current = setTimeout(() => {
+            setDownPulse(false);
+            downTimeoutRef.current = null;
+          }, PULSE_DECAY_MS);
+        }
+
+        prevUpRef.current = currentUp;
+        prevDownRef.current = currentDown;
+
         force((n) => n + 1);
       }
     }, 500);
-    return () => clearInterval(id);
+    return () => {
+      clearInterval(id);
+      if (upTimeoutRef.current !== null) {
+        clearTimeout(upTimeoutRef.current);
+        upTimeoutRef.current = null;
+        setUpPulse(false);
+      }
+      if (downTimeoutRef.current !== null) {
+        clearTimeout(downTimeoutRef.current);
+        downTimeoutRef.current = null;
+        setDownPulse(false);
+      }
+    };
   }, [agent]);
 
   const stats: SpinnerStats | null = agent.spinnerStats;
@@ -105,9 +164,15 @@ export function StatusBar({ agent }: StatusBarProps) {
           depicts, so the two can't be confused. */}
       {stats && (
         <>
-          <Text color={colors.muted}>
-            turn {up}↑ {down}↓{cost}{'   '}
+          <Text color={colors.muted}>turn </Text>
+          <Text color={upPulse ? colors.accent : colors.muted} bold={upPulse}>
+            {up}↑
           </Text>
+          <Text color={colors.muted}> </Text>
+          <Text color={downPulse ? colors.accent : colors.muted} bold={downPulse}>
+            {down}↓
+          </Text>
+          <Text color={colors.muted}>{cost}{'   '}</Text>
           {sessionCost ? <Text color={colors.muted}>{sessionCost}</Text> : null}
           <Text color={colors.muted}>ctx {formatTokenCount(stats.latestPromptTokens)} </Text>
           {filledCount > 0 && <Text color={fillColor}>{'●'.repeat(filledCount)}</Text>}

--- a/src/ui/__tests__/StatusBar.test.tsx
+++ b/src/ui/__tests__/StatusBar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
 import stripAnsi from 'strip-ansi';
@@ -147,5 +147,100 @@ describe('<StatusBar> idle-tick guard (#232)', () => {
     (agent.spinnerStats as { turnPromptTokens: number }).turnPromptTokens = 2222;
     await new Promise((r) => setTimeout(r, 600)); // past the 500ms poll interval
     expect(stripAnsi(lastFrame() ?? '')).toMatch(/turn\s+2\.2k↑/);
+  });
+});
+
+describe('<StatusBar> token counter pulse (#246)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('triggers an extra re-render for the ↑ counter when prompt tokens increase (pulse on), then again when it decays (pulse off)', async () => {
+    // The pulse mechanism fires two state transitions per increment:
+    //   1. setUpPulse(true)  — on the poll tick (500 ms)
+    //   2. setUpPulse(false) — on the decay timeout (+ 250 ms)
+    // Each state transition forces a new frame, so frames.length must grow
+    // by at least 2 compared to idle (no new frames when nothing changes).
+    const agent = stubAgent(0.55);
+    const { frames } = render(createElement(StatusBar, { agent }));
+
+    const framesBeforePoll = frames.length;
+
+    // Increase prompt tokens — the poll will see this at 500 ms.
+    (agent.spinnerStats as { turnPromptTokens: number }).turnPromptTokens = 5000;
+
+    // Advance to 500 ms → poll fires, snapshot changes, setUpPulse(true) + force() called.
+    await vi.advanceTimersByTimeAsync(500);
+    const framesAfterPoll = frames.length;
+
+    // At least one new frame from the poll re-render (pulse on + counter value update).
+    expect(framesAfterPoll).toBeGreaterThan(framesBeforePoll);
+
+    // Advance another 250 ms → decay timeout fires, setUpPulse(false) called.
+    await vi.advanceTimersByTimeAsync(250);
+    const framesAfterDecay = frames.length;
+
+    // At least one more frame from the decay re-render.
+    expect(framesAfterDecay).toBeGreaterThan(framesAfterPoll);
+
+    // The displayed token count must reflect the new value in the final frame.
+    // formatTokenCount(5000) = "5.0k"
+    expect(stripAnsi(frames[framesAfterDecay - 1] ?? '')).toMatch(/5\.0k↑/);
+  });
+
+  it('triggers an extra re-render for the ↓ counter when completion tokens increase (pulse on), then again when it decays (pulse off)', async () => {
+    const agent = stubAgent(0.55);
+    const { frames } = render(createElement(StatusBar, { agent }));
+
+    const framesBeforePoll = frames.length;
+
+    // Increase completion tokens — the poll will see this at 500 ms.
+    (agent.spinnerStats as { turnCompletionTokens: number }).turnCompletionTokens = 3000;
+
+    await vi.advanceTimersByTimeAsync(500);
+    const framesAfterPoll = frames.length;
+
+    expect(framesAfterPoll).toBeGreaterThan(framesBeforePoll);
+
+    await vi.advanceTimersByTimeAsync(250);
+    const framesAfterDecay = frames.length;
+
+    expect(framesAfterDecay).toBeGreaterThan(framesAfterPoll);
+
+    // formatTokenCount(3000) = "3.0k"
+    expect(stripAnsi(frames[framesAfterDecay - 1] ?? '')).toMatch(/3\.0k↓/);
+  });
+
+  it('does NOT trigger a ↓ pulse when only prompt tokens increase', async () => {
+    // When turnCompletionTokens stays constant, only the ↑ pulse fires.
+    // We verify this by confirming that the decay timer for ↓ never fires an
+    // extra frame after the ↑ decay is already done.
+    const agent = stubAgent(0.55);
+    const { frames } = render(createElement(StatusBar, { agent }));
+
+    // Only increase prompt tokens; completion tokens stay at 567.
+    (agent.spinnerStats as { turnPromptTokens: number }).turnPromptTokens = 5000;
+
+    // Advance well past both the poll (500 ms) and the decay (250 ms).
+    await vi.advanceTimersByTimeAsync(500);
+    const framesAtPoll = frames.length;
+    await vi.advanceTimersByTimeAsync(250);
+    const framesAfterUpDecay = frames.length;
+
+    // ↑ pulse should have fired (at least one new frame).
+    expect(framesAfterUpDecay).toBeGreaterThan(framesAtPoll);
+
+    // Now advance a further 500 ms with no token changes — no new frames
+    // should appear, because the ↓ pulse never fired and there's nothing else
+    // to re-render.
+    await vi.advanceTimersByTimeAsync(500);
+    const framesAfterIdle = frames.length;
+    expect(framesAfterIdle).toBe(framesAfterUpDecay);
+
+    // The ↓ value must still be the original 567 throughout.
+    expect(stripAnsi(frames[framesAfterIdle - 1] ?? '')).toMatch(/567↓/);
   });
 });


### PR DESCRIPTION
## Summary

- Splits the single `<Text>turn {up}↑ {down}↓</Text>` into per-direction `<Text>` nodes so each direction can carry its own `color` and `bold` prop independently
- When `turnPromptTokens` or `turnCompletionTokens` increases (detected on the existing 500ms poll), the corresponding `↑`/`↓` counter brightens to `colors.accent` for ~250ms, then decays back to `colors.muted`
- Rapid successive increments restart/extend the decay timer rather than stacking — implemented via `clearTimeout` before each new `setTimeout`
- The effect cleanup now also resets `upPulse`/`downPulse` to `false` when the decay timer is cancelled (prevents permanently stuck accent color if `agent` prop ever changes mid-pulse)
- Only the direction whose count increased pulses — an unchanged direction stays muted

## Test plan

- [x] 3 new component tests using `vi.useFakeTimers()` (matching `Spinner.test.tsx` pattern):
  - ↑ counter pulses (extra frames) when `turnPromptTokens` increases, decays after 250ms
  - ↓ counter pulses when `turnCompletionTokens` increases, decays after 250ms  
  - Only-one-direction change does NOT pulse the other direction
- [x] All 14 StatusBar tests pass (`npx vitest run src/ui/__tests__/StatusBar.test.tsx`)
- [x] Full test suite: 3074 passing, 4 pre-existing unrelated failures (eval-harness model-policy, cron job limit)
- [x] `npm run build` compiles clean (TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)