### PR TITLE
feat(lineups): per-model generation params via a provider adapter (#286)

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -175,6 +175,9 @@ export async function extractDomainFacts(
       const result = await generateText({
         model: site.model,
         providerOptions: site.providerOptions,
+        // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+        // this site's output cap stays authoritative (#286).
+        ...site.params,
         maxTokens: 2048,
         system: domain.extractionPrompt,
         messages: [
@@ -283,6 +286,9 @@ export async function compressHistory(
     const summarizePromise = generateText({
       model: summarizerSite.model,
       providerOptions: summarizerSite.providerOptions,
+      // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+      // this site's output cap stays authoritative (#286).
+      ...summarizerSite.params,
       maxTokens: 2048,
       system: SUMMARIZATION_PROMPT,
       messages: [{ role: 'user', content: `Summarize this conversation:\n\n${serialized}` }],

--- a/src/framework/agents/cron.ts
+++ b/src/framework/agents/cron.ts
@@ -236,6 +236,7 @@ export const cronDefinition: AgentDefinition<CronInput, string> = {
     return {
       model: site.model,
       providerOptions: site.providerOptions,
+      params: site.params,
       provider: site.provider,
       modelName: site.modelName,
       // Carry the resolved tier for ledger attribution (#258); harmless under

--- a/src/framework/agents/run.ts
+++ b/src/framework/agents/run.ts
@@ -258,6 +258,7 @@ export async function runDefinition<TInput, TFormatted>(
   const baseSpec: AgentSpec = {
     model: resolved.model,
     providerOptions: resolved.providerOptions,
+    params: resolved.params,
     tools,
     maxSteps: baseMaxSteps,
     maxTokens: config.maxTokens,
@@ -344,6 +345,7 @@ function resolveModel<TInput, TFormatted>(
   return {
     model: site.model,
     providerOptions: site.providerOptions,
+    params: site.params,
     provider: site.provider,
     modelName: site.modelName,
     tier: site.tier,

--- a/src/framework/agents/specialist.ts
+++ b/src/framework/agents/specialist.ts
@@ -130,6 +130,7 @@ export const specialistDefinition: AgentDefinition<SpecialistInput, string> = {
     return {
       model: site.model,
       providerOptions: site.providerOptions,
+      params: site.params,
       provider: site.provider,
       modelName: site.modelName,
       // Carry the resolved tier so ledger attribution (#258) buckets this

--- a/src/framework/agents/tool-wrapper.ts
+++ b/src/framework/agents/tool-wrapper.ts
@@ -111,6 +111,7 @@ export const toolWrapperDefinition: AgentDefinition<ToolWrapperInput, WrapperRes
     return {
       model: site.model,
       providerOptions: site.providerOptions,
+      params: site.params,
       provider: site.provider,
       modelName: site.modelName,
       // Carry the resolved tier so ledger attribution (#258) buckets this

--- a/src/framework/agents/types.ts
+++ b/src/framework/agents/types.ts
@@ -36,6 +36,11 @@ export interface ModelOverrides {
 export interface ResolvedModel {
   model: LanguageModel;
   providerOptions?: Parameters<typeof import('ai').generateText>[0]['providerOptions'];
+  /**
+   * Top-level generation params (issue #286), carried from {@link SiteModel}
+   * into the {@link AgentSpec} so the runner spreads them into the call.
+   */
+  params?: Record<string, unknown>;
   /** Provider name used (post-override). Available to hooks that need it. */
   provider: string;
   /** Model name used (post-override). */

--- a/src/framework/runner.ts
+++ b/src/framework/runner.ts
@@ -53,6 +53,12 @@ function parseDispatchTimeoutMs(): number | null {
 export interface AgentSpec {
   model: LanguageModel;
   providerOptions?: Parameters<typeof generateText>[0]['providerOptions'];
+  /**
+   * Top-level generation params (issue #286): `temperature`, `topP`,
+   * `maxOutputTokens`. Resolved per lineup slot by `resolveSiteModel` and
+   * spread into the `generateText`/`streamText` call alongside `providerOptions`.
+   */
+  params?: Record<string, unknown>;
   tools?: Record<string, Tool>;
   maxSteps?: number;
   maxTokens?: number;
@@ -310,6 +316,9 @@ async function runNonStreaming(
     experimental_prepareStep: spec.prepareStep,
     experimental_repairToolCall: spec.repair,
     onStepFinish,
+    // Per-slot params last so a slot-set temperature/topP/maxTokens overrides
+    // the defaults above (issue #286).
+    ...spec.params,
   });
   const abortSignal = spec.abortSignal;
   if (!abortSignal) return gen;
@@ -345,6 +354,8 @@ async function runStreaming(
     abortSignal: spec.abortSignal,
     experimental_repairToolCall: spec.repair,
     onStepFinish,
+    // Per-slot params last so they override the defaults above (issue #286).
+    ...spec.params,
   });
   // Defensive: race every await against the parent abort signal. The AI SDK
   // is supposed to settle `textStream` and the result promises when its own

--- a/src/lineups.ts
+++ b/src/lineups.ts
@@ -36,6 +36,7 @@ import { atomicWriteFileSync } from './fs-utils.js';
 import { getCatalogForProvider } from './providers/catalog.js';
 import { deriveTiers } from './providers/tiers.js';
 import { BUILTIN_PROVIDERS, type BuiltinProvider } from './providers/types.js';
+import type { ModelParams } from './providers/model-params.js';
 import { ALL_ROLE_IDS, type RoleId } from './model-roles.js';
 
 /** The three cost-tier slots every role defines. */
@@ -46,6 +47,13 @@ export type LineupTier = (typeof LINEUP_TIERS)[number];
 export interface LineupSlot {
   provider: string;
   model: string;
+  /**
+   * Optional generation parameters for this slot (issue #286). Absent =
+   * provider/model defaults (today's behavior, byte-for-byte). Keyed by
+   * {@link ParamDescriptor.id}; serialized into the AI-SDK call by
+   * `serializeModelParams` (`src/providers/model-params.ts`).
+   */
+  params?: ModelParams;
 }
 
 /** The `{premium, mid, cheap}` cost ladder for one role. */

--- a/src/llm-cache.ts
+++ b/src/llm-cache.ts
@@ -31,6 +31,11 @@ export interface LLMCacheKey {
   modelId: string;
   /** Provider options passed to `generateText`. */
   providerOptions?: unknown;
+  /**
+   * Top-level generation params (issue #286: `temperature`, `topP`,
+   * `maxOutputTokens`). Included by value so different params hash separately.
+   */
+  params?: unknown;
   /** System prompt. */
   system: string;
   /** Stringified user content (messages or single user message). */
@@ -51,6 +56,7 @@ function stableKey(k: LLMCacheKey): string {
     s: k.siteName,
     m: k.modelId,
     p: k.providerOptions ?? null,
+    pp: k.params ?? null,
     sys: k.system,
     u: k.userContent,
   });

--- a/src/model-policy.test.ts
+++ b/src/model-policy.test.ts
@@ -166,6 +166,89 @@ describe('resolveSiteModel — tier mapping per mode (anthropic lineup)', () => 
   });
 });
 
+describe('resolveSiteModel — per-slot generation params (#286)', () => {
+  // Overwrites the seeded lineups.json with a single lineup whose slots carry
+  // optional `params`, and points `activeLineupId` at it.
+  function seedParamsLineup(slots: {
+    premium: Record<string, unknown>;
+    mid: Record<string, unknown>;
+    cheap: Record<string, unknown>;
+  }): void {
+    const cfgDir = path.join(tmpDir, 'bernard');
+    const now = new Date().toISOString();
+    fs.writeFileSync(
+      path.join(cfgDir, 'lineups.json'),
+      JSON.stringify(
+        {
+          lineups: {
+            paramy: {
+              id: 'paramy',
+              name: 'Paramy',
+              roles: fullRoles(slots as never),
+              createdAt: now,
+              updatedAt: now,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  it('keeps today behavior byte-for-byte when no slot params: rewriter gets temperature 0', async () => {
+    const { resolveSiteModel } = await loadModule();
+    // No params anywhere; anthropic haiku supports temperature, so the rewriter
+    // baseline (formerly the temperatureParam spread) re-injects temperature: 0.
+    const r = resolveSiteModel(makeConfig({ modelMode: 'balanced' }), 'rewriter');
+    expect(r.params).toEqual({ temperature: 0 });
+    // Anthropic carries no providerOptions (no OpenAI strictSchemas).
+    expect(r.providerOptions).toBeUndefined();
+  });
+
+  it('routes a slot reasoningEffort to providerOptions.xai', async () => {
+    seedParamsLineup({
+      premium: { provider: 'xai', model: 'grok-4-1-fast-reasoning', params: { reasoningEffort: 'high' } },
+      mid: { provider: 'xai', model: 'grok-4-fast-non-reasoning' },
+      cheap: { provider: 'xai', model: 'grok-3-mini' },
+    });
+    const { resolveSiteModel } = await loadModule();
+    const config = makeConfig({ activeLineupId: 'paramy', modelMode: 'optimize-performance' });
+    const r = resolveSiteModel(config, 'main'); // premium slot
+    expect(r.modelName).toBe('grok-4-1-fast-reasoning');
+    expect((r.providerOptions as Record<string, unknown>)?.xai).toEqual({ reasoningEffort: 'high' });
+  });
+
+  it('a slot temperature overrides the per-site baseline', async () => {
+    seedParamsLineup({
+      premium: { provider: 'anthropic', model: 'claude-opus-4-6' },
+      mid: { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
+      cheap: { provider: 'anthropic', model: 'claude-haiku-4-5-20251001', params: { temperature: 0.7 } },
+    });
+    const { resolveSiteModel } = await loadModule();
+    // balanced → rewriter resolves to the cheap slot.
+    const r = resolveSiteModel(
+      makeConfig({ activeLineupId: 'paramy', modelMode: 'balanced' }),
+      'rewriter',
+    );
+    expect(r.params).toEqual({ temperature: 0.7 });
+  });
+
+  it('merges OpenAI strictSchemas with a slot reasoningEffort', async () => {
+    seedParamsLineup({
+      premium: { provider: 'openai', model: 'gpt-5.2', params: { reasoningEffort: 'high' } },
+      mid: { provider: 'openai', model: 'gpt-4.1' },
+      cheap: { provider: 'openai', model: 'gpt-4.1-mini' },
+    });
+    const { resolveSiteModel } = await loadModule();
+    const r = resolveSiteModel(
+      makeConfig({ activeLineupId: 'paramy', modelMode: 'optimize-performance' }),
+      'main',
+    );
+    expect(r.providerOptions).toEqual({ openai: { strictSchemas: false, reasoningEffort: 'high' } });
+  });
+});
+
 describe('resolveSiteModel — openai lineup', () => {
   it('balanced picks gpt-5.2 / gpt-4.1 / gpt-4.1-mini', async () => {
     const { resolveSiteModel } = await loadModule();

--- a/src/model-policy.ts
+++ b/src/model-policy.ts
@@ -1,4 +1,4 @@
-import type { LanguageModel } from 'ai';
+import type { LanguageModel, generateText } from 'ai';
 import type { BernardConfig } from './config.js';
 import type { Specialist } from './specialists.js';
 import {
@@ -8,6 +8,8 @@ import {
   blankToUndefined,
 } from './config.js';
 import { getModelForConfig, getProviderOptionsForConfig } from './providers/index.js';
+import { modelSupportsTemperature } from './providers/profiles.js';
+import { serializeModelParams, type ModelParams } from './providers/model-params.js';
 import { loadLineups, resolveActiveLineup, type Lineup } from './lineups.js';
 import { DEFAULT_ROLE_TIERS, SITE_ROLE, type RoleId } from './model-roles.js';
 import { debugLog } from './logger.js';
@@ -36,6 +38,9 @@ export type ModelSite =
 export type ModelMode = 'optimize-tokens' | 'balanced' | 'optimize-performance';
 
 export type ModelTier = 'cheap' | 'mid' | 'premium';
+
+/** The AI SDK's `providerOptions` shape (`Record<string, Record<string, JSONValue>>`). */
+type SdkProviderOptions = Parameters<typeof generateText>[0]['providerOptions'];
 
 /**
  * Resolves the cost tier for a functional role under the active `modelMode`,
@@ -72,7 +77,19 @@ export function normalizeStoredModelMode(v: unknown): ModelMode | undefined {
  */
 export interface SiteModel {
   model: LanguageModel;
-  providerOptions: ReturnType<typeof getProviderOptionsForConfig>;
+  /**
+   * Provider-options half (issue #286): the base `getProviderOptionsForConfig`
+   * result (OpenAI `strictSchemas`) deep-merged with any per-slot provider
+   * params (`providerOptions.<sdk>.reasoningEffort`, Anthropic `thinking`).
+   */
+  providerOptions: SdkProviderOptions;
+  /**
+   * Top-level `generateText` params half (issue #286): `temperature`, `topP`,
+   * `maxOutputTokens`. Spread into every `generateText` call alongside
+   * `providerOptions`. `undefined` when the slot has no top-level params and no
+   * per-site baseline applies.
+   */
+  params?: Record<string, unknown>;
   provider: string;
   modelName: string;
   /**
@@ -129,9 +146,10 @@ export function resolveSiteModel(
     provider: blankToUndefined(opts?.overrides?.provider),
     model: blankToUndefined(opts?.overrides?.model),
   };
-  const specialist = {
+  const specialist: { provider?: string; model?: string; params?: ModelParams } = {
     provider: blankToUndefined(opts?.specialist?.provider),
     model: blankToUndefined(opts?.specialist?.model),
+    params: opts?.specialist?.params,
   };
 
   // Loaded at most once per resolve — both the pin guard and the tier lookup
@@ -176,6 +194,7 @@ export function resolveSiteModel(
       });
       specialist.provider = undefined;
       specialist.model = undefined;
+      specialist.params = undefined;
     }
   }
 
@@ -197,12 +216,22 @@ export function resolveSiteModel(
         defaultProviderErrorMessage(resolution.provider, resolution.envVar, resolution.isCustom),
       );
     }
-    const source: SiteModel['source'] =
-      override.provider || override.model ? 'override' : 'specialist';
+    const isOverride = Boolean(override.provider || override.model);
+    const source: SiteModel['source'] = isOverride ? 'override' : 'specialist';
     // Pass `site` so `model-policy:resolve` logs fire on override/specialist
     // short-circuits too. Tier/lineup intentionally omitted — those concepts
-    // don't apply when the lineup was bypassed.
-    return buildSiteModel(config, resolution.provider, resolution.model, source, site);
+    // don't apply when the lineup was bypassed. Specialist params ride along on
+    // the specialist branch only (an invocation override carries no params).
+    return buildSiteModel(
+      config,
+      resolution.provider,
+      resolution.model,
+      source,
+      site,
+      undefined,
+      undefined,
+      isOverride ? undefined : specialist.params,
+    );
   }
 
   // Step 3 — tier-table lookup against the active lineup. Defensively
@@ -214,7 +243,7 @@ export function resolveSiteModel(
   const lineup = getActiveLineup();
   const slot = lineup.roles[role][tier];
   if (hasProviderKey(config, slot.provider)) {
-    return buildSiteModel(config, slot.provider, slot.model, 'policy', site, tier, lineup);
+    return buildSiteModel(config, slot.provider, slot.model, 'policy', site, tier, lineup, slot.params);
   }
   // Lineup slot points at a provider with no key — fall through to the
   // session-global so the turn doesn't crash. This is the only "silent
@@ -271,6 +300,44 @@ function lineupProviders(lineup: Lineup): string[] {
   return [...out];
 }
 
+/**
+ * Sites that historically forced `temperature: 0` via the ad-hoc
+ * `temperatureParam(...)` spread (now retired). To keep "absent slot params =
+ * today's behavior, byte-for-byte" (issue #286 acceptance criterion), we
+ * re-inject that baseline here when the model accepts temperature and the slot
+ * didn't override it. `compressor` never used `temperatureParam`, so it is
+ * deliberately excluded.
+ */
+const TEMPERATURE_ZERO_SITES: ReadonlySet<ModelSite> = new Set([
+  'rewriter',
+  'reference-resolver',
+  'reference-lookup',
+  'specialist-detector',
+]);
+
+/**
+ * Deep-merges two `providerOptions` shapes one level deep (per-SDK key), so the
+ * base OpenAI `{ strictSchemas: false }` survives alongside a serialized
+ * `{ reasoningEffort }`. Returns the base reference unchanged when there's
+ * nothing to merge (preserves identity for byte-for-byte behavior).
+ */
+function mergeProviderOptions(
+  base: SdkProviderOptions,
+  extra: Record<string, unknown>,
+): SdkProviderOptions {
+  if (Object.keys(extra).length === 0) return base;
+  const out: Record<string, unknown> = { ...(base ?? {}) };
+  for (const [sdk, opts] of Object.entries(extra)) {
+    const existing = out[sdk];
+    if (existing && typeof existing === 'object' && opts && typeof opts === 'object') {
+      out[sdk] = { ...(existing as Record<string, unknown>), ...(opts as Record<string, unknown>) };
+    } else {
+      out[sdk] = opts;
+    }
+  }
+  return out as SdkProviderOptions;
+}
+
 function buildSiteModel(
   config: BernardConfig,
   provider: string,
@@ -279,10 +346,32 @@ function buildSiteModel(
   site?: ModelSite,
   tier?: ModelTier,
   lineup?: Lineup,
+  slotParams?: ModelParams,
 ): SiteModel {
+  const sdk = config.customProviders?.[provider]?.sdk;
+  const serialized = serializeModelParams(provider, modelName, slotParams, sdk);
+
+  // Top-level half (temperature/topP/maxOutputTokens), plus the per-site
+  // temperature:0 baseline that preserves the pre-#286 classifier behavior.
+  const params: Record<string, unknown> = { ...serialized.params };
+  if (
+    site &&
+    TEMPERATURE_ZERO_SITES.has(site) &&
+    params.temperature === undefined &&
+    modelSupportsTemperature(modelName, provider)
+  ) {
+    params.temperature = 0;
+  }
+
+  const providerOptions = mergeProviderOptions(
+    getProviderOptionsForConfig(config, provider),
+    serialized.providerOptions,
+  );
+
   const out: SiteModel = {
     model: getModelForConfig(config, provider, modelName),
-    providerOptions: getProviderOptionsForConfig(config, provider),
+    providerOptions,
+    params: Object.keys(params).length > 0 ? params : undefined,
     provider,
     modelName,
     source,
@@ -301,6 +390,8 @@ function buildSiteModel(
         source,
         lineupId: lineup?.id,
         lineupName: lineup?.name,
+        params: out.params,
+        providerOptions: out.providerOptions,
       });
     }
   }

--- a/src/prompt-rewriter.ts
+++ b/src/prompt-rewriter.ts
@@ -1,6 +1,5 @@
 import { generateText } from 'ai';
 import type { ModelProfile } from './providers/profiles.js';
-import { temperatureParam } from './providers/profiles.js';
 import type { ResolvedEntry } from './reference-resolver.js';
 import type { BernardConfig } from './config.js';
 import { resolveSiteModel } from './model-policy.js';
@@ -159,6 +158,7 @@ export async function rewritePrompt(
           siteName: 'rewriter',
           modelId: site.model.modelId,
           providerOptions: site.providerOptions,
+          params: site.params,
           system,
           userContent,
         }
@@ -180,11 +180,14 @@ export async function rewritePrompt(
         generateText({
           model: site.model,
           providerOptions: site.providerOptions,
+          // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+          // this site's deterministic output cap stays authoritative — a slot
+          // maxOutputTokens must not blow the classifier budget (#286).
+          ...site.params,
           system,
           messages: [{ role: 'user', content: userContent }],
           maxSteps: 1,
           maxTokens: REWRITER_MAX_TOKENS,
-          ...temperatureParam(site.model.modelId, site.provider),
           abortSignal,
         }),
       );

--- a/src/providers/model-params.test.ts
+++ b/src/providers/model-params.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  describeModelParams,
+  serializeModelParams,
+  validateModelParams,
+} from './model-params.js';
+
+// These tests use model names absent from the vendored catalog so the adapter's
+// family heuristics (the catalog-miss fallback) fire deterministically, rather
+// than depending on catalog tag contents that can shift.
+
+describe('describeModelParams — capability gating', () => {
+  it('xAI reasoning model exposes reasoningEffort [low, high] and no temperature', () => {
+    const ds = describeModelParams('xai', 'grok-4-fast-reasoning');
+    const byId = Object.fromEntries(ds.map((d) => [d.id, d]));
+    expect(byId.reasoningEffort).toBeDefined();
+    expect(byId.reasoningEffort.kind).toBe('enum');
+    expect(byId.reasoningEffort.options).toEqual(['low', 'high']);
+    expect(byId.temperature).toBeUndefined();
+    expect(byId.topP).toBeUndefined();
+    // max output tokens is universal
+    expect(byId.maxOutputTokens).toBeDefined();
+  });
+
+  it('OpenAI reasoning model exposes reasoningEffort [minimal, low, medium, high]', () => {
+    const ds = describeModelParams('openai', 'o3-pro-test');
+    const byId = Object.fromEntries(ds.map((d) => [d.id, d]));
+    expect(byId.reasoningEffort?.options).toEqual(['minimal', 'low', 'medium', 'high']);
+    expect(byId.temperature).toBeUndefined();
+  });
+
+  it('non-reasoning model exposes temperature and topP', () => {
+    const ds = describeModelParams('openai', 'gpt-4-omni-test');
+    const byId = Object.fromEntries(ds.map((d) => [d.id, d]));
+    expect(byId.temperature).toBeDefined();
+    expect(byId.temperature.kind).toBe('range');
+    expect(byId.topP).toBeDefined();
+    expect(byId.reasoningEffort).toBeUndefined();
+  });
+
+  it('Anthropic model exposes a thinkingBudget number param', () => {
+    const ds = describeModelParams('anthropic', 'claude-test-1');
+    const byId = Object.fromEntries(ds.map((d) => [d.id, d]));
+    expect(byId.thinkingBudget).toBeDefined();
+    expect(byId.thinkingBudget.kind).toBe('number');
+  });
+
+  it('never exposes both temperature and reasoningEffort for a catalog-miss gpt-5 reasoning model', () => {
+    // `gpt-5-experimental-test` isn't in the catalog; the family heuristic
+    // classifies it as reasoning, but `modelSupportsTemperature` (o-series only)
+    // would otherwise fail open. The `!reasoning` gate must win so we don't offer
+    // a temperature knob alongside reasoningEffort (the API would 400 on both).
+    const ds = describeModelParams('openai', 'gpt-5-experimental-test');
+    const byId = Object.fromEntries(ds.map((d) => [d.id, d]));
+    expect(byId.reasoningEffort).toBeDefined();
+    expect(byId.temperature).toBeUndefined();
+    expect(byId.topP).toBeUndefined();
+  });
+
+  it('keys the param surface off the wrapped sdk for custom providers', () => {
+    // An Ollama-style provider wrapping the OpenAI SDK with a reasoning model.
+    const ds = describeModelParams('ollama', 'o3-local-test', 'openai');
+    const byId = Object.fromEntries(ds.map((d) => [d.id, d]));
+    expect(byId.reasoningEffort?.options).toEqual(['minimal', 'low', 'medium', 'high']);
+  });
+});
+
+describe('serializeModelParams — routing to the two destinations', () => {
+  it('routes temperature/topP to top-level params and maxOutputTokens to the SDK maxTokens key', () => {
+    const { params, providerOptions } = serializeModelParams('openai', 'gpt-4-omni-test', {
+      temperature: 0.7,
+      topP: 0.9,
+      maxOutputTokens: 1024,
+    });
+    // AI SDK v4 names the cap `maxTokens`.
+    expect(params).toEqual({ temperature: 0.7, topP: 0.9, maxTokens: 1024 });
+    expect(providerOptions).toEqual({});
+  });
+
+  it('routes xAI reasoningEffort to providerOptions.xai', () => {
+    const { params, providerOptions } = serializeModelParams('xai', 'grok-4-fast-reasoning', {
+      reasoningEffort: 'high',
+    });
+    expect(params).toEqual({});
+    expect(providerOptions).toEqual({ xai: { reasoningEffort: 'high' } });
+  });
+
+  it('routes OpenAI reasoningEffort to providerOptions.openai', () => {
+    const { providerOptions } = serializeModelParams('openai', 'o3-pro-test', {
+      reasoningEffort: 'medium',
+    });
+    expect(providerOptions).toEqual({ openai: { reasoningEffort: 'medium' } });
+  });
+
+  it('routes Anthropic thinkingBudget to providerOptions.anthropic.thinking', () => {
+    const { providerOptions } = serializeModelParams('anthropic', 'claude-test-1', {
+      thinkingBudget: 4096,
+    });
+    expect(providerOptions).toEqual({
+      anthropic: { thinking: { type: 'enabled', budgetTokens: 4096 } },
+    });
+  });
+
+  it('omits Anthropic thinking when budget is 0 (disabled)', () => {
+    const { providerOptions } = serializeModelParams('anthropic', 'claude-test-1', {
+      thinkingBudget: 0,
+    });
+    expect(providerOptions).toEqual({});
+  });
+
+  it('returns empty objects for undefined values', () => {
+    const { params, providerOptions } = serializeModelParams('openai', 'gpt-4-omni-test', undefined);
+    expect(params).toEqual({});
+    expect(providerOptions).toEqual({});
+  });
+});
+
+describe('validateModelParams — capability gate', () => {
+  it('drops temperature on a reasoning model', () => {
+    const out = validateModelParams('xai', 'grok-4-fast-reasoning', {
+      temperature: 0.5,
+      reasoningEffort: 'high',
+    });
+    expect(out).toEqual({ reasoningEffort: 'high' });
+  });
+
+  it('drops reasoningEffort on a non-reasoning model', () => {
+    const out = validateModelParams('openai', 'gpt-4-omni-test', {
+      reasoningEffort: 'high',
+      temperature: 0.3,
+    });
+    expect(out).toEqual({ temperature: 0.3 });
+  });
+
+  it('serialize never emits a rejected param even if smuggled in', () => {
+    const { params } = serializeModelParams('xai', 'grok-4-fast-reasoning', {
+      temperature: 0.5,
+    });
+    expect(params.temperature).toBeUndefined();
+  });
+});

--- a/src/providers/model-params.ts
+++ b/src/providers/model-params.ts
@@ -1,0 +1,219 @@
+/**
+ * Provider-agnostic generation-parameter adapter (issue #286).
+ *
+ * Given a `(provider, model)` this module answers two questions behind one
+ * uniform surface, so the lineup UI looks identical regardless of provider:
+ *
+ *  1. **What can I tune?** — `describeModelParams` returns capability-gated
+ *     {@link ParamDescriptor}s (id, label, kind, options/min/max, default).
+ *  2. **How do I send it?** — `serializeModelParams` splits chosen values into
+ *     the two AI-SDK destinations the SDK insists on:
+ *       - **top-level** `generateText` params: `temperature`, `topP`,
+ *         `maxOutputTokens`;
+ *       - **`providerOptions.<sdk>`**: xAI/OpenAI `reasoningEffort`, Anthropic
+ *         `thinking: { type: 'enabled', budgetTokens }`.
+ *
+ * Capability detection is **catalog-first** (consistent with `getModelProfile`):
+ * it reuses the catalog `reasoning` tag and `modelSupportsTemperature` rather
+ * than inventing a parallel capability map. Family resolution keys off
+ * `sdk ?? provider`, so a custom provider that wraps the OpenAI SDK (Ollama,
+ * OpenRouter, …) gets the OpenAI param surface even though its registry name
+ * isn't `openai` — mirroring `getProviderOptions(provider, custom?.sdk)`.
+ */
+import type { SupportedSdk } from './types.js';
+import { getModelMeta, findModelMetaByName } from './catalog.js';
+import { modelSupportsTemperature } from './profiles.js';
+
+export type ParamKind = 'enum' | 'number' | 'range' | 'toggle';
+
+/** The closed set of tunable param ids (issue #286). */
+export const PARAM_IDS = [
+  'temperature',
+  'topP',
+  'maxOutputTokens',
+  'reasoningEffort',
+  'thinkingBudget',
+] as const;
+export type ParamId = (typeof PARAM_IDS)[number];
+
+export interface ParamDescriptor {
+  /** Stable id, also the key in {@link ModelParams}. */
+  id: ParamId;
+  label: string;
+  kind: ParamKind;
+  /** For `enum`: the allowed values. */
+  options?: string[];
+  /** For `number`/`range`: inclusive bounds. */
+  min?: number;
+  max?: number;
+  step?: number;
+  /** A sensible default shown in the editor (not auto-applied). */
+  default?: string | number | boolean;
+}
+
+/**
+ * User-chosen values, keyed by {@link ParamId}. Narrowing to the closed id set
+ * makes a typo (`temperture`) a compile error and lets the Zod schemas reject
+ * unknown keys, rather than silently persisting junk that `validateModelParams`
+ * later drops.
+ */
+export type ModelParams = Partial<Record<ParamId, string | number | boolean>>;
+
+/** Resolve the SDK family that governs the param surface. */
+function family(provider: string, sdk?: SupportedSdk): string {
+  return (sdk ?? provider).toLowerCase();
+}
+
+/**
+ * Catalog-first reasoning detection mirroring `getModelProfile`. Returns the
+ * catalog tag when present, else applies the same family heuristics so a
+ * catalog miss (custom proxy, brand-new model) still classifies correctly.
+ */
+function isReasoningModel(provider: string, model: string, sdk?: SupportedSdk): boolean {
+  const meta = getModelMeta(provider, model) ?? findModelMetaByName(model);
+  if (meta) return meta.tags.includes('reasoning');
+
+  const m = model.toLowerCase();
+  const fam = family(provider, sdk);
+  if (fam === 'openai') return /^o\d/.test(m) || /^gpt-5/.test(m);
+  if (fam === 'xai') {
+    if (m.includes('non-reasoning')) return false;
+    if (m.includes('reasoning')) return true;
+    return /^grok-4(\b|[-.])/.test(m);
+  }
+  if (fam === 'anthropic') return false; // extended thinking is opt-in, not a gate
+  return false;
+}
+
+/** Best-known max output tokens from the catalog (for the slider/validation cap). */
+function maxOutputCap(provider: string, model: string): number | undefined {
+  const meta = getModelMeta(provider, model) ?? findModelMetaByName(model);
+  return meta?.maxOutputTokens;
+}
+
+/**
+ * Returns the tunable params this `(provider, model)` actually supports —
+ * capability-gated, so reasoning models never expose `temperature`, and only
+ * reasoning-capable models expose `reasoningEffort` / `thinkingBudget`.
+ * Empty array → the lineup UI skips the params step entirely (unchanged UX).
+ */
+export function describeModelParams(
+  provider: string,
+  model: string,
+  sdk?: SupportedSdk,
+): ParamDescriptor[] {
+  const fam = family(provider, sdk);
+  const reasoning = isReasoningModel(provider, model, sdk);
+  const out: ParamDescriptor[] = [];
+
+  // temperature / top_p — only on models that accept temperature (reasoning
+  // models reject it). Gate on `!reasoning` AND `modelSupportsTemperature` so a
+  // reasoning model never exposes BOTH temperature and reasoningEffort (which
+  // the provider would 400 on); this also keeps the two capability checks from
+  // diverging on a catalog-miss model the heuristics classify differently.
+  if (!reasoning && modelSupportsTemperature(model, provider)) {
+    out.push({ id: 'temperature', label: 'Temperature', kind: 'range', min: 0, max: 2, step: 0.1, default: 0 });
+    out.push({ id: 'topP', label: 'Top-p', kind: 'range', min: 0, max: 1, step: 0.05, default: 1 });
+  }
+
+  // reasoning_effort — provider-specific option ladders.
+  if (reasoning && fam === 'openai') {
+    out.push({
+      id: 'reasoningEffort',
+      label: 'Reasoning effort',
+      kind: 'enum',
+      options: ['minimal', 'low', 'medium', 'high'],
+      default: 'medium',
+    });
+  } else if (reasoning && fam === 'xai') {
+    out.push({
+      id: 'reasoningEffort',
+      label: 'Reasoning effort',
+      kind: 'enum',
+      options: ['low', 'high'],
+      default: 'low',
+    });
+  }
+
+  // Anthropic extended-thinking budget (tokens). Opt-in: 0 / unset = disabled.
+  if (fam === 'anthropic') {
+    out.push({
+      id: 'thinkingBudget',
+      label: 'Thinking budget (tokens)',
+      kind: 'number',
+      min: 0,
+      max: maxOutputCap(provider, model),
+      default: 0,
+    });
+  }
+
+  // max_output_tokens — universally applicable.
+  out.push({
+    id: 'maxOutputTokens',
+    label: 'Max output tokens',
+    kind: 'number',
+    min: 1,
+    max: maxOutputCap(provider, model),
+  });
+
+  return out;
+}
+
+/**
+ * Drops any value whose id isn't a supported descriptor for this
+ * `(provider, model)`. This is the capability gate used at save time and
+ * defensively inside {@link serializeModelParams}, so a param the model
+ * rejects (e.g. temperature on a reasoning model) never reaches the API.
+ */
+export function validateModelParams(
+  provider: string,
+  model: string,
+  values: ModelParams,
+  sdk?: SupportedSdk,
+): ModelParams {
+  const allowed = new Set<ParamId>(describeModelParams(provider, model, sdk).map((d) => d.id));
+  const out: ModelParams = {};
+  for (const [k, v] of Object.entries(values)) {
+    if (allowed.has(k as ParamId)) out[k as ParamId] = v;
+  }
+  return out;
+}
+
+/**
+ * Splits chosen values into the two AI-SDK destinations. Always validates
+ * first, so callers can't smuggle a rejected param through. Returns plain
+ * objects ready to merge into `generateText`'s top-level args (`params`) and
+ * `providerOptions` respectively.
+ */
+export function serializeModelParams(
+  provider: string,
+  model: string,
+  values: ModelParams | undefined,
+  sdk?: SupportedSdk,
+): { params: Record<string, unknown>; providerOptions: Record<string, unknown> } {
+  const params: Record<string, unknown> = {};
+  const providerOptions: Record<string, unknown> = {};
+  if (!values) return { params, providerOptions };
+
+  const safe = validateModelParams(provider, model, values, sdk);
+  const fam = family(provider, sdk);
+
+  if (typeof safe.temperature === 'number') params.temperature = safe.temperature;
+  if (typeof safe.topP === 'number') params.topP = safe.topP;
+  // AI SDK v4 names the top-level cap `maxTokens` (not `maxOutputTokens`); emit
+  // the SDK key so it actually takes effect. The descriptor keeps the
+  // provider-neutral `maxOutputTokens` id for the UI.
+  if (typeof safe.maxOutputTokens === 'number') params.maxTokens = safe.maxOutputTokens;
+
+  if (safe.reasoningEffort !== undefined && (fam === 'openai' || fam === 'xai')) {
+    providerOptions[fam] = { reasoningEffort: safe.reasoningEffort };
+  }
+
+  if (fam === 'anthropic' && typeof safe.thinkingBudget === 'number' && safe.thinkingBudget > 0) {
+    providerOptions.anthropic = {
+      thinking: { type: 'enabled', budgetTokens: safe.thinkingBudget },
+    };
+  }
+
+  return { params, providerOptions };
+}

--- a/src/reference-resolver.ts
+++ b/src/reference-resolver.ts
@@ -4,7 +4,6 @@ import { sanitizeKey, REWRITER_HINTS_KEY, type MemoryStore } from './memory.js';
 import type { RAGStore, RAGSearchResult } from './rag.js';
 import type { BernardConfig } from './config.js';
 import { resolveSiteModel } from './model-policy.js';
-import { temperatureParam } from './providers/profiles.js';
 import { getCachedLLM, setCachedLLM, type LLMCacheKey } from './llm-cache.js';
 import { usageRecordFromSite, type UsageRecorder } from './framework/hooks/token-stats.js';
 
@@ -317,6 +316,7 @@ export async function resolveReferences(
           siteName: 'reference-resolver',
           modelId: site.model.modelId,
           providerOptions: site.providerOptions,
+          params: site.params,
           system: RESOLVER_SYSTEM_PROMPT,
           userContent: userMessage,
         }
@@ -333,11 +333,13 @@ export async function resolveReferences(
         generateText({
           model: site.model,
           providerOptions: site.providerOptions,
+          // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+          // this site's output cap stays authoritative (#286).
+          ...site.params,
           system: RESOLVER_SYSTEM_PROMPT,
           messages: [{ role: 'user', content: userMessage }],
           maxSteps: 1,
           maxTokens: RESOLVER_MAX_TOKENS,
-          ...temperatureParam(site.model.modelId, site.provider),
           abortSignal,
         }),
       );

--- a/src/reference-tool-lookup.ts
+++ b/src/reference-tool-lookup.ts
@@ -3,7 +3,6 @@ import { readToolMeta } from './framework/tools/adapter.js';
 import { debugLog, traceLlm } from './logger.js';
 import type { BernardConfig } from './config.js';
 import { resolveSiteModel } from './model-policy.js';
-import { temperatureParam } from './providers/profiles.js';
 import { isReadOnlyMCPSuffix } from './risk.js';
 import { getCachedLLM, setCachedLLM, type LLMCacheKey } from './llm-cache.js';
 
@@ -168,6 +167,7 @@ export async function selectLookupTool(
           siteName: 'reference-lookup:select',
           modelId: site.model.modelId,
           providerOptions: site.providerOptions,
+          params: site.params,
           system: SELECT_SYSTEM_PROMPT,
           userContent,
         }
@@ -184,11 +184,14 @@ export async function selectLookupTool(
         generateText({
           model: site.model,
           providerOptions: site.providerOptions,
+          // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+          // this site's output cap stays authoritative — a small slot
+          // maxOutputTokens must not truncate the JSON selection (#286).
+          ...site.params,
           system: SELECT_SYSTEM_PROMPT,
           messages: [{ role: 'user', content: userContent }],
           maxSteps: 1,
           maxTokens: SELECT_MAX_TOKENS,
-          ...temperatureParam(site.model.modelId, site.provider),
           abortSignal,
         }),
       );
@@ -316,6 +319,7 @@ export async function interpretLookupResult(
           siteName: 'reference-lookup:interpret',
           modelId: site.model.modelId,
           providerOptions: site.providerOptions,
+          params: site.params,
           system: INTERPRET_SYSTEM_PROMPT,
           userContent,
         }
@@ -332,11 +336,14 @@ export async function interpretLookupResult(
         generateText({
           model: site.model,
           providerOptions: site.providerOptions,
+          // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+          // this site's output cap stays authoritative — a small slot
+          // maxOutputTokens must not truncate the JSON interpretation (#286).
+          ...site.params,
           system: INTERPRET_SYSTEM_PROMPT,
           messages: [{ role: 'user', content: userContent }],
           maxSteps: 1,
           maxTokens: INTERPRET_MAX_TOKENS,
-          ...temperatureParam(site.model.modelId, site.provider),
           abortSignal,
         }),
       );

--- a/src/specialist-detector.ts
+++ b/src/specialist-detector.ts
@@ -2,7 +2,6 @@ import { generateText } from 'ai';
 import { debugLog, traceLlm } from './logger.js';
 import type { BernardConfig } from './config.js';
 import { resolveSiteModel } from './model-policy.js';
-import { temperatureParam } from './providers/profiles.js';
 import { getCachedLLM, setCachedLLM, type LLMCacheKey } from './llm-cache.js';
 import type { Specialist, SpecialistSummary } from './specialists.js';
 import type { SpecialistCandidate } from './specialist-candidates.js';
@@ -138,6 +137,7 @@ export async function detectSpecialistCandidate(
           siteName: 'specialist-detector',
           modelId: site.model.modelId,
           providerOptions: site.providerOptions,
+          params: site.params,
           system: DETECTION_SYSTEM_PROMPT,
           userContent,
         }
@@ -153,8 +153,11 @@ export async function detectSpecialistCandidate(
         generateText({
           model: site.model,
           providerOptions: site.providerOptions,
+          // Slot params (temperature/topP) apply, but spread BEFORE maxTokens so
+          // this site's output cap stays authoritative — a small slot
+          // maxOutputTokens must not truncate the JSON detection result (#286).
+          ...site.params,
           maxTokens: 2048,
-          ...temperatureParam(site.model.modelId, site.provider),
           system: DETECTION_SYSTEM_PROMPT,
           messages: [{ role: 'user', content: userContent }],
         }),

--- a/src/specialists.ts
+++ b/src/specialists.ts
@@ -8,6 +8,7 @@ import {
   assertCanDeleteSpecialist,
   assertCanEditSpecialist,
 } from './specialist-authority.js';
+import type { ModelParams } from './providers/model-params.js';
 
 // Re-exported so existing importers (e.g. the `/specialists` UI grouping) keep
 // resolving it from this module; the authoritative definition lives in
@@ -41,6 +42,12 @@ export interface Specialist {
   guidelines: string[];
   provider?: string;
   model?: string;
+  /**
+   * Optional generation parameters applied when this specialist's pinned
+   * `provider`/`model` resolves (issue #286). Absent = model defaults. Keyed
+   * by {@link ParamDescriptor.id}; serialized by `serializeModelParams`.
+   */
+  params?: ModelParams;
   createdAt: string;
   updatedAt: string;
   /** Optional. Defaults to 'persona' for back-compat. */
@@ -68,6 +75,7 @@ export interface SpecialistSummary {
   description: string;
   provider?: string;
   model?: string;
+  params?: ModelParams;
   kind?: SpecialistKind;
 }
 
@@ -82,6 +90,7 @@ export interface CreateSpecialistInput {
   guidelines?: string[];
   provider?: string;
   model?: string;
+  params?: ModelParams;
   kind?: SpecialistKind;
   targetTools?: string[];
   goodExamples?: SpecialistExample[];
@@ -98,6 +107,7 @@ export type SpecialistUpdates = Partial<
     | 'guidelines'
     | 'provider'
     | 'model'
+    | 'params'
     | 'kind'
     | 'targetTools'
     | 'goodExamples'
@@ -268,6 +278,7 @@ export class SpecialistStore {
       guidelines: input.guidelines ?? [],
       ...(input.provider !== undefined ? { provider: input.provider } : {}),
       ...(input.model !== undefined ? { model: input.model } : {}),
+      ...(input.params !== undefined ? { params: input.params } : {}),
       ...(input.kind !== undefined ? { kind: input.kind } : {}),
       ...(input.targetTools !== undefined ? { targetTools: input.targetTools } : {}),
       ...(input.goodExamples !== undefined ? { goodExamples: input.goodExamples } : {}),
@@ -323,6 +334,14 @@ export class SpecialistStore {
         delete specialist.model;
       } else {
         specialist.model = updates.model;
+      }
+    }
+    // An empty object clears params; undefined means "don't change".
+    if (updates.params !== undefined) {
+      if (Object.keys(updates.params).length === 0) {
+        delete specialist.params;
+      } else {
+        specialist.params = updates.params;
       }
     }
     if (updates.kind !== undefined) specialist.kind = updates.kind;
@@ -397,12 +416,13 @@ export class SpecialistStore {
   getSummaries(): SpecialistSummary[] {
     return this.list()
       .filter((s) => !s.disabled)
-      .map(({ id, name, description, provider, model, kind }) => ({
+      .map(({ id, name, description, provider, model, params, kind }) => ({
         id,
         name,
         description,
         ...(provider !== undefined ? { provider } : {}),
         ...(model !== undefined ? { model } : {}),
+        ...(params !== undefined ? { params } : {}),
         ...(kind !== undefined ? { kind } : {}),
       }));
   }

--- a/src/tools/lineup.ts
+++ b/src/tools/lineup.ts
@@ -9,11 +9,13 @@ import {
   LINEUP_TIERS,
   type Lineup,
   type LineupTier,
+  type LineupSlot,
   type RoleSlots,
 } from '../lineups.js';
 import { ALL_ROLE_IDS, getRole, type RoleId } from '../model-roles.js';
 import { savePreferences, type BernardConfig } from '../config.js';
 import { BUILTIN_PROVIDERS } from '../providers/types.js';
+import { validateModelParams, PARAM_IDS } from '../providers/model-params.js';
 import { validateLineup, formatLineupValidation } from '../model-validate.js';
 
 /**
@@ -46,13 +48,27 @@ const SlotSchema = z.object({
     .describe('Cost tier: premium (strongest), mid, or cheap.'),
   provider: z.string().describe('Provider id, e.g. "openai", "anthropic", "xai", or a custom one.'),
   model: z.string().describe('Model name as the provider expects it, e.g. "gpt-5.5-pro".'),
+  params: z
+    .record(z.enum(PARAM_IDS), z.union([z.string(), z.number(), z.boolean()]))
+    .optional()
+    .describe(
+      'Optional per-slot generation params (issue #286), keyed by id: ' +
+        '"temperature"/"topP"/"maxOutputTokens" (numbers), "reasoningEffort" ' +
+        '(e.g. "low"/"high"), "thinkingBudget" (Anthropic tokens). Capability-' +
+        'gated — params the model rejects are dropped on save. Omit to use ' +
+        'model defaults.',
+    ),
 });
 
 function formatMatrix(l: Lineup): string {
   const lines: string[] = [];
   for (const roleId of ALL_ROLE_IDS) {
     const slots = l.roles[roleId];
-    const cell = (t: LineupTier): string => `${slots[t].provider}/${slots[t].model}`;
+    const cell = (t: LineupTier): string => {
+      const s = slots[t];
+      const p = s.params ? ` {${Object.entries(s.params).map(([k, v]) => `${k}=${v}`).join(',')}}` : '';
+      return `${s.provider}/${s.model}${p}`;
+    };
     lines.push(
       `  ${getRole(roleId).label.padEnd(16)} premium=${cell('premium')}  mid=${cell('mid')}  cheap=${cell('cheap')}`,
     );
@@ -70,7 +86,16 @@ function applySlots(
 ): void {
   for (const s of slots) {
     const tier = s.tier as LineupTier;
-    const binding = { provider: s.provider.trim(), model: s.model.trim() };
+    const provider = s.provider.trim();
+    const model = s.model.trim();
+    // Capability-gate params: drop anything this (provider, model) rejects so a
+    // bad knob never reaches the API (issue #286). Empty → omit the field.
+    const safeParams = s.params ? validateModelParams(provider, model, s.params) : undefined;
+    const binding: LineupSlot = {
+      provider,
+      model,
+      ...(safeParams && Object.keys(safeParams).length > 0 ? { params: safeParams } : {}),
+    };
     const targets: RoleId[] = s.role === 'all' ? [...ALL_ROLE_IDS] : [s.role as RoleId];
     for (const r of targets) roles[r] = { ...roles[r], [tier]: { ...binding } };
   }

--- a/src/tools/specialist.ts
+++ b/src/tools/specialist.ts
@@ -15,6 +15,7 @@ import {
   blankToUndefined,
 } from '../config.js';
 import { resolveSiteModel } from '../model-policy.js';
+import { validateModelParams, PARAM_IDS, type ModelParams } from '../providers/model-params.js';
 import { attachMeta } from '../framework/tools/adapter.js';
 
 const goodExampleSchema = z.object({
@@ -90,6 +91,15 @@ export function createSpecialistTool(
           .describe(
             'Optional model override for this specialist (e.g. "grok-code-fast-1"). Used with create/update.',
           ),
+        params: z
+          .record(z.enum(PARAM_IDS), z.union([z.string(), z.number(), z.boolean()]))
+          .optional()
+          .describe(
+            'Optional generation params for this specialist\'s pinned model (issue #286), keyed by id: ' +
+              '"temperature"/"topP"/"maxOutputTokens" (numbers), "reasoningEffort" (e.g. "low"/"high"), ' +
+              '"thinkingBudget" (Anthropic tokens). Capability-gated against the pinned (provider, model) — ' +
+              'rejected params are dropped. Requires a provider/model pin. Used with create/update.',
+          ),
         kind: z
           .enum(['persona', 'tool-wrapper', 'meta'])
           .optional()
@@ -130,6 +140,7 @@ export function createSpecialistTool(
         guidelines,
         provider,
         model,
+        params,
         kind,
         targetTools,
         goodExamples,
@@ -220,6 +231,17 @@ export function createSpecialistTool(
                 // Policy resolution is best-effort; fall through to no override.
               }
             }
+            // Capability-gate params against the pinned model; needs a pin.
+            // Reject rather than silently drop so the caller knows params
+            // require a provider+model to bind to.
+            let resolvedParams: ModelParams | undefined;
+            if (params && Object.keys(params).length > 0) {
+              if (!resolvedProvider || !resolvedModel) {
+                return 'Error: params require a provider and model pin. Set provider+model on this specialist (or enable a model-mode lineup) before adding params.';
+              }
+              const safe = validateModelParams(resolvedProvider, resolvedModel, params);
+              if (Object.keys(safe).length > 0) resolvedParams = safe;
+            }
             try {
               const specialist = store.createFull({
                 id,
@@ -229,6 +251,7 @@ export function createSpecialistTool(
                 guidelines: guidelines ?? [],
                 provider: resolvedProvider,
                 model: resolvedModel,
+                params: resolvedParams,
                 kind,
                 targetTools,
                 goodExamples: goodExamples as SpecialistExample[] | undefined,
@@ -269,6 +292,21 @@ export function createSpecialistTool(
             if (guidelines !== undefined) updates.guidelines = guidelines;
             if (provider !== undefined) updates.provider = provider;
             if (model !== undefined) updates.model = model;
+            if (params !== undefined) {
+              // Validate against the effective pin: the new provider/model if
+              // supplied, else the specialist's existing one. An empty `params`
+              // object is an explicit "clear". A non-empty `params` with no pin
+              // is rejected rather than silently dropped — params need a
+              // provider+model to bind to.
+              const existing = store.get(id);
+              const effProvider = blankToUndefined(provider) ?? existing?.provider;
+              const effModel = blankToUndefined(model) ?? existing?.model;
+              if (Object.keys(params).length > 0 && (!effProvider || !effModel)) {
+                return 'Error: params require a provider and model pin. Set provider+model on this specialist before adding params.';
+              }
+              updates.params =
+                effProvider && effModel ? validateModelParams(effProvider, effModel, params) : {};
+            }
             if (kind !== undefined) updates.kind = kind;
             if (targetTools !== undefined) updates.targetTools = targetTools;
             if (goodExamples !== undefined)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -114,6 +114,13 @@ import { rewritePrompt } from '../prompt-rewriter.js';
 import { loadRewriterHints } from '../memory.js';
 import { stripImagePaths } from '../image.js';
 import { getModelProfile } from '../providers/index.js';
+import {
+  describeModelParams,
+  validateModelParams,
+  type ModelParams,
+  type ParamId,
+  type ParamDescriptor,
+} from '../providers/model-params.js';
 import { debugLog, getSessionId, getSessionLogPath, isDebugEnabled } from '../logger.js';
 import { acquireSlot, releaseSlot, getMaxConcurrentAgents } from '../tools/agent-pool.js';
 import type {
@@ -3629,6 +3636,100 @@ type RequestTextInput = (options: ValuePromptOptions) => Promise<ValueResult>;
 type FlashToast = (message: string, variant?: ToastVariant) => void;
 
 /**
+ * Generation-params editor step (issue #286). Rendered after a model is picked
+ * in a lineup slot (or a specialist pin). If the model exposes no tunable
+ * params (`describeModelParams` empty) it returns immediately, so the UX is
+ * unchanged for models without knobs. Otherwise it loops a menu of descriptors
+ * — enum/toggle via a sub-menu, number/range via a validated text input —
+ * until the user picks Done (or Esc). Returns the chosen {@link ModelParams},
+ * or `undefined` when nothing is set (clean disk record = model defaults).
+ */
+async function pickGenerationParamsInk(
+  provider: string,
+  model: string,
+  sdk: SupportedSdk | undefined,
+  current: ModelParams | undefined,
+  requestMenu: RequestMenu,
+  requestTextInput: RequestTextInput,
+  flashToast: FlashToast,
+): Promise<ModelParams | undefined> {
+  const descriptors = describeModelParams(provider, model, sdk);
+  if (descriptors.length === 0) return current;
+
+  const values: ModelParams = { ...(current ?? {}) };
+
+  while (true) {
+    const entries: MenuEntry[] = descriptors.map((d) => {
+      const v = values[d.id];
+      return {
+        label: d.label,
+        annotation: v === undefined ? '(default)' : String(v),
+        value: { kind: 'edit', descriptor: d } as const,
+      };
+    });
+    entries.push({ type: 'section', title: '' });
+    entries.push({ label: 'Done', value: { kind: 'done' } as const });
+    entries.push({ label: 'Reset to model defaults', value: { kind: 'reset' } as const });
+
+    const pick = await requestMenu(entries, {
+      title: `Generation params · ${model}`,
+      headerLines: ['Leave a param as (default) to use the model default. Esc = done.'],
+    });
+    if (pick.cancelled) break; // Esc commits whatever's set so far
+    const choice = pick.item.value as
+      | { kind: 'edit'; descriptor: ParamDescriptor }
+      | { kind: 'done' }
+      | { kind: 'reset' };
+    if (choice.kind === 'done') break;
+    if (choice.kind === 'reset') {
+      for (const k of Object.keys(values) as ParamId[]) delete values[k];
+      continue;
+    }
+
+    const d = choice.descriptor;
+    if (d.kind === 'enum' || d.kind === 'toggle') {
+      const opts = d.kind === 'toggle' ? ['on', 'off'] : (d.options ?? []);
+      const optEntries: MenuEntry[] = [
+        { label: '(use model default)', value: { clear: true } as const },
+        ...opts.map((o) => ({ label: o, value: { val: o } as const })),
+      ];
+      const sel = await requestMenu(optEntries, { title: d.label });
+      if (sel.cancelled) continue;
+      const sv = sel.item.value as { clear: true } | { val: string };
+      if ('clear' in sv) delete values[d.id];
+      else values[d.id] = d.kind === 'toggle' ? sv.val === 'on' : sv.val;
+    } else {
+      const isFloat = d.kind === 'range';
+      const bounds = `${d.min ?? '−∞'}–${d.max ?? '∞'}`;
+      const res = await requestTextInput({
+        label: `${d.label} (${bounds}; empty = default)`,
+        initialValue: values[d.id] !== undefined ? String(values[d.id]) : '',
+      });
+      if (res.cancelled) continue;
+      const raw = res.raw.trim();
+      if (raw === '') {
+        delete values[d.id];
+        continue;
+      }
+      const parsed = isFloat ? Number.parseFloat(raw) : Number.parseInt(raw, 10);
+      if (
+        Number.isNaN(parsed) ||
+        (!isFloat && String(parsed) !== raw) ||
+        (d.min !== undefined && parsed < d.min) ||
+        (d.max !== undefined && parsed > d.max)
+      ) {
+        flashToast(`${d.label} must be a ${isFloat ? 'number' : 'whole number'} in ${bounds}.`, 'error');
+        continue;
+      }
+      values[d.id] = parsed;
+    }
+  }
+
+  const cleaned = validateModelParams(provider, model, values, sdk);
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+}
+
+/**
  * Two-step picker for a lineup slot: provider first (filtered to those with
  * keys), then model (rendered in a multi-column grid). Esc from the model
  * step returns to the provider step; Esc from the provider step returns
@@ -3762,6 +3863,12 @@ async function pickLineupSlotInk(
     });
     if (result.cancelled) continue; // back to provider step
 
+    const sdk = config.customProviders?.[provider]?.sdk;
+    // Pre-fill the params editor with the slot's existing params only when the
+    // provider+model are unchanged — switching model shouldn't carry stale knobs.
+    const paramsFor = (model: string): ModelParams | undefined =>
+      provider === current.provider && model === current.model ? current.params : undefined;
+
     const picked = items[result.index];
     if (picked === FREE_TYPE) {
       const modelRes = await requestTextInput({ label: `New model name for ${provider}` });
@@ -3774,9 +3881,15 @@ async function pickLineupSlotInk(
         rememberCustomModel(provider, model);
         config.customProviders = loadCustomProviders();
       }
-      return { provider, model };
+      const params = await pickGenerationParamsInk(
+        provider, model, sdk, paramsFor(model), requestMenu, requestTextInput, flashToast,
+      );
+      return { provider, model, ...(params ? { params } : {}) };
     }
-    return { provider, model: picked };
+    const params = await pickGenerationParamsInk(
+      provider, picked, sdk, paramsFor(picked), requestMenu, requestTextInput, flashToast,
+    );
+    return { provider, model: picked, ...(params ? { params } : {}) };
   }
 }
 
@@ -3845,6 +3958,13 @@ function summarizeRoleSlots(slots: RoleSlots): string {
  * "edit" hint; a lineup-level action row shows a one-line explainer + hint. The
  * overlay supplies the surrounding border and the row's label as the card title.
  */
+/** Compact one-line summary of a slot's generation params, '' when none. */
+function formatParamsSummary(params?: ModelParams): string {
+  if (!params) return '';
+  const parts = Object.entries(params).map(([k, v]) => `${k} ${v}`);
+  return parts.length > 0 ? parts.join(', ') : '';
+}
+
 function renderLineupDetail(item: MenuItem, draft: Lineup): ReactNode {
   const colors = getThemeColors();
   const value = item.value as
@@ -3864,11 +3984,13 @@ function renderLineupDetail(item: MenuItem, draft: Lineup): ReactNode {
         {LINEUP_TIERS.map((tier) => {
           const val = `${slots[tier].provider}/${slots[tier].model}`;
           const dots = '.'.repeat(Math.max(2, LEADER_WIDTH - tier.length - val.length));
+          const params = formatParamsSummary(slots[tier].params);
           return (
             <Text key={tier}>
               {tier}
               <Text dimColor>{dots}</Text>
               <Text color={colors.accent}>{val}</Text>
+              {params ? <Text dimColor> · {params}</Text> : null}
             </Text>
           );
         })}
@@ -3924,11 +4046,14 @@ async function runRoleSlotsEditorInk(
     cheap: { ...initial.cheap },
   };
   while (true) {
-    const tierRows: MenuEntry[] = LINEUP_TIERS.map((tier) => ({
-      label: `${tier.toUpperCase()}`,
-      annotation: `→ ${slots[tier].provider} / ${slots[tier].model}`,
-      value: { kind: 'tier', tier },
-    }));
+    const tierRows: MenuEntry[] = LINEUP_TIERS.map((tier) => {
+      const params = formatParamsSummary(slots[tier].params);
+      return {
+        label: `${tier.toUpperCase()}`,
+        annotation: `→ ${slots[tier].provider} / ${slots[tier].model}${params ? ` · ${params}` : ''}`,
+        value: { kind: 'tier', tier },
+      };
+    });
     const entries: MenuEntry[] = [
       ...tierRows,
       { type: 'section', title: '' },


### PR DESCRIPTION
## Summary

Closes #286. Adds a provider-agnostic generation-parameter layer so each **lineup slot** (and persisted specialist pin) can carry tunable params — `reasoning_effort`, Anthropic thinking budget, `temperature`, `top_p`, `max_output_tokens` — behind one uniform, capability-gated descriptor surface. Absent params = today's behavior, byte-for-byte.

## What's included

- **New adapter `src/providers/model-params.ts`** — `describeModelParams` (catalog-first capability gating, keyed off the wrapped `sdk` for custom providers), `serializeModelParams` (splits values into top-level `generateText` params vs `providerOptions.<sdk>`), `validateModelParams` (drops params the model rejects). A reasoning model never exposes `temperature` alongside `reasoningEffort`.
- **Storage** — optional `LineupSlot.params` and `Specialist.params`. No migration needed.
- **Resolution** — `SiteModel.params` + widened `providerOptions`; `buildSiteModel` deep-merges serialized provider options into the base (preserving OpenAI `strictSchemas`) and re-injects the per-site `temperature: 0` baseline for the classifier sites so the retired `temperatureParam` spreads stay byte-for-byte. `model-policy:resolve` logs the applied params.
- **Threading** — through the runner (`generateText` + `streamText`) and every agent `resolveModel` site; the 5 ad-hoc `temperatureParam` spreads are unified into `...site.params`. At fixed-budget utility sites params are spread **before** the explicit `maxTokens` so a slot's `max_output_tokens` can't truncate structured output; the runner honors a slot output cap.
- **UI / tools** — a params-editor step in the `/lineup` model picker (skipped when a model has no tunable params), plus capability-gated, key-validated (`z.enum(PARAM_IDS)`) `params` fields on the agent-facing `lineup` and `specialist` tools.

## Acceptance criteria

- [x] Lineup slot stores optional params; absent = today's behavior.
- [x] xAI reasoning models expose `reasoning_effort` reaching `providerOptions.xai.reasoningEffort`.
- [x] Temperature (where supported) is settable per slot via the unified channel; `temperatureParam` spreads unified.
- [x] Params step shows only when the model has tunable params; controls are provider-uniform.
- [x] Capability gating prevents saving/sending params a model rejects.
- [x] `BERNARD_DEBUG=1` `model-policy:resolve` logs include applied params.

## Testing

- `npm run build` ✅, `tsc --noEmit` ✅, lint 0 errors.
- **3125 tests pass** — added `model-params` unit tests (describe/serialize/validate, reasoning-gate regression) and `model-policy` tests (byte-for-byte temp-0 baseline, xAI `reasoningEffort` routing, slot-temperature override, OpenAI `strictSchemas`+`reasoningEffort` merge).

## Review notes

This branch went through `/simplify` (tightened `ModelParams` to a closed `ParamId` set; Zod schemas reject unknown keys) and `/review` (fixed: slot `max_output_tokens` no longer clobbers fixed per-site caps / truncates structured output; reasoning models never offer both `temperature` and `reasoningEffort`; specialist tool errors instead of silently dropping params without a model pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)